### PR TITLE
feat: add real GitHub repo link to header and footer

### DIFF
--- a/src/features/docs/components/DocsHeader.tsx
+++ b/src/features/docs/components/DocsHeader.tsx
@@ -138,7 +138,9 @@ export function DocsHeader() {
             </button>
             <ThemeToggle />
             <a
-              href="#"
+              href="https://github.com/sindev08/react-principles"
+              target="_blank"
+              rel="noopener noreferrer"
               className="flex items-center gap-2 rounded-lg bg-primary px-4 py-1.5 text-[11px] font-bold text-white transition-colors hover:bg-primary/90"
             >
               <GithubIcon />

--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 const RESOURCES = [
   { label: "Documentation", href: "/docs/introduction" },
   { label: "Cookbook", href: "/nextjs/cookbook" },
+  { label: "GitHub", href: "https://github.com/sindev08/react-principles" },
 ];
 
 const FRAMEWORKS = [
@@ -36,12 +37,23 @@ export function Footer() {
             <ul className="space-y-3 text-sm text-slate-500">
               {RESOURCES.map((item) => (
                 <li key={item.label}>
-                  <Link
-                    href={item.href}
-                    className="transition-colors hover:text-primary"
-                  >
-                    {item.label}
-                  </Link>
+                  {item.href.startsWith("http") ? (
+                    <a
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="transition-colors hover:text-primary"
+                    >
+                      {item.label}
+                    </a>
+                  ) : (
+                    <Link
+                      href={item.href}
+                      className="transition-colors hover:text-primary"
+                    >
+                      {item.label}
+                    </Link>
+                  )}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- Add GitHub repo link to DocsHeader button
- Add GitHub link to Footer Resources section

## Test plan
- [x] Click GitHub button in docs header → opens `https://github.com/sindev08/react-principles`
- [x] Click GitHub link in footer → opens repo in new tab