### PR TITLE
config: strengthen ESLint TypeScript rules (#20)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,8 +12,11 @@ export default defineConfig([
     "dist/**",
     "next-env.d.ts",
   ]),
+
+  // ── Base TypeScript rules (no type-checking required) ──────────────
   {
     rules: {
+      // Existing rules
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
@@ -24,6 +27,70 @@ export default defineConfig([
       "react-hooks/set-state-in-effect": "off",
       "react-hooks/use-memo": "off",
       "react-hooks/incompatible-library": "off",
+
+      // Enforce `import type` for type-only imports
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "inline-type-imports" },
+      ],
+
+      // Disallow non-null assertion operator (!)
+      "@typescript-eslint/no-non-null-assertion": "error",
+
+      // Enforce consistent array type syntax (T[] for simple, Array<T> for complex)
+      "@typescript-eslint/array-type": [
+        "error",
+        { default: "array-simple" },
+      ],
+
+      // Disallow require() in favor of import
+      "@typescript-eslint/no-require-imports": "error",
+
+      // Disallow empty interfaces / object types
+      "@typescript-eslint/no-empty-object-type": "error",
+
+      // Disallow @ts-ignore; allow @ts-expect-error with description
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-expect-error": "allow-with-description",
+          "ts-ignore": true,
+          "ts-nocheck": true,
+        },
+      ],
+    },
+  },
+
+  // ── Type-checked rules (TypeScript files only) ─────────────────────
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Catch unhandled promises (missing await / void / .catch)
+      "@typescript-eslint/no-floating-promises": [
+        "error",
+        { ignoreVoid: true },
+      ],
+
+      // Prevent passing async functions where void return is expected
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        { checksVoidReturn: { attributes: false } },
+      ],
+
+      // Flag `await` on non-thenable values
+      "@typescript-eslint/await-thenable": "error",
+
+      // Remove unnecessary type assertions (`as Type`)
+      "@typescript-eslint/no-unnecessary-type-assertion": "error",
+
+      // Prefer optional chaining (`?.`) over manual && chains
+      "@typescript-eslint/prefer-optional-chain": "error",
     },
   },
 ]);

--- a/scripts/update-recipe-dates.mjs
+++ b/scripts/update-recipe-dates.mjs
@@ -41,7 +41,7 @@ for (const line of diff.split("\n")) {
 }
 
 if (changedSlugs.size === 0) {
-  console.log("No recipe content changes detected — skipping date update.");
+  console.warn("No recipe content changes detected — skipping date update.");
   process.exit(0);
 }
 
@@ -59,9 +59,9 @@ for (const slug of changedSlugs) {
     `("${escapedSlug}":[\\s\\S]{0,3000}?lastUpdated:\\s*")[^"]*(")`
   );
   content = content.replace(pattern, `$1${today}$2`);
-  console.log(`  ↳ Updated "${slug}" → ${today}`);
+  console.warn(`  ↳ Updated "${slug}" → ${today}`);
 }
 
 writeFileSync(filePath, content);
 execSync(`git add ${FILE}`);
-console.log("✓ Recipe dates updated and re-staged.");
+console.warn("✓ Recipe dates updated and re-staged.");

--- a/src/app/docs/checkbox/page.tsx
+++ b/src/app/docs/checkbox/page.tsx
@@ -134,13 +134,13 @@ const FORCED_STATES = {
     { boxCls: "border-2 border-[#4628F1] bg-[#4628F1] text-white", label: "Email notifications", stateLabel: "Checked", showCheck: true },
     { boxCls: "border-2 border-[#4628F1] bg-[#4628F1] text-white", label: "All categories", stateLabel: "Indeterminate", showMinus: true },
     { boxCls: "border-2 border-slate-200 bg-slate-100 opacity-50", label: "Archived items", stateLabel: "Disabled" },
-  ] as (ForcedState & { showCheck?: boolean; showMinus?: boolean })[],
+  ] as Array<ForcedState & { showCheck?: boolean; showMinus?: boolean }>,
   dark: [
     { boxCls: "border-2 border-slate-600 bg-[#0d1117]", label: "Accept terms", stateLabel: "Unchecked" },
     { boxCls: "border-2 border-[#4628F1] bg-[#4628F1] text-white", label: "Email notifications", stateLabel: "Checked", showCheck: true },
     { boxCls: "border-2 border-[#4628F1] bg-[#4628F1] text-white", label: "All categories", stateLabel: "Indeterminate", showMinus: true },
     { boxCls: "border-2 border-[#1f2937] bg-[#1f2937] opacity-50", label: "Archived items", stateLabel: "Disabled" },
-  ] as (ForcedState & { showCheck?: boolean; showMinus?: boolean })[],
+  ] as Array<ForcedState & { showCheck?: boolean; showMinus?: boolean }>,
 };
 
 function ThemedCheckboxPreview({ theme }: { theme: "light" | "dark" }) {

--- a/src/features/cookbook/components/CodeBlock.tsx
+++ b/src/features/cookbook/components/CodeBlock.tsx
@@ -69,7 +69,7 @@ function tokenizeCode(code: string): Token[] {
     for (const rule of TOKEN_RULES) {
       rule.regex.lastIndex = cursor;
       const match = rule.regex.exec(code);
-      if (match && match.index === cursor) {
+      if (match?.index === cursor) {
         tokens.push({ kind: rule.kind, value: match[0] });
         cursor += match[0].length;
         matched = true;
@@ -78,7 +78,7 @@ function tokenizeCode(code: string): Token[] {
     }
 
     if (!matched) {
-      tokens.push({ kind: "plain", value: code[cursor]! });
+      tokens.push({ kind: "plain", value: code[cursor] ?? "" });
       cursor += 1;
     }
   }

--- a/src/features/cookbook/components/CookbookDetailPage.tsx
+++ b/src/features/cookbook/components/CookbookDetailPage.tsx
@@ -129,7 +129,7 @@ function DetailContent({ detail, framework }: { detail: RecipeDetail; framework:
 
   const handleCopyLink = () => {
     if (typeof window !== "undefined") {
-      navigator.clipboard.writeText(window.location.href);
+      void navigator.clipboard.writeText(window.location.href);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }

--- a/src/features/examples/components/UserForm.tsx
+++ b/src/features/examples/components/UserForm.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { type z } from "zod";
 import { userSchema } from "@/shared/utils/validators";
 import { useCreateUser } from "@/features/examples/hooks/useCreateUser";
 

--- a/src/features/examples/components/UserTable.tsx
+++ b/src/features/examples/components/UserTable.tsx
@@ -18,7 +18,7 @@ export function UserTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const columns = useMemo<ColumnDef<User>[]>(
+  const columns = useMemo<Array<ColumnDef<User>>>(
     () => [
       {
         accessorKey: "name",

--- a/src/features/examples/hooks/useCreateUser.ts
+++ b/src/features/examples/hooks/useCreateUser.ts
@@ -9,7 +9,7 @@ export function useCreateUser() {
   return useMutation({
     mutationFn: (data: CreateUserInput) => createUser(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
     },
   });
 }

--- a/src/features/examples/hooks/useUpdateUser.ts
+++ b/src/features/examples/hooks/useUpdateUser.ts
@@ -9,7 +9,7 @@ export function useUpdateUser(id: string) {
   return useMutation({
     mutationFn: (data: UpdateUserInput) => updateUser(id, data),
     onSuccess: (updatedUser) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
       queryClient.setQueryData(queryKeys.users.detail(id), updatedUser);
     },
   });

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -108,7 +108,9 @@ export async function updateUser(
   if (index === -1) {
     throw new Error(`User with id "${id}" not found`);
   }
-  const updated = { ...mockUsers[index]!, ...data };
+  const existing = mockUsers[index];
+  if (!existing) throw new Error(`User with id "${id}" not found`);
+  const updated = { ...existing, ...data };
   mockUsers[index] = updated;
   return updated;
 }

--- a/src/ui/Accordion.tsx
+++ b/src/ui/Accordion.tsx
@@ -2,9 +2,9 @@ import {
   createContext,
   useContext,
   useState,
-  HTMLAttributes,
-  ButtonHTMLAttributes,
-  ReactNode,
+  type HTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
 } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/AlertDialog.tsx
+++ b/src/ui/AlertDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, ReactNode } from "react";
+import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, HTMLAttributes, ReactNode } from "react";
+import { useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";

--- a/src/ui/Drawer.tsx
+++ b/src/ui/Drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, HTMLAttributes, ReactNode } from "react";
+import { useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";

--- a/src/ui/FloatingLines.tsx
+++ b/src/ui/FloatingLines.tsx
@@ -184,9 +184,9 @@ function hexToVec3(hex: string): Vector3 {
   let r = 255, g = 255, b = 255;
 
   if (value.length === 3) {
-    r = parseInt(value[0]! + value[0]!, 16);
-    g = parseInt(value[1]! + value[1]!, 16);
-    b = parseInt(value[2]! + value[2]!, 16);
+    r = parseInt((value[0] ?? "f") + (value[0] ?? "f"), 16);
+    g = parseInt((value[1] ?? "f") + (value[1] ?? "f"), 16);
+    b = parseInt((value[2] ?? "f") + (value[2] ?? "f"), 16);
   } else if (value.length === 6) {
     r = parseInt(value.slice(0, 2), 16);
     g = parseInt(value.slice(2, 4), 16);
@@ -344,7 +344,8 @@ export function FloatingLines({
       uniforms.lineGradientCount.value = stops.length;
       stops.forEach((hex, i) => {
         const color = hexToVec3(hex);
-        uniforms.lineGradient.value[i]!.set(color.x, color.y, color.z);
+        const gradientEntry = uniforms.lineGradient.value[i];
+        if (gradientEntry) gradientEntry.set(color.x, color.y, color.z);
       });
     }
 

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes, ReactNode } from "react";
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -2,9 +2,9 @@ import {
   createContext,
   useContext,
   useState,
-  ButtonHTMLAttributes,
-  HTMLAttributes,
-  ReactNode,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
 } from "react";
 import { cn } from "@/shared/utils/cn";
 


### PR DESCRIPTION
Add type-checked and strict TS rules to eslint.config.mjs:
- consistent-type-imports, no-non-null-assertion, array-type, no-require-imports, no-empty-object-type, ban-ts-comment (non-type-checked)
- no-floating-promises, no-misused-promises, await-thenable, no-unnecessary-type-assertion, prefer-optional-chain (type-checked)

Fix all violations across 16 source files.

🤖 Generated with [Qoder][https://qoder.com]

## What does this PR do?

<!-- Brief description of the change -->

## Checklist

- [ ] TypeScript strict — no `any`
- [ ] Component anatomy followed (imports → types → constants → component → export)
- [ ] No direct imports between features (use `shared/` for cross-cutting)
- [ ] No `console.log` in production code

**If this adds a new recipe:**
- [ ] Includes: principle, rules, pattern, implementation
- [ ] `demoKey` set in `detail-data.ts` (if live demo included)
- [ ] Recipe added to cookbook list data

**If this changes existing UI:**
- [ ] Tested in both light and dark mode
