### PR TITLE
fix(ci): fix changesets publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: pnpm build:pkg && pnpm changeset publish
+          publish: pnpm release
           title: "chore: release package"
           commit: "chore: release package"
         env:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "prepare": "husky",
-    "prepublishOnly": "pnpm build:pkg"
+    "prepublishOnly": "pnpm build:pkg",
+    "release": "pnpm changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "prebuild": "node ../../scripts/sync-registry.mjs",
     "build": "tsup",
+    "prepublishOnly": "pnpm build",
     "dev": "tsup src/index.ts --format cjs --watch",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary

- `release.yml`: ganti `pnpm build:pkg && pnpm changeset publish` → `pnpm release`
  (`changesets/action` tidak jalankan publish lewat shell, jadi `&&` diteruskan sebagai argumen ke tsup)
- `package.json`: tambah script `release: pnpm changeset publish`
- `packages/cli/package.json`: tambah `prepublishOnly: pnpm build` agar CLI selalu build sebelum publish

## Root Cause

`changesets/action@v1` mengeksekusi `publish` tanpa shell, sehingga token `&&`, `pnpm`, `changeset`, `publish` diteruskan sebagai argumen file ke tsup → `Cannot find &&,pnpm,changeset,publish`.