### PR TITLE
feat: react-principles UI highlight and CLI package rename

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,219 @@
+# react-principles
+
+A CLI to add react-principles UI components to your project — copy-paste based, no dependency lock-in.
+
+## Requirements
+
+- Node.js 18+
+- React 18+
+- Tailwind CSS v4
+
+## Usage
+
+No installation needed. Run directly with `npx`:
+
+```bash
+npx react-principles init
+npx react-principles add <component>
+npx react-principles list
+```
+
+---
+
+## Commands
+
+### `init`
+
+Initialize react-principles in your project. Run this once before adding components.
+
+```bash
+npx react-principles init
+npx react-principles init --template next
+```
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `-t, --template <framework>` | Skip prompt and set framework directly: `next` \| `vite` \| `remix` \| `other` |
+
+**What it does**
+
+1. Auto-detects your framework from `package.json`
+2. Prompts for install directories (components, hooks, utilities)
+3. Creates `components.json` in your project root
+4. Installs `cn()` utility to your lib directory
+5. Installs `clsx`, `tailwind-merge`, and `tailwind-animate`
+6. Appends `@import "tailwindcss"` to your `globals.css` (skipped for Vite)
+
+**Interactive prompts**
+
+```
+? Which framework are you using?   › Next.js  (detected: Next.js)
+? Where should components be installed?  › src/components/ui
+? Where should hooks be installed?  › src/hooks
+? Where should utilities be installed?  › src/lib
+```
+
+**Generated `components.json`**
+
+```json
+{
+  "framework": "next",
+  "rsc": true,
+  "tsx": true,
+  "componentsDir": "src/components/ui",
+  "hooksDir": "src/hooks",
+  "libDir": "src/lib",
+  "aliases": {
+    "components": "@/components/ui",
+    "hooks": "@/hooks",
+    "lib": "@/lib"
+  }
+}
+```
+
+---
+
+### `add`
+
+Add one or more components to your project.
+
+```bash
+npx react-principles add button
+npx react-principles add button input card
+npx react-principles add --all
+```
+
+**Arguments**
+
+| Argument | Description |
+|----------|-------------|
+| `<components...>` | One or more component names (space-separated) |
+| `--all` | Install all available components at once |
+
+**What it does**
+
+1. Reads `components.json` to determine install paths
+2. Resolves transitive dependencies automatically (e.g. adding `dialog` also installs `utils` and `use-animated-mount`)
+3. Writes component files to the configured directory
+4. Skips files that already exist — your customizations are safe
+5. Installs any required npm packages using your detected package manager (pnpm / yarn / npm)
+
+**Example output**
+
+```
+✓ Created src/lib/utils.ts
+✓ Created src/hooks/use-animated-mount.ts
+✓ Created src/components/ui/Dialog.tsx
+– Skipped src/lib/utils.ts (already exists)
+
+Done!
+```
+
+---
+
+### `list`
+
+Display all available components.
+
+```bash
+npx react-principles list
+```
+
+**Example output**
+
+```
+Available components:
+
+  accordion              Collapsible content sections
+  alert                  Inline status messages
+  alert-dialog           Confirmation dialog with destructive actions
+  ...
+```
+
+---
+
+## Configuration
+
+`components.json` is created by `init` and read by `add`. You can edit it manually if you change your project structure.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `framework` | `next` \| `vite` \| `remix` \| `other` | Your framework |
+| `rsc` | `boolean` | React Server Components (auto-set to `true` for Next.js) |
+| `tsx` | `boolean` | TypeScript (always `true`) |
+| `componentsDir` | `string` | Where UI components are written |
+| `hooksDir` | `string` | Where hooks are written |
+| `libDir` | `string` | Where utilities are written |
+| `aliases.components` | `string` | Import alias for components |
+| `aliases.hooks` | `string` | Import alias for hooks |
+| `aliases.lib` | `string` | Import alias for utilities |
+
+---
+
+## Available Components
+
+Run `npx react-principles list` to see all components. Below is the full reference:
+
+### Utilities
+
+These are installed automatically as dependencies but can also be added directly.
+
+| Name | Output | Description |
+|------|--------|-------------|
+| `utils` | `lib/utils.ts` | `cn()` utility for merging Tailwind classes |
+| `use-animated-mount` | `hooks/use-animated-mount.ts` | Hook for managing animated mount/unmount timing |
+
+### Components
+
+| Name | Output | Description | Extra deps |
+|------|--------|-------------|------------|
+| `accordion` | `Accordion.tsx` | Collapsible content sections | — |
+| `alert` | `Alert.tsx` | Inline status messages | — |
+| `alert-dialog` | `AlertDialog.tsx` | Confirmation dialog with destructive actions | `use-animated-mount` |
+| `avatar` | `Avatar.tsx` | User avatar with size variants | — |
+| `badge` | `Badge.tsx` | Status and label tags | — |
+| `breadcrumb` | `Breadcrumb.tsx` | Navigation breadcrumb trail | — |
+| `button` | `Button.tsx` | Primary, secondary, ghost, outline, destructive variants | — |
+| `card` | `Card.tsx` | Content container with variants | — |
+| `checkbox` | `Checkbox.tsx` | Controlled checkbox with label | — |
+| `combobox` | `Combobox.tsx` | Searchable dropdown select | — |
+| `command` | `Command.tsx` | Command palette container | — |
+| `date-picker` | `DatePicker.tsx` | Date input | — |
+| `dialog` | `Dialog.tsx` | Modal dialog with compound sub-components | `use-animated-mount` |
+| `drawer` | `Drawer.tsx` | Slide-in panel (left/right) | `use-animated-mount` |
+| `dropdown-menu` | `DropdownMenu.tsx` | Contextual dropdown | — |
+| `floating-lines` | `FloatingLines.tsx` | Decorative animated background | — |
+| `input` | `Input.tsx` | Text input with variants | — |
+| `pagination` | `Pagination.tsx` | Page navigation | — |
+| `popover` | `Popover.tsx` | Floating content anchored to a trigger | — |
+| `progress` | `Progress.tsx` | Linear progress bar | — |
+| `progress-bar` | `ProgressBar.tsx` | Animated top progress bar tied to navigation | `use-animated-mount` |
+| `radio-group` | `RadioGroup.tsx` | Radio button group | — |
+| `search-dialog` | `SearchDialog.tsx` | Full-screen search dialog | `use-animated-mount` |
+| `select` | `Select.tsx` | Native select with styling | — |
+| `separator` | `Separator.tsx` | Horizontal/vertical divider | — |
+| `skeleton` | `Skeleton.tsx` | Loading placeholder shapes | — |
+| `slider` | `Slider.tsx` | Range input | — |
+| `switch` | `Switch.tsx` | Toggle switch | — |
+| `tabs` | `Tabs.tsx` | Tabbed content panels | — |
+| `textarea` | `Textarea.tsx` | Multi-line text input | — |
+| `toast` | `Toast.tsx` | Transient notification | `use-animated-mount` |
+| `tooltip` | `Tooltip.tsx` | Hover tooltip with positioning | — |
+
+> **Note:** All components depend on `utils` (`cn()` utility). It is always installed automatically.
+
+---
+
+## How It Works
+
+react-principles uses a **copy-paste model** — component source code is copied directly into your project. You own the code and can customize it freely without maintaining a fork or ejecting from a library.
+
+There are no runtime dependencies on react-principles. Once a component is added to your project, it has no connection to this package.
+
+---
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-principles-cli",
+  "name": "react-principles",
   "version": "0.0.1",
   "description": "CLI to add react-principles UI components to your project",
   "author": "Singgih Budi Purnadi",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -7,7 +7,7 @@ export async function add(names: string[], cwd: string): Promise<void> {
   const config = readConfig(cwd);
 
   if (!config) {
-    console.log(pc.red("No components.json found. Run `npx react-principles-cli init` first."));
+    console.log(pc.red("No components.json found. Run `npx react-principles init` first."));
     process.exit(1);
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -132,6 +132,6 @@ export async function init(cwd: string, frameworkFlag?: string): Promise<void> {
   console.log(
     pc.bold(pc.green("\nDone!")) +
     ` Framework: ${FRAMEWORK_LABELS[framework]} | RSC: ${rsc ? "yes" : "no"}\n` +
-    `Run ${pc.cyan("npx react-principles-cli add <component>")} to add components.\n`
+    `Run ${pc.cyan("npx react-principles add <component>")} to add components.\n`
   );
 }

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -55,6 +55,11 @@ export function HeroSection() {
             Read the Docs
           </Link>
         </div>
+
+        <div className="mt-6 inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white/80 px-5 py-2.5 font-mono text-sm text-slate-500 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-400">
+          <span className="text-primary">$</span>
+          npx react-principles init
+        </div>
       </div>
 
       {/* Browser Mockup */}

--- a/src/features/landing/components/TechStackSection.tsx
+++ b/src/features/landing/components/TechStackSection.tsx
@@ -42,9 +42,9 @@ const STACK_ITEMS = [
     subtitle: "Styling",
   },
   {
-    icon: <span className="text-3xl material-symbols-outlined">extension</span>,
-    title: "shadcn/ui",
-    subtitle: "Components",
+    icon: <span className="text-3xl material-symbols-outlined">widgets</span>,
+    title: "react-principles",
+    subtitle: "UI Library",
   },
 ];
 

--- a/src/features/landing/components/WhySection.tsx
+++ b/src/features/landing/components/WhySection.tsx
@@ -16,6 +16,22 @@ const FEATURES = [
     description:
       "Battle-tested solutions for state management, data fetching, and forms.",
   },
+  {
+    icon: (
+      <span className="material-symbols-outlined text-primary">widgets</span>
+    ),
+    title: "UI Components",
+    description:
+      "35 accessible, zero-dependency components built with pure Tailwind CSS.",
+  },
+  {
+    icon: (
+      <span className="material-symbols-outlined text-primary">terminal</span>
+    ),
+    title: "CLI Ready",
+    description:
+      "Add any component to your project instantly with a single command.",
+  },
 ];
 
 const LAB_ITEMS = [


### PR DESCRIPTION
## Summary

- Rename npm package from `react-principles-cli` to `react-principles` and add comprehensive README
- Improve landing page content to accurately highlight the react-principles UI library and CLI

## Changes

### CLI Package (`packages/cli`)
- Rename package from `react-principles-cli` → `react-principles`
- Fix inconsistent binary name references in CLI output messages (`init.ts`, `add.ts`)
- Add `README.md` covering all commands, components, config, and usage examples

### Landing Page
- **TechStackSection**: Replace `shadcn/ui` with `react-principles / UI Library` (accurate representation)
- **WhySection**: Expand from 2 → 4 feature cards — add *UI Components* and *CLI Ready*
- **HeroSection**: Add `npx react-principles init` command block below CTA buttons

## Test plan

- [x] Landing page renders correctly in light and dark mode
- [x] All 4 feature cards display correctly in WhySection
- [x] TechStackSection shows correct stack items
- [x] CLI install block visible in HeroSection
- [x] `npx react-principles init` works correctly
- [x] `npx react-principles add <component>` works correctly
- [x] `npx react-principles list` works correctly