### PR TITLE
release: development → main

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -85,7 +85,9 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-(--background) text-(--foreground) antialiased">
-                <Script src="https://analytics.sindev.my.id/track.js" data-api-key="4744f6b200cecd79c9241430f5049e3e5c1f65478888e82542469a170d6c6e7c" />
+                {process.env.NODE_ENV === "production" && (
+          <Script src="https://analytics.sindev.my.id/track.js" data-api-key="4744f6b200cecd79c9241430f5049e3e5c1f65478888e82542469a170d6c6e7c" />
+        )}
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Providers } from "./providers";
 import "./globals.css";
 import "@material-symbols/font-400/outlined.css";
+import Script from "next/script";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 const TITLE = "React Principles";
@@ -84,6 +85,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-(--background) text-(--foreground) antialiased">
+                <Script src="https://analytics.sindev.my.id/track.js" data-api-key="4744f6b200cecd79c9241430f5049e3e5c1f65478888e82542469a170d6c6e7c" />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/features/cookbook/components/CookbookDetailPage.tsx
+++ b/src/features/cookbook/components/CookbookDetailPage.tsx
@@ -314,7 +314,7 @@ function CookbookFooter() {
             </span>
           </div>
           <p className="text-sm text-slate-500">
-            Helping developers build robust React applications since 2025.
+            Helping developers build robust React applications since 2026.
           </p>
         </div>
         <div className="flex gap-12">
@@ -345,7 +345,7 @@ function CookbookFooter() {
         </div>
       </div>
       <div className="pt-8 mt-12 text-xs text-center border-t border-slate-100 dark:border-[#1f2937] text-slate-400">
-        © 2025 React Patterns Cookbook. Built with ❤️ for the community.
+        © 2026 React Patterns Cookbook. Built with ❤️ for the community.
       </div>
     </footer>
   );

--- a/src/features/cookbook/data/detail-data.ts
+++ b/src/features/cookbook/data/detail-data.ts
@@ -771,7 +771,7 @@ export function RevenueChart({ range }: { range: string }) {
     title: "Folder Structure",
     breadcrumbCategory: "Foundations",
     description: "A feature-based folder structure so you always know where a file goes — and why it belongs there.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "A good folder structure answers one question instantly: 'where does this file go?' Feature-based organization groups everything related to a feature together — its components, hooks, and data — so you spend time building, not searching. When a feature grows or gets deleted, everything moves together.",
       tip: "If you can't decide where a file goes in under 10 seconds, your structure is too abstract. Feature-based organization should make the answer obvious.",
@@ -860,7 +860,7 @@ export function RevenueChart({ range }: { range: string }) {
     title: "TypeScript for React",
     breadcrumbCategory: "Foundations",
     description: "How to type component props, event handlers, and hooks correctly. The contracts that prevent silent bugs.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "Bugs caught at compile time cost nothing to fix. Bugs caught in production cost everything. TypeScript for React is not about learning the full TypeScript language — it is about writing the right contracts between your components so that mistakes are caught before the code even runs.",
       tip: "Start by typing your component props. If you can describe what a component accepts and returns, the rest of the types follow naturally.",
@@ -968,7 +968,7 @@ function useUser(id: string): {
     title: "Component Anatomy",
     breadcrumbCategory: "Foundations",
     description: "The consistent internal structure every component follows — imports, types, constants, function, export.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "When every component follows the same structure, you stop thinking about where things go inside a file and start thinking about what the component actually does. Consistent anatomy means anyone on the team can open any file and immediately know where to look — props are always at the top, constants are always before the function, exports are always at the bottom.",
       tip: "The hardest part of component anatomy is constants vs. props. Rule of thumb: if it never changes based on what's passed in, it is a constant. If it could change from outside, it is a prop.",
@@ -1228,7 +1228,7 @@ app.get('/auth/callback/github', async (c) => {
     title: "useEffect & Render Cycle",
     breadcrumbCategory: "Foundations",
     description: "When effects run, why the dependency array exists, and how to clean up after yourself.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "useEffect is not a lifecycle method — it is a synchronization tool. It answers one question: 'what side effects need to stay in sync with this data?' Every time the dependency array changes, React re-runs the effect to keep things synchronized. When you understand this mental model, dependency arrays stop feeling like magic rules and start making sense.",
       tip: "If you find yourself writing useEffect to fetch data, stop. That is what React Query is for. useEffect is for synchronizing with things outside React — browser APIs, subscriptions, timers.",
@@ -1346,7 +1346,7 @@ export function useWindowSize() {
     title: "Component Composition",
     breadcrumbCategory: "Foundations",
     description: "How components combine and communicate — children props, slot patterns, and why composition beats deep prop drilling.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "Prop drilling happens when you pass data through multiple components that do not use it — just to get it to a component deep in the tree. Composition solves this differently: instead of passing data down, you pass components down. The parent controls what gets rendered, and children receive exactly what they need directly.",
       tip: "When you find yourself adding a prop to a component just to pass it further down, stop. That is the signal to use composition instead.",
@@ -1495,7 +1495,7 @@ export function RecipePage() {
     title: "Services Layer",
     breadcrumbCategory: "Foundations",
     description: "How to organize all backend communication in one place — so when an API changes, you fix it in one file, not twenty.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "When you fetch data directly inside a component, the component becomes responsible for knowing the URL, the HTTP method, the request format, and the error handling. That is four responsibilities too many. A services layer centralizes all backend communication — components just call a function and get data back. When the API changes, you fix it in one file, not twenty.",
       tip: "A service function should read like plain English: getUserById(id), createOrder(data), deletePost(id). If it needs more than one argument object, consider splitting it into two functions.",
@@ -1631,7 +1631,7 @@ export function useUsers() {
     title: "State Taxonomy",
     breadcrumbCategory: "Foundations",
     description: "Three categories of state — local, shared, and server — and exactly which tool handles each one.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "Not all state is the same. Before reaching for any state management library, ask one question: where does this data come from? Local state lives inside one component. Shared state is UI state needed by multiple components. Server state comes from an API and has its own lifecycle — loading, error, stale, and needs refreshing. Each category has a different tool, and mixing them up causes bugs that are hard to trace.",
       tip: "When you find yourself putting API data into Zustand, stop. Server state belongs in React Query. When you find yourself using React Query for a toggle or a modal, stop. UI state belongs in useState or Zustand.",
@@ -1763,7 +1763,7 @@ function Navbar() {
     title: "Custom Hooks",
     breadcrumbCategory: "Foundations",
     description: "The boundary between logic and rendering. When to extract a hook, what the rules are, and how to avoid the most common mistake.",
-    lastUpdated: "2025-03-01",
+    lastUpdated: "2026-03-01",
     principle: {
       text: "A custom hook is not just a function that starts with 'use' — it is a boundary between logic and rendering. The component handles what the user sees. The hook handles how data gets there. When you separate these two concerns, components become easier to read, logic becomes easier to test, and both become easier to change independently.",
       tip: "If you would write a unit test for the logic, it belongs in a hook. If you would write a component test for it, it belongs in the JSX.",

--- a/src/features/docs/components/DocsSidebar.tsx
+++ b/src/features/docs/components/DocsSidebar.tsx
@@ -4,7 +4,12 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/shared/utils/cn";
-import { DOCS_NAV, COOKBOOK_ITEMS } from "./docs-nav";
+import { DOCS_NAV } from "./docs-nav";
+import { RECIPES } from "@/features/cookbook/data/cookbook-data";
+
+const IS_DEV = process.env.NODE_ENV === "development";
+
+const SORTED_RECIPES = [...RECIPES].sort((a, b) => a.order - b.order);
 
 type Framework = "nextjs" | "vitejs";
 
@@ -15,7 +20,7 @@ interface IndicatorPos {
 }
 
 function cookbookHref(framework: Framework, slug: string) {
-  return slug ? `/${framework}/cookbook/${slug}` : `/${framework}/cookbook`;
+  return `/${framework}/cookbook/${slug}`;
 }
 
 export function DocsSidebar() {
@@ -107,25 +112,50 @@ export function DocsSidebar() {
               Cookbook
             </h4>
             <ul className="flex flex-col gap-1.5">
-              {COOKBOOK_ITEMS.map((item) => {
-                const href = cookbookHref(cookbookFramework, item.slug);
+              {/* All Recipes link */}
+              <li ref={(el) => { itemRefs.current[`/${cookbookFramework}/cookbook`] = el; }}>
+                <Link
+                  href={`/${cookbookFramework}/cookbook`}
+                  className={cn(
+                    "relative z-10 flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors",
+                    pathname === `/${cookbookFramework}/cookbook`
+                      ? "text-primary font-semibold"
+                      : "text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white",
+                  )}
+                >
+                  All Recipes
+                </Link>
+              </li>
+
+              {SORTED_RECIPES.map((recipe) => {
+                const isComingSoon = recipe.status === "coming-soon";
+
+                // In production, hide coming-soon items entirely
+                if (isComingSoon && !IS_DEV) return null;
+
+                const href = cookbookHref(cookbookFramework, recipe.slug);
                 const isActive = pathname === href;
 
                 return (
                   <li
-                    key={item.slug}
+                    key={recipe.slug}
                     ref={(el) => { itemRefs.current[href] = el; }}
                   >
                     <Link
                       href={href}
                       className={cn(
-                        "relative z-10 flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors",
+                        "relative z-10 flex items-center justify-between px-3 py-2 text-sm font-medium rounded-lg transition-colors",
                         isActive
                           ? "text-primary font-semibold"
                           : "text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white",
                       )}
                     >
-                      {item.label}
+                      {recipe.title}
+                      {isComingSoon && IS_DEV && (
+                        <span className="text-[9px] font-bold uppercase tracking-wider bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 px-1.5 py-0.5 rounded-sm">
+                          Dev
+                        </span>
+                      )}
                     </Link>
                   </li>
                 );

--- a/src/features/docs/components/docs-nav.ts
+++ b/src/features/docs/components/docs-nav.ts
@@ -1,22 +1,3 @@
-export interface CookbookNavItem {
-  label: string;
-  slug: string; // "" for "All Recipes"
-}
-
-export const COOKBOOK_ITEMS: CookbookNavItem[] = [
-  { label: "All Recipes", slug: "" },
-  { label: "Server State", slug: "server-state" },
-  { label: "Client State", slug: "client-state" },
-  { label: "Form Validation", slug: "form-validation" },
-  { label: "Data Tables", slug: "data-tables" },
-  { label: "E-commerce Dashboard", slug: "e-commerce-dashboard" },
-  { label: "SaaS Landing Page", slug: "saas-landing-page" },
-  { label: "Authentication Flow", slug: "authentication-flow" },
-  { label: "OAuth Flow", slug: "oauth-flow" },
-  { label: "Data Visualization", slug: "data-visualization" },
-  { label: "API Integration", slug: "api-integration" },
-];
-
 export interface NavItem {
   label: string;
   href: string;

--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -82,7 +82,7 @@ export function Footer() {
         {/* Bottom bar */}
         <div className="flex flex-col items-center justify-between gap-4 pt-8 border-t border-slate-100 dark:border-white/5 md:flex-row">
           <p className="text-xs text-slate-400">
-            © 2025 react-principles. Built for the React community.
+            © 2026 react-principles. Built for the React community.
           </p>
         </div>
       </div>

--- a/src/shared/utils/formatters.test.ts
+++ b/src/shared/utils/formatters.test.ts
@@ -23,21 +23,21 @@ describe("formatCurrency", () => {
 
 describe("formatDate", () => {
   it("formats a Date object", () => {
-    const date = new Date("2025-01-15T00:00:00Z");
+    const date = new Date("2026-01-15T00:00:00Z");
     const result = formatDate(date, { year: "numeric", month: "short", day: "numeric" }, "en-US");
-    expect(result).toContain("2025");
+    expect(result).toContain("2026");
     expect(result).toContain("15");
   });
 
   it("formats an ISO string", () => {
-    const result = formatDate("2025-06-01T00:00:00Z", { year: "numeric", month: "short", day: "numeric" }, "en-US");
-    expect(result).toContain("2025");
+    const result = formatDate("2026-06-01T00:00:00Z", { year: "numeric", month: "short", day: "numeric" }, "en-US");
+    expect(result).toContain("2026");
   });
 
   it("formats a timestamp", () => {
-    const ts = new Date("2025-03-01T00:00:00Z").getTime();
+    const ts = new Date("2026-03-01T00:00:00Z").getTime();
     const result = formatDate(ts, { year: "numeric" }, "en-US");
-    expect(result).toBe("2025");
+    expect(result).toBe("2026");
   });
 });
 

--- a/src/shared/utils/validators.test.ts
+++ b/src/shared/utils/validators.test.ts
@@ -72,7 +72,7 @@ describe("userSchema", () => {
     email: "john@example.com",
     role: "admin",
     status: "active",
-    createdAt: "2025-01-01T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
   };
 
   it("accepts valid user", () => {


### PR DESCRIPTION
## Summary

### Features
- **Hero badge & footer versioning** — Updated hero badge to "Early access" and added npm version to footer
- **Mobile landing page** — Added mobile nav menu, hero tab switcher, and mobile code card

### Bug Fixes
- **CLI rename** — Renamed `react-principles-cli` → `react-principles` across all docs, README, and CLI error messages
- **`--all` flag** — Registered `--all` as a proper Commander option so `npx react-principles add --all` works without `--` separator
- **Component docs** — Fixed broken hrefs and incorrect import paths in all component doc pages
- **npm README** — Added `README.md` to published package files so npm shows CLI docs instead of root README

### Package
- Bumped `react-principles` CLI: `0.0.1` → `0.0.2` → `0.0.3`

### Chores
- Cleaned up root `package.json` — removed npm publishing fields, marked as `private: true`
- Rewrote root `README.md` as project overview (not npm library docs)
- Removed orphaned `tsup.config.ts` and `release.yml` workflow
- Untracked `CLAUDE.md` and added to `.gitignore`
- Updated `pnpm-lock.yaml` after removing `@changesets/cli`