### PR TITLE
fix docs and component issues from #69 to #90

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -189,7 +189,7 @@ These are installed automatically as dependencies but can also be added directly
 | `pagination` | `Pagination.tsx` | Page navigation | — |
 | `popover` | `Popover.tsx` | Floating content anchored to a trigger | — |
 | `progress` | `Progress.tsx` | Linear progress bar | — |
-| `progress-bar` | `ProgressBar.tsx` | Animated top progress bar tied to navigation | `use-animated-mount` |
+| `page-progress` | `PageProgress.tsx` | Animated top progress bar tied to navigation | `use-animated-mount` |
 | `radio-group` | `RadioGroup.tsx` | Radio button group | — |
 | `search-dialog` | `SearchDialog.tsx` | Full-screen search dialog | `use-animated-mount` |
 | `select` | `Select.tsx` | Native select with styling | — |

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -217,10 +217,10 @@ export const REGISTRY: RegistryEntry[] = [
     target: "components",
   },
   {
-    name: "progress-bar",
+    name: "page-progress",
     description: "Animated top progress bar tied to navigation",
-    templateKey: "ProgressBar",
-    outputFile: "ProgressBar.tsx",
+    templateKey: "PageProgress",
+    outputFile: "PageProgress.tsx",
     internalDeps: ["utils"],
     npmDeps: [],
     target: "components",

--- a/packages/cli/src/registry/templates.ts
+++ b/packages/cli/src/registry/templates.ts
@@ -2584,11 +2584,11 @@ export function Progress({ value, max = 100, className, ...props }: ProgressProp
     </div>
   );
 }`,
-  "ProgressBar": `import { cn } from "@/lib/utils";
+  "PageProgress": `import { cn } from "@/lib/utils";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export interface ProgressBarProps {
+export interface PageProgressProps {
   /** Current progress 0–100 */
   progress: number;
   /** Whether the bar is visible (false triggers fade-out) */
@@ -2601,7 +2601,7 @@ export interface ProgressBarProps {
  * Thin top-of-page progress bar for navigation feedback.
  * Pair with \`useProgressBar\` hook.
  */
-export function ProgressBar({ progress, visible }: ProgressBarProps) {
+export function PageProgress({ progress, visible }: PageProgressProps) {
   return (
     <div
       role="progressbar"

--- a/src/app/docs/alert/page.tsx
+++ b/src/app/docs/alert/page.tsx
@@ -3,11 +3,22 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Alert } from "@/ui/Alert";
+import type { AlertVariant } from "@/ui/Alert";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const VARIANTS: { variant: AlertVariant; title: string; description: string }[] = [
+  { variant: "default", title: "Information", description: "System maintenance starts at 22:00 UTC." },
+  { variant: "success", title: "Published", description: "Your release is now visible to all workspace members." },
+  { variant: "warning", title: "Unsaved changes", description: "You have pending edits that are not yet published." },
+  { variant: "error", title: "Payment failed", description: "The latest invoice could not be processed automatically." },
+  { variant: "info", title: "Heads up", description: "Team invitations are sent from the workspace email domain." },
 ];
 
 const CODE_SNIPPET = `import { Alert } from "@/ui/Alert";
@@ -27,100 +38,159 @@ export type AlertVariant = "default" | "success" | "warning" | "error" | "info";
 
 export interface AlertProps extends HTMLAttributes<HTMLDivElement> {
   variant?: AlertVariant;
-}
-
-const VARIANT_CLASSES: Record<AlertVariant, string> = {
-  default: "border-slate-200 bg-white dark:border-[#1f2937] dark:bg-[#161b22]",
-  success: "border-green-300 bg-green-50 dark:border-green-900 dark:bg-green-950/30",
-  warning: "border-amber-300 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30",
-  error: "border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950/30",
-  info: "border-blue-300 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30",
-};
-
-export function Alert({ variant = "default", className, ...props }: AlertProps) {
-  return (
-    <div
-      role="alert"
-      className={cn("rounded-xl border p-4", VARIANT_CLASSES[variant], className)}
-      {...props}
-    />
-  );
-}
-
-Alert.Title = function AlertTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
-  return (
-    <h4
-      className={cn("text-sm font-semibold text-slate-900 dark:text-white", className)}
-      {...props}
-    />
-  );
-}
-
-Alert.Description = function AlertDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
-  return (
-    <p
-      className={cn("mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400", className)}
-      {...props}
-    />
-  );
-}
-
-Alert.Footer = function AlertFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("mt-3 flex items-center gap-2", className)}
-      {...props}
-    />
-  );
-}
-
-Alert.Action = function AlertAction({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90",
-        className
-      )}
-      {...props}
-    />
-  );
 }`;
+
+const PROPS_ROWS = [
+  { prop: "variant", type: '"default" | "success" | "warning" | "error" | "info"', default: '"default"', description: "Changes the semantic styling for the alert surface." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the alert container." },
+];
+
+function ThemedAlertPanel({ dark }: { dark: boolean }) {
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-white";
+
+  return (
+    <div className={`rounded-xl border p-6 space-y-3 ${shell}`}>
+      {VARIANTS.map(({ variant, title, description }) => (
+        <Alert key={variant} variant={variant}>
+          <Alert.Title>{title}</Alert.Title>
+          <Alert.Description>{description}</Alert.Description>
+        </Alert>
+      ))}
+    </div>
+  );
+}
 
 export default function AlertDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Alert</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Callout banner for important contextual messages.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Feedback</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Alert</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Alert
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Inline callout surface for important context, warnings, and success confirmation inside
+            the page layout.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "5 Variants"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="alert" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedAlertPanel dark={false} />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedAlertPanel dark />
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Alert>
-              <Alert.Title>Information</Alert.Title>
-              <Alert.Description>System maintenance window starts at 22:00.</Alert.Description>
-            </Alert>
-            <Alert variant="warning">
-              <Alert.Title>Unsaved changes</Alert.Title>
-              <Alert.Description>You have pending edits that are not published yet.</Alert.Description>
-              <Alert.Footer>
-                <Alert.Action>Review changes</Alert.Action>
-              </Alert.Footer>
-            </Alert>
+            {VARIANTS.map(({ variant, title, description }) => (
+              <Alert key={variant} variant={variant}>
+                <Alert.Title>{title}</Alert.Title>
+                <Alert.Description>{description}</Alert.Description>
+                {variant === "warning" ? (
+                  <Alert.Footer>
+                    <Alert.Action>Review changes</Alert.Action>
+                  </Alert.Footer>
+                ) : null}
+              </Alert>
+            ))}
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Alert.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Alert.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/alert/page.tsx
+++ b/src/app/docs/alert/page.tsx
@@ -13,7 +13,7 @@ const TOC_ITEMS = [
   { label: "Props", href: "#props" },
 ];
 
-const VARIANTS: { variant: AlertVariant; title: string; description: string }[] = [
+const VARIANTS: Array<{ variant: AlertVariant; title: string; description: string }> = [
   { variant: "default", title: "Information", description: "System maintenance starts at 22:00 UTC." },
   { variant: "success", title: "Published", description: "Your release is now visible to all workspace members." },
   { variant: "warning", title: "Unsaved changes", description: "You have pending edits that are not yet published." },

--- a/src/app/docs/avatar/page.tsx
+++ b/src/app/docs/avatar/page.tsx
@@ -1,14 +1,20 @@
 "use client";
 
+import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Avatar } from "@/ui/Avatar";
+import type { AvatarSize } from "@/ui/Avatar";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
+
+const SIZES: AvatarSize[] = ["sm", "md", "lg", "xl"];
 
 const CODE_SNIPPET = `import { Avatar } from "@/ui/Avatar";
 
@@ -29,110 +35,184 @@ export interface AvatarProps {
   size?: AvatarSize;
   className?: string;
   children?: ReactNode;
-}
-
-interface AvatarContextValue {
-  hasImageError: boolean;
-  setHasImageError: (value: boolean) => void;
-}
-
-const AvatarContext = createContext<AvatarContextValue | null>(null);
-
-function useAvatarContext() {
-  const context = useContext(AvatarContext);
-  if (!context) throw new Error("Avatar sub-components must be used inside <Avatar>");
-  return context;
-}
-
-const SIZE_CLASSES: Record<AvatarSize, string> = {
-  sm: "h-8 w-8 text-xs",
-  md: "h-10 w-10 text-sm",
-  lg: "h-14 w-14 text-base",
-  xl: "h-20 w-20 text-lg",
-};
-
-export function Avatar({ size = "md", className, children }: AvatarProps) {
-  const [hasImageError, setHasImageError] = useState(false);
-
-  return (
-    <AvatarContext.Provider value={{ hasImageError, setHasImageError }}>
-      <span
-        className={cn(
-          "relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-100 text-slate-700 dark:bg-[#1f2937] dark:text-slate-200",
-          SIZE_CLASSES[size],
-          className
-        )}
-      >
-        {children}
-      </span>
-    </AvatarContext.Provider>
-  );
-}
-
-Avatar.Image = function AvatarImage({ className, onError, alt, ...props }: ImgHTMLAttributes<HTMLImageElement>) {
-  const { hasImageError, setHasImageError } = useAvatarContext();
-
-  if (hasImageError) return null;
-
-  return (
-    <img
-      className={cn("h-full w-full object-cover", className)}
-      alt={alt ?? ""}
-      onError={(event) => {
-        setHasImageError(true);
-        onError?.(event);
-      }}
-      {...props}
-    />
-  );
-}
-
-Avatar.Fallback = function AvatarFallback({ className, children }: { className?: string; children: ReactNode }) {
-  const { hasImageError } = useAvatarContext();
-  if (!hasImageError) return null;
-
-  return <span className={cn("font-semibold uppercase", className)}>{children}</span>;
 }`;
 
+const PROPS_ROWS = [
+  { prop: "size", type: '"sm" | "md" | "lg" | "xl"', default: '"md"', description: "Controls the avatar diameter and fallback text size." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the avatar root." },
+  { prop: "children", type: "ReactNode", default: "—", description: "Usually composed with Avatar.Image and Avatar.Fallback." },
+  { prop: "Avatar.Image", type: "ImgHTMLAttributes<HTMLImageElement>", default: "—", description: "Displays the profile image until an error occurs." },
+  { prop: "Avatar.Fallback", type: "{ className?: string; children: ReactNode }", default: "—", description: "Fallback initials or content shown after image load failure." },
+];
+
+function AvatarRow() {
+  return (
+    <div className="flex items-center gap-4">
+      <Avatar size="sm">
+        <Avatar.Image src="https://i.pravatar.cc/40?img=15" alt="User" />
+        <Avatar.Fallback>AL</Avatar.Fallback>
+      </Avatar>
+      <Avatar size="md">
+        <Avatar.Image src="https://i.pravatar.cc/60?img=32" alt="User" />
+        <Avatar.Fallback>BR</Avatar.Fallback>
+      </Avatar>
+      <Avatar size="lg">
+        <Avatar.Image src="https://i.pravatar.cc/100?img=12" alt="User" />
+        <Avatar.Fallback>CK</Avatar.Fallback>
+      </Avatar>
+      <Avatar size="xl">
+        <Avatar.Image src="https://invalid.example.com/avatar.png" alt="Fallback" />
+        <Avatar.Fallback>DD</Avatar.Fallback>
+      </Avatar>
+    </div>
+  );
+}
+
 export default function AvatarDocPage() {
+  const [size, setSize] = useState<AvatarSize>("lg");
+
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Avatar</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">User identity visual with image fallback initials.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">General</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Avatar</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Avatar
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Identity marker for people, teams, and entities with automatic image fallback handling
+            and four size options for dense or spacious layouts.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "4 Sizes"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="avatar" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <div className="rounded-xl border border-slate-200 bg-white p-6">
+                <AvatarRow />
+              </div>
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <div className="rounded-xl border border-[#1f2937] bg-[#0d1117] p-6">
+                <AvatarRow />
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Avatar size="sm">
-              <Avatar.Image src="https://i.pravatar.cc/40?img=15" alt="User" />
-              <Avatar.Fallback>AL</Avatar.Fallback>
-            </Avatar>
-            <Avatar size="md">
-              <Avatar.Image src="https://i.pravatar.cc/60?img=32" alt="User" />
-              <Avatar.Fallback>BR</Avatar.Fallback>
-            </Avatar>
-            <Avatar size="lg">
-              <Avatar.Image src="https://i.pravatar.cc/100?img=12" alt="User" />
-              <Avatar.Fallback>CK</Avatar.Fallback>
-            </Avatar>
-            <Avatar size="xl">
-              <Avatar.Image src="https://invalid.example.com/avatar.png" alt="Fallback" />
-              <Avatar.Fallback>DD</Avatar.Fallback>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Size</span>
+              <div className="flex gap-2">
+                {SIZES.map((entry) => (
+                  <button
+                    key={entry}
+                    type="button"
+                    onClick={() => setSize(entry)}
+                    className={`rounded-lg px-3 py-1 text-xs font-semibold transition-all ${size === entry ? "bg-primary text-white" : "bg-slate-100 text-slate-600 dark:bg-[#1f2937] dark:text-slate-400"}`}
+                  >
+                    {entry}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <Avatar size={size}>
+              <Avatar.Image src="https://i.pravatar.cc/120?img=21" alt="Profile" />
+              <Avatar.Fallback>JD</Avatar.Fallback>
             </Avatar>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Avatar.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Avatar.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/breadcrumb/page.tsx
+++ b/src/app/docs/breadcrumb/page.tsx
@@ -8,6 +8,7 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Breadcrumb } from "@/ui/Breadcrumb";
@@ -57,30 +58,69 @@ Breadcrumb.Separator = function BreadcrumbSeparator({ className, children = <spa
   return <span className={cn("text-slate-400 dark:text-slate-500", className)}>{children}</span>;
 }`;
 
+const PROPS_ROWS = [
+  { prop: "Breadcrumb", type: "HTMLAttributes<HTMLElement>", default: "—", description: "Root navigation landmark with the breadcrumb ARIA label." },
+  { prop: "Breadcrumb.List", type: "HTMLAttributes<HTMLOListElement>", default: "—", description: "Ordered list wrapper that lays out items inline." },
+  { prop: "Breadcrumb.Item", type: "HTMLAttributes<HTMLLIElement>", default: "—", description: "List item wrapper for each breadcrumb segment." },
+  { prop: "Breadcrumb.Link", type: "AnchorHTMLAttributes<HTMLAnchorElement>", default: "—", description: "Interactive ancestor link for navigable segments." },
+  { prop: "Breadcrumb.Page", type: "HTMLAttributes<HTMLSpanElement>", default: "—", description: "Current page label rendered as non-interactive text." },
+  { prop: "Breadcrumb.Separator", type: "{ className?: string; children?: ReactNode }", default: '"/"', description: "Visual separator between breadcrumb items." },
+];
+
 export default function BreadcrumbDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Breadcrumb</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Hierarchical navigation path for nested pages.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Navigation</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Breadcrumb</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Breadcrumb
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Hierarchical navigation pattern that shows the current page location and gives users a
+            quick path back to parent sections.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="breadcrumb" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Breadcrumb>
               <Breadcrumb.List>
                 <Breadcrumb.Item>
-                  <Breadcrumb.Link href="#">Dashboard</Breadcrumb.Link>
+                  <Breadcrumb.Link href="/">Home</Breadcrumb.Link>
                 </Breadcrumb.Item>
                 <Breadcrumb.Separator />
                 <Breadcrumb.Item>
-                  <Breadcrumb.Link href="#">Projects</Breadcrumb.Link>
+                  <Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
                 </Breadcrumb.Item>
                 <Breadcrumb.Separator />
                 <Breadcrumb.Item>
-                  <Breadcrumb.Page>React Principles</Breadcrumb.Page>
+                  <Breadcrumb.Page>Button</Breadcrumb.Page>
                 </Breadcrumb.Item>
               </Breadcrumb.List>
             </Breadcrumb>
@@ -88,13 +128,74 @@ export default function BreadcrumbDocPage() {
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
-          <CodeBlock filename="src/ui/Breadcrumb.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
+          <CodeBlock filename="src/ui/Breadcrumb.tsx" copyText={CODE_SNIPPET}>
+            {CODE_SNIPPET}
+          </CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
-          <CodeBlock filename="Breadcrumb.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+              Copy-Paste (Single File)
+            </h2>
+          </div>
+          <CodeBlock filename="Breadcrumb.tsx" copyText={COPY_PASTE_SNIPPET}>
+            {COPY_PASTE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th
+                      key={heading}
+                      className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                    >
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono font-semibold text-primary">{row.prop}</code>
+                    </td>
+                    <td className="px-4 py-3 max-w-[260px]">
+                      <code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">
+                        {row.type}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code>
+                    </td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/combobox/page.tsx
+++ b/src/app/docs/combobox/page.tsx
@@ -9,19 +9,24 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const OPTIONS = [
+  { label: "Next.js", value: "next", description: "App Router and full-stack React" },
+  { label: "Vite", value: "vite", description: "Fast dev server for modern frontends" },
+  { label: "Remix", value: "remix", description: "Nested routing with progressive enhancement" },
+  { label: "Vue", value: "vue", description: "Progressive framework" },
 ];
 
 const CODE_SNIPPET = `import { Combobox } from "@/ui/Combobox";
 
 <Combobox
-  value={value}
-  onValueChange={setValue}
-  options={[
-    { label: "React", value: "react" },
-    { label: "Vue", value: "vue" },
-    { label: "Svelte", value: "svelte" },
-  ]}
-  placeholder="Search framework..."
+  options={frameworks}
+  value={framework}
+  onValueChange={setFramework}
+  label="Framework"
+  description="Search and select a frontend stack."
 />`;
 
 const COPY_PASTE_SNIPPET = `import { useEffect, useMemo, useRef, useState } from "react";
@@ -44,200 +49,125 @@ export interface ComboboxProps {
   label?: string;
   description?: string;
   className?: string;
-}
-
-export function Combobox({
-  options,
-  value,
-  defaultValue,
-  onValueChange,
-  placeholder = "Search...",
-  emptyText = "No results",
-  label,
-  description,
-  className,
-}: ComboboxProps) {
-  const [query, setQuery] = useState("");
-  const [open, setOpen] = useState(false);
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const [internalValue, setInternalValue] = useState(defaultValue ?? "");
-  const containerRef = useRef<HTMLDivElement>(null);
-  const isControlled = value !== undefined;
-  const selectedValue = isControlled ? value : internalValue;
-
-  const selectedOption = useMemo(
-    () => options.find((option) => option.value === selectedValue),
-    [options, selectedValue]
-  );
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return options;
-    return options.filter(
-      (option) =>
-        option.label.toLowerCase().includes(q) || option.description?.toLowerCase().includes(q)
-    );
-  }, [options, query]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    window.addEventListener("mousedown", onPointerDown);
-    return () => window.removeEventListener("mousedown", onPointerDown);
-  }, [open]);
-
-  useEffect(() => {
-    if (selectedOption && !open) {
-      setQuery(selectedOption.label);
-    }
-  }, [selectedOption, open]);
-
-  const selectValue = (nextValue: string) => {
-    if (!isControlled) setInternalValue(nextValue);
-    onValueChange?.(nextValue);
-    const nextOption = options.find((option) => option.value === nextValue);
-    setQuery(nextOption?.label ?? "");
-    setOpen(false);
-  };
-
-  return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
-      {label && <label className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</label>}
-
-      <div ref={containerRef} className="relative">
-        <input
-          value={query}
-          onChange={(event) => {
-            setQuery(event.target.value);
-            setOpen(true);
-            setHighlightedIndex(0);
-          }}
-          onFocus={() => setOpen(true)}
-          onKeyDown={(event) => {
-            if (!open && event.key === "ArrowDown") {
-              setOpen(true);
-              return;
-            }
-            if (event.key === "ArrowDown") {
-              event.preventDefault();
-              setHighlightedIndex((index) => Math.min(index + 1, filtered.length - 1));
-            }
-            if (event.key === "ArrowUp") {
-              event.preventDefault();
-              setHighlightedIndex((index) => Math.max(index - 1, 0));
-            }
-            if (event.key === "Enter") {
-              event.preventDefault();
-              const option = filtered[highlightedIndex];
-              if (option && !option.disabled) selectValue(option.value);
-            }
-            if (event.key === "Escape") {
-              setOpen(false);
-            }
-          }}
-          placeholder={placeholder}
-          className={cn(
-            "h-10 w-full rounded-lg border border-slate-200 bg-white px-3.5 text-sm text-slate-900 outline-hidden transition-all",
-            "hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20",
-            "dark:border-[#1f2937] dark:bg-[#0d1117] dark:text-white dark:hover:border-slate-600"
-          )}
-        />
-        <span className="material-symbols-outlined pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[18px] text-slate-400">
-          {open ? "expand_less" : "expand_more"}
-        </span>
-
-        {open && (
-          <div className="absolute z-40 mt-2 max-h-64 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg dark:border-[#1f2937] dark:bg-[#161b22]">
-            {filtered.length === 0 && (
-              <p className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400">{emptyText}</p>
-            )}
-            {filtered.map((option, index) => {
-              const isSelected = selectedValue === option.value;
-              const isHighlighted = index === highlightedIndex;
-              return (
-                <button
-                  key={option.value}
-                  type="button"
-                  disabled={option.disabled}
-                  onMouseEnter={() => setHighlightedIndex(index)}
-                  onClick={() => !option.disabled && selectValue(option.value)}
-                  className={cn(
-                    "flex w-full items-start gap-2 rounded-lg px-3 py-2 text-left transition-colors",
-                    isHighlighted && "bg-primary/10",
-                    !isHighlighted && "hover:bg-slate-50 dark:hover:bg-[#0d1117]",
-                    option.disabled && "cursor-not-allowed opacity-50"
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "mt-0.5 material-symbols-outlined text-[16px]",
-                      isSelected ? "text-primary" : "text-transparent"
-                    )}
-                  >
-                    check
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm text-slate-900 dark:text-white">{option.label}</span>
-                    {option.description && (
-                      <span className="mt-0.5 block truncate text-xs text-slate-500 dark:text-slate-400">
-                        {option.description}
-                      </span>
-                    )}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {description && <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>}
-    </div>
-  );
 }`;
 
+const PROPS_ROWS = [
+  { prop: "options", type: "ComboboxOption[]", default: "—", description: "Available options shown in the floating results list." },
+  { prop: "value", type: "string", default: "—", description: "Controlled selected option value." },
+  { prop: "defaultValue", type: "string", default: "—", description: "Initial selected option value when uncontrolled." },
+  { prop: "onValueChange", type: "(value: string) => void", default: "—", description: "Called when users pick a result." },
+  { prop: "placeholder", type: "string", default: '"Search..."', description: "Input placeholder text before search begins." },
+  { prop: "emptyText", type: "string", default: '"No results"', description: "Fallback message when filtering returns no matches." },
+  { prop: "label", type: "string", default: "—", description: "Optional field label shown above the input." },
+  { prop: "description", type: "string", default: "—", description: "Helper text displayed below the combobox." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the root wrapper." },
+];
+
 export default function ComboboxDocPage() {
-  const [value, setValue] = useState("react");
+  const [framework, setFramework] = useState("next");
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Combobox</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Searchable picker for larger option lists with keyboard navigation support.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Combobox</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Combobox
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Searchable selection input that combines free-form filtering with a structured list of
+            options for large or descriptive datasets.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Keyboard Nav", "Animated"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="combobox" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Combobox
-              value={value}
-              onValueChange={setValue}
-              placeholder="Search framework..."
-              options={[
-                { label: "React", value: "react", description: "Component-driven UI" },
-                { label: "Vue", value: "vue", description: "Progressive framework" },
-                { label: "Svelte", value: "svelte", description: "Compiler-based" },
-                { label: "Solid", value: "solid", description: "Fine-grained reactivity" },
-              ]}
+              options={OPTIONS}
+              value={framework}
+              onValueChange={setFramework}
+              label="Framework"
+              description="Search and select a frontend stack."
             />
+            <p className="text-xs text-slate-500 dark:text-slate-400">Selected value: {framework}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Combobox.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Combobox.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/command/page.tsx
+++ b/src/app/docs/command/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Command } from "@/ui/Command";
@@ -9,17 +8,18 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Command } from "@/ui/Command";
 
 <Command>
-  <Command.Input placeholder="Type a command..." />
+  <Command.Input placeholder="Search commands..." />
   <Command.List>
     <Command.Group>
       <Command.Label>Navigation</Command.Label>
-      <Command.Item value="Go to dashboard">Go to dashboard</Command.Item>
-      <Command.Item value="Open settings">Open settings</Command.Item>
+      <Command.Item value="go-home">Go to home</Command.Item>
+      <Command.Item value="open-docs">Open docs</Command.Item>
     </Command.Group>
   </Command.List>
 </Command>`;
@@ -30,153 +30,131 @@ import { cn } from "@/lib/utils";
 interface CommandContextValue {
   query: string;
   setQuery: (query: string) => void;
-}
-
-const CommandContext = createContext<CommandContextValue | null>(null);
-
-function useCommandContext() {
-  const context = useContext(CommandContext);
-  if (!context) throw new Error("Command sub-components must be used inside <Command>");
-  return context;
-}
-
-export function Command({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  const [query, setQuery] = useState("");
-
-  return (
-    <CommandContext.Provider value={{ query, setQuery }}>
-      <div
-        className={cn(
-          "rounded-xl border border-slate-200 bg-white dark:border-[#1f2937] dark:bg-[#161b22]",
-          className
-        )}
-        {...props}
-      />
-    </CommandContext.Provider>
-  );
-}
-
-Command.Input = function CommandInput({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
-  const { query, setQuery } = useCommandContext();
-
-  return (
-    <div className="flex items-center gap-2 border-b border-slate-100 px-3 py-2 dark:border-[#1f2937]">
-      <span className="material-symbols-outlined text-[18px] text-slate-400">search</span>
-      <input
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        className={cn(
-          "h-8 w-full bg-transparent text-sm text-slate-900 outline-hidden placeholder:text-slate-400 dark:text-white",
-          className
-        )}
-        {...props}
-      />
-    </div>
-  );
-}
-
-Command.List = function CommandList({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("max-h-64 overflow-y-auto p-1", className)} {...props} />;
-}
-
-interface CommandItemProps extends HTMLAttributes<HTMLButtonElement> {
-  value: string;
-  keywords?: string[];
-  children: ReactNode;
-}
-
-Command.Item = function CommandItem({ value, keywords, className, children, ...props }: CommandItemProps) {
-  const { query } = useCommandContext();
-
-  const visible = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return true;
-    const terms = [value, ...(keywords ?? [])].join(" ").toLowerCase();
-    return terms.includes(normalized);
-  }, [query, value, keywords]);
-
-  if (!visible) return null;
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-slate-700 transition-colors hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-[#0d1117]",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
-
-Command.Empty = function CommandEmpty({ className, children = "No results" }: { className?: string; children?: ReactNode }) {
-  const { query } = useCommandContext();
-  if (!query.trim()) return null;
-  return <p className={cn("px-3 py-5 text-center text-xs text-slate-500 dark:text-slate-400", className)}>{children}</p>;
-}
-
-Command.Group = function CommandGroup({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("space-y-1", className)} {...props} />;
-}
-
-Command.Label = function CommandLabel({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
-  return (
-    <p
-      className={cn("px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400", className)}
-      {...props}
-    />
-  );
-}
-
-Command.Separator = function CommandSeparator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
 }`;
 
-export default function CommandDocPage() {
-  const [lastCommand, setLastCommand] = useState("None");
+const PROPS_ROWS = [
+  { prop: "Command.Input", type: "InputHTMLAttributes<HTMLInputElement>", default: "—", description: "Search field bound to the internal command query state." },
+  { prop: "Command.List", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Scrollable container for filtered command groups and items." },
+  { prop: "Command.Item.value", type: "string", default: "—", description: "Primary searchable string used for filtering the item." },
+  { prop: "Command.Item.keywords", type: "string[]", default: "—", description: "Additional search terms matched against the current query." },
+  { prop: "Command.Group", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Logical grouping wrapper for related command items." },
+  { prop: "Command.Label", type: "HTMLAttributes<HTMLParagraphElement>", default: "—", description: "Uppercase section label for a command group." },
+  { prop: "Command.Separator", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Visual divider between command groups." },
+  { prop: "Command.Empty", type: "{ className?: string; children?: ReactNode }", default: '"No results"', description: "Fallback message shown when the query has no matches." },
+];
 
+export default function CommandDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Command</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Quick-action list with search filtering for power users.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Navigation</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Command</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Command
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Search-first command palette surface for app navigation, shortcuts, and filtered action
+            discovery with a small set of composable subcomponents.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="command" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Command>
-              <Command.Input placeholder="Type a command..." />
+              <Command.Input placeholder="Search commands..." />
               <Command.List>
                 <Command.Group>
                   <Command.Label>Navigation</Command.Label>
-                  <Command.Item value="Go to dashboard" onClick={() => setLastCommand("Go to dashboard")}>Go to dashboard</Command.Item>
-                  <Command.Item value="Open settings" onClick={() => setLastCommand("Open settings")}>Open settings</Command.Item>
+                  <Command.Item value="go-home" keywords={["dashboard", "landing"]}>Go to home</Command.Item>
+                  <Command.Item value="open-docs" keywords={["guide", "reference"]}>Open docs</Command.Item>
                 </Command.Group>
                 <Command.Separator />
                 <Command.Group>
-                  <Command.Label>Project</Command.Label>
-                  <Command.Item value="Invite member" onClick={() => setLastCommand("Invite member")}>Invite member</Command.Item>
-                  <Command.Item value="Archive project" onClick={() => setLastCommand("Archive project")}>Archive project</Command.Item>
+                  <Command.Label>Actions</Command.Label>
+                  <Command.Item value="create-project" keywords={["new", "workspace"]}>Create project</Command.Item>
+                  <Command.Item value="invite-team" keywords={["members", "collaborators"]}>Invite team</Command.Item>
                 </Command.Group>
-                <Command.Empty>No commands found</Command.Empty>
+                <Command.Empty>No matching command</Command.Empty>
               </Command.List>
             </Command>
-            <p className="text-xs text-slate-500 dark:text-slate-400">Last command: {lastCommand}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Command.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Command.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/date-picker/page.tsx
+++ b/src/app/docs/date-picker/page.tsx
@@ -9,14 +9,14 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { DatePicker } from "@/ui/DatePicker";
 
 <DatePicker
-  label="Due date"
-  value={dueDate}
-  onChange={(event) => setDueDate(event.target.value)}
+  label="Launch date"
+  description="Select the deployment day."
 />`;
 
 const COPY_PASTE_SNIPPET = `import { forwardRef, type InputHTMLAttributes } from "react";
@@ -26,71 +26,120 @@ export interface DatePickerProps extends Omit<InputHTMLAttributes<HTMLInputEleme
   label?: string;
   description?: string;
   error?: string;
-}
+}`;
 
-export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(function DatePickerRoot(
-  { label, description, error, className, id, ...props },
-  ref
-) {
-  const inputId = id ?? (label ? label.toLowerCase().replace(/\\s+/g, "-") : undefined);
-
-  return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
-      {label && (
-        <label htmlFor={inputId} className="text-sm font-medium text-slate-700 dark:text-slate-300">
-          {label}
-        </label>
-      )}
-      <input
-        ref={ref}
-        id={inputId}
-        type="date"
-        className={cn(
-          "h-10 w-full rounded-lg border border-slate-200 bg-white px-3.5 text-sm text-slate-900 outline-hidden transition-all",
-          "hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20",
-          "dark:border-[#1f2937] dark:bg-[#0d1117] dark:text-white dark:hover:border-slate-600",
-          error && "border-red-400 focus:border-red-400 focus:ring-red-400/20 dark:border-red-500"
-        )}
-        {...props}
-      />
-      {description && !error && <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>}
-      {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
-    </div>
-  );
-});`;
+const PROPS_ROWS = [
+  { prop: "label", type: "string", default: "—", description: "Optional label displayed above the date input." },
+  { prop: "description", type: "string", default: "—", description: "Helper text shown below the field when there is no error." },
+  { prop: "error", type: "string", default: "—", description: "Error message that replaces the helper text and applies error styling." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the root wrapper." },
+  { prop: "id", type: "string", default: "Generated from label", description: "Overrides the input id used by the label element." },
+];
 
 export default function DatePickerDocPage() {
-  const [dueDate, setDueDate] = useState("");
+  const [value, setValue] = useState("2026-04-10");
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Date Picker</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Native date input wrapped with consistent styling and helper text.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Date Picker</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Date Picker
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Styled native date input for scheduling, due dates, and release planning with built-in
+            label, helper text, and validation messaging support.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="date-picker" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <DatePicker
-              label="Due date"
-              value={dueDate}
-              description="Set your milestone deadline"
-              onChange={(event) => setDueDate(event.target.value)}
+              label="Launch date"
+              description="Select the deployment day."
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
             />
-            <p className="text-xs text-slate-500 dark:text-slate-400">Selected: {dueDate || "None"}</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">Selected date: {value}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/DatePicker.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="DatePicker.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/dropdown-menu/page.tsx
+++ b/src/app/docs/dropdown-menu/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { DropdownMenu } from "@/ui/DropdownMenu";
@@ -9,36 +8,22 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { DropdownMenu } from "@/ui/DropdownMenu";
 
 <DropdownMenu>
-  <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+  <DropdownMenu.Trigger>Open menu</DropdownMenu.Trigger>
   <DropdownMenu.Content>
-    <DropdownMenu.Label>Profile</DropdownMenu.Label>
-    <DropdownMenu.Item onSelect={() => console.log("Edit")}>Edit profile</DropdownMenu.Item>
-    <DropdownMenu.Item onSelect={() => console.log("Invite")}>Invite member</DropdownMenu.Item>
-    <DropdownMenu.Separator />
-    <DropdownMenu.Item onSelect={() => console.log("Delete")}>Delete project</DropdownMenu.Item>
+    <DropdownMenu.Label>Actions</DropdownMenu.Label>
+    <DropdownMenu.Item onSelect={() => console.log("Rename")}>Rename</DropdownMenu.Item>
+    <DropdownMenu.Item inset onSelect={() => console.log("Duplicate")}>Duplicate</DropdownMenu.Item>
   </DropdownMenu.Content>
 </DropdownMenu>`;
 
-const COPY_PASTE_SNIPPET = `import { createContext, useCallback, useContext, useEffect, useRef, useState, type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode } from "react";
+const COPY_PASTE_SNIPPET = `import { createContext, useContext, useEffect, useRef, useState, type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
-
-interface DropdownMenuContextValue {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-}
-
-const DropdownMenuContext = createContext<DropdownMenuContextValue | null>(null);
-
-function useDropdownMenuContext() {
-  const context = useContext(DropdownMenuContext);
-  if (!context) throw new Error("DropdownMenu sub-components must be used inside <DropdownMenu>");
-  return context;
-}
 
 export interface DropdownMenuProps {
   open?: boolean;
@@ -46,179 +31,126 @@ export interface DropdownMenuProps {
   onOpenChange?: (open: boolean) => void;
   children: ReactNode;
   className?: string;
-}
-
-export interface DropdownMenuTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
-}
-
-export interface DropdownMenuContentProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-}
-
-export interface DropdownMenuItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  inset?: boolean;
-  onSelect?: () => void;
-}
-
-export function DropdownMenu({ open, defaultOpen = false, onOpenChange, children, className }: DropdownMenuProps) {
-  const [internalOpen, setInternalOpen] = useState(defaultOpen);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internalOpen;
-
-  const setOpen = useCallback((next: boolean) => {
-    if (!isControlled) setInternalOpen(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const onPointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-
-    window.addEventListener("mousedown", onPointerDown);
-    window.addEventListener("keydown", onKeyDown);
-
-    return () => {
-      window.removeEventListener("mousedown", onPointerDown);
-      window.removeEventListener("keydown", onKeyDown);
-    };
-  }, [isOpen, setOpen]);
-
-  return (
-    <DropdownMenuContext.Provider value={{ open: isOpen, setOpen }}>
-      <div ref={containerRef} className={cn("relative inline-block", className)}>
-        {children}
-      </div>
-    </DropdownMenuContext.Provider>
-  );
-}
-
-DropdownMenu.Trigger = function DropdownMenuTrigger({ children, className, onClick, ...props }: DropdownMenuTriggerProps) {
-  const { open, setOpen } = useDropdownMenuContext();
-
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        onClick?.(event);
-        setOpen(!open);
-      }}
-      className={cn(
-        "inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 transition-all",
-        "hover:bg-slate-50 dark:border-[#1f2937] dark:bg-[#0d1117] dark:text-slate-200 dark:hover:bg-[#161b22]",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
-
-DropdownMenu.Content = function DropdownMenuContent({ children, className, ...props }: DropdownMenuContentProps) {
-  const { open } = useDropdownMenuContext();
-  if (!open) return null;
-
-  return (
-    <div
-      className={cn(
-        "absolute right-0 top-[calc(100%+8px)] z-50 min-w-56 rounded-xl border border-slate-200 bg-white p-1 shadow-xl",
-        "dark:border-[#1f2937] dark:bg-[#161b22]",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
-
-DropdownMenu.Label = function DropdownMenuLabel({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("px-2.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400", className)}
-      {...props}
-    />
-  );
-}
-
-DropdownMenu.Separator = function DropdownMenuSeparator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
-}
-
-DropdownMenu.Item = function DropdownMenuItem({ inset = false, onSelect, onClick, className, disabled, ...props }: DropdownMenuItemProps) {
-  const { setOpen } = useDropdownMenuContext();
-
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={(event) => {
-        onClick?.(event);
-        if (disabled) return;
-        onSelect?.();
-        setOpen(false);
-      }}
-      className={cn(
-        "flex w-full items-center rounded-lg px-2.5 py-2 text-left text-sm text-slate-700 transition-all",
-        "hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-[#0d1117]",
-        inset && "pl-8",
-        disabled && "cursor-not-allowed opacity-50",
-        className
-      )}
-      {...props}
-    />
-  );
 }`;
 
-export default function DropdownMenuDocPage() {
-  const [lastAction, setLastAction] = useState("None");
+const PROPS_ROWS = [
+  { prop: "open", type: "boolean", default: "—", description: "Controlled open state for the menu." },
+  { prop: "defaultOpen", type: "boolean", default: "false", description: "Initial open state for uncontrolled usage." },
+  { prop: "onOpenChange", type: "(open: boolean) => void", default: "—", description: "Called whenever the menu opens or closes." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the root wrapper." },
+  { prop: "DropdownMenu.Trigger", type: "ButtonHTMLAttributes<HTMLButtonElement>", default: "—", description: "Button that toggles the menu." },
+  { prop: "DropdownMenu.Content", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Floating content surface that contains labels, items, and separators." },
+  { prop: "DropdownMenu.Item.inset", type: "boolean", default: "false", description: "Adds extra left padding for nested or secondary items." },
+  { prop: "DropdownMenu.Item.onSelect", type: "() => void", default: "—", description: "Convenience callback invoked before the menu closes." },
+  { prop: "DropdownMenu.Label", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Section label for grouped menu items." },
+  { prop: "DropdownMenu.Separator", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Visual divider between menu sections." },
+];
 
+export default function DropdownMenuDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Dropdown Menu</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Compact action menu for contextual operations.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Overlay</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Dropdown Menu</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Dropdown Menu
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Compact action menu for grouped commands, secondary controls, and contextual operations
+            that should stay close to their trigger.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Animated", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="dropdown-menu" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <DropdownMenu>
-              <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+              <DropdownMenu.Trigger>Open menu</DropdownMenu.Trigger>
               <DropdownMenu.Content>
-                <DropdownMenu.Label>Project</DropdownMenu.Label>
-                <DropdownMenu.Item onSelect={() => setLastAction("Edit profile")}>Edit profile</DropdownMenu.Item>
-                <DropdownMenu.Item onSelect={() => setLastAction("Invite member")}>Invite member</DropdownMenu.Item>
+                <DropdownMenu.Label>Actions</DropdownMenu.Label>
+                <DropdownMenu.Item onSelect={() => undefined}>Rename project</DropdownMenu.Item>
+                <DropdownMenu.Item inset onSelect={() => undefined}>Duplicate project</DropdownMenu.Item>
                 <DropdownMenu.Separator />
-                <DropdownMenu.Item onSelect={() => setLastAction("Delete project")}>Delete project</DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={() => undefined}>Archive project</DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu>
-            <p className="text-xs text-slate-500 dark:text-slate-400">Last action: {lastAction}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/DropdownMenu.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="DropdownMenu.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/page-progress/page.tsx
+++ b/src/app/docs/page-progress/page.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState } from "react";
+import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
+import { PageProgress } from "@/ui/PageProgress";
+import { useProgressBar } from "@/shared/hooks/useProgressBar";
+
+const TOC_ITEMS = [
+  { label: "Live Demo", href: "#demo" },
+  { label: "Code Snippet", href: "#snippet" },
+  { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const CODE_SNIPPET = `import { useState } from "react";
+import { PageProgress } from "@/ui/PageProgress";
+import { useProgressBar } from "@/shared/hooks/useProgressBar";
+
+export function RouteFeedback() {
+  const [navigationKey, setNavigationKey] = useState("initial");
+  const { progress, visible } = useProgressBar(navigationKey);
+
+  return (
+    <>
+      <button onClick={() => setNavigationKey(\`nav-\${Date.now()}\`)}>
+        Simulate navigation
+      </button>
+      <PageProgress progress={progress} visible={visible} />
+    </>
+  );
+}`;
+
+const COPY_PASTE_SNIPPET = `import { cn } from "@/lib/utils";
+
+export interface PageProgressProps {
+  progress: number;
+  visible: boolean;
+}
+
+export function PageProgress({ progress, visible }: PageProgressProps) {
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={progress}
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none fixed left-0 top-0 z-200 h-0.5 bg-primary",
+        "shadow-[0_0_8px_1px_rgba(70,40,241,0.7)]",
+        "transition-opacity duration-300",
+        visible ? "opacity-100" : "opacity-0"
+      )}
+      style={{
+        width: \`\${progress}%\`,
+        transition: \`width \${progress === 0 ? "0ms" : progress === 100 ? "150ms" : "350ms"} ease-out, opacity 300ms\`,
+      }}
+    />
+  );
+}`;
+
+const PROPS_ROWS = [
+  {
+    prop: "progress",
+    type: "number",
+    default: "—",
+    description: "Current completion percentage from 0 to 100.",
+  },
+  {
+    prop: "visible",
+    type: "boolean",
+    default: "—",
+    description: "Controls the fade-in and fade-out visibility state.",
+  },
+];
+
+function PageProgressDemo() {
+  const [navigationKey, setNavigationKey] = useState("initial");
+  const [attempts, setAttempts] = useState(0);
+  const { progress, visible } = useProgressBar(navigationKey);
+
+  const handleSimulateNavigation = () => {
+    setAttempts((count) => count + 1);
+    setNavigationKey(`navigation-${Date.now()}`);
+  };
+
+  return (
+    <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-5">
+      <PageProgress progress={progress} visible={visible} />
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-slate-900 dark:text-white">
+            Simulate a route transition
+          </p>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            Trigger the hook and watch the top edge of the viewport for the animated progress bar.
+          </p>
+        </div>
+        <Button onClick={handleSimulateNavigation}>Simulate navigation</Button>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-lg border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#0d1117] p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Visible
+          </p>
+          <p className="mt-2 text-lg font-bold text-slate-900 dark:text-white">
+            {visible ? "Yes" : "No"}
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#0d1117] p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Progress
+          </p>
+          <p className="mt-2 text-lg font-bold text-slate-900 dark:text-white">
+            {Math.round(progress)}%
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#0d1117] p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Runs
+          </p>
+          <p className="mt-2 text-lg font-bold text-slate-900 dark:text-white">
+            {attempts}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PageProgressDocPage() {
+  return (
+    <DocsPageLayout tocItems={TOC_ITEMS}>
+      <div className="max-w-4xl">
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Navigation</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Page Progress</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Page Progress
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            A thin top-of-page progress indicator for route transitions and optimistic navigation
+            feedback. It pairs with the <code className="font-mono">useProgressBar</code> hook to
+            animate route changes without blocking content.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Dark Mode", "Animated", "Portal"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <CliInstallBlock name="page-progress" />
+
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <p className="mb-6 leading-relaxed text-slate-600 dark:text-slate-400">
+            This demo wires the component to <code className="font-mono">useProgressBar</code> so
+            you can replay a route transition and observe the bar animating at the top of the
+            viewport.
+          </p>
+          <PageProgressDemo />
+        </section>
+
+        <section id="snippet" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
+          <CodeBlock filename="src/ui/PageProgress.tsx" copyText={CODE_SNIPPET}>
+            {CODE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="copy-paste" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+              Copy-Paste (Single File)
+            </h2>
+          </div>
+          <CodeBlock filename="PageProgress.tsx" copyText={COPY_PASTE_SNIPPET}>
+            {COPY_PASTE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th
+                      key={heading}
+                      className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                    >
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr
+                    key={row.prop}
+                    className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]"
+                  >
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono font-semibold text-primary">{row.prop}</code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-600 dark:text-slate-400">
+                        {row.type}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-500 dark:text-slate-400">
+                        {row.default}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </DocsPageLayout>
+  );
+}

--- a/src/app/docs/pagination/page.tsx
+++ b/src/app/docs/pagination/page.tsx
@@ -9,13 +9,14 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Pagination } from "@/ui/Pagination";
 
 <Pagination
   page={page}
-  totalPages={24}
+  totalPages={12}
   onPageChange={setPage}
   siblingCount={1}
 />`;
@@ -67,57 +68,15 @@ function buildRange(page: number, totalPages: number, siblingCount: number): Pag
   if (totalPages > 1) pages.push(totalPages);
 
   return pages;
-}
-
-export function Pagination({ page, totalPages, onPageChange, siblingCount = 1, className }: PaginationProps) {
-  const clampedPage = Math.min(Math.max(page, 1), Math.max(totalPages, 1));
-  const range = buildRange(clampedPage, totalPages, siblingCount);
-
-  return (
-    <nav aria-label="Pagination" className={cn("inline-flex items-center gap-1", className)}>
-      <button
-        type="button"
-        onClick={() => onPageChange(clampedPage - 1)}
-        disabled={clampedPage <= 1}
-        className="rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-700 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#1f2937] dark:text-slate-200 dark:hover:bg-[#161b22]"
-      >
-        Prev
-      </button>
-
-      {range.map((token, index) =>
-        token === "ellipsis" ? (
-          <span key={\`ellipsis-\${index}\`} className="px-1 text-xs text-slate-400">
-            ...
-          </span>
-        ) : (
-          <button
-            key={token}
-            type="button"
-            onClick={() => onPageChange(token)}
-            aria-current={token === clampedPage ? "page" : undefined}
-            className={cn(
-              "min-w-8 rounded-md px-2.5 py-1.5 text-xs font-medium transition-all",
-              token === clampedPage
-                ? "bg-primary text-white"
-                : "border border-slate-200 text-slate-700 hover:bg-slate-50 dark:border-[#1f2937] dark:text-slate-200 dark:hover:bg-[#161b22]"
-            )}
-          >
-            {token}
-          </button>
-        )
-      )}
-
-      <button
-        type="button"
-        onClick={() => onPageChange(clampedPage + 1)}
-        disabled={clampedPage >= totalPages}
-        className="rounded-md border border-slate-200 px-2.5 py-1.5 text-xs text-slate-700 transition-all hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#1f2937] dark:text-slate-200 dark:hover:bg-[#161b22]"
-      >
-        Next
-      </button>
-    </nav>
-  );
 }`;
+
+const PROPS_ROWS = [
+  { prop: "page", type: "number", default: "—", description: "Current active page number." },
+  { prop: "totalPages", type: "number", default: "—", description: "Total number of pages available in the range." },
+  { prop: "onPageChange", type: "(page: number) => void", default: "—", description: "Called when users move to the previous, next, or a numbered page." },
+  { prop: "siblingCount", type: "number", default: "1", description: "Controls how many pages remain visible on either side of the current page." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the pagination nav wrapper." },
+];
 
 export default function PaginationDocPage() {
   const [page, setPage] = useState(5);
@@ -125,29 +84,99 @@ export default function PaginationDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Pagination</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Page navigation control with previous/next and adaptive page range.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Navigation</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Pagination</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Pagination
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Compact page navigation control with clamped prev and next actions plus ellipsis-based
+            range collapsing for longer result sets.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="pagination" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Pagination page={page} totalPages={24} onPageChange={setPage} />
+            <Pagination page={page} totalPages={12} onPageChange={setPage} />
             <p className="text-xs text-slate-500 dark:text-slate-400">Current page: {page}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Pagination.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Pagination.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/popover/page.tsx
+++ b/src/app/docs/popover/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Popover } from "@/ui/Popover";
@@ -8,18 +9,16 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Popover } from "@/ui/Popover";
 
-<Popover>
-  <Popover.Trigger>Open profile card</Popover.Trigger>
+<Popover side="bottom" align="start">
+  <Popover.Trigger>Open details</Popover.Trigger>
   <Popover.Content>
-    <h4 className="text-sm font-semibold">Project Access</h4>
-    <p className="mt-1 text-xs text-slate-500">Invite teammates and set role permissions.</p>
-    <div className="mt-3">
-      <Popover.Close>Done</Popover.Close>
-    </div>
+    <p>Popover content goes here.</p>
+    <Popover.Close>Close</Popover.Close>
   </Popover.Content>
 </Popover>`;
 
@@ -29,21 +28,6 @@ import { cn } from "@/lib/utils";
 type PopoverSide = "top" | "bottom";
 type PopoverAlign = "start" | "center" | "end";
 
-interface PopoverContextValue {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-  side: PopoverSide;
-  align: PopoverAlign;
-}
-
-const PopoverContext = createContext<PopoverContextValue | null>(null);
-
-function usePopoverContext() {
-  const context = useContext(PopoverContext);
-  if (!context) throw new Error("Popover sub-components must be used inside <Popover>");
-  return context;
-}
-
 export interface PopoverProps {
   open?: boolean;
   defaultOpen?: boolean;
@@ -52,164 +36,77 @@ export interface PopoverProps {
   align?: PopoverAlign;
   children: ReactNode;
   className?: string;
-}
-
-export interface PopoverTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
-}
-
-export interface PopoverContentProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-}
-
-export interface PopoverCloseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children?: ReactNode;
-}
-
-export function Popover({
-  open,
-  defaultOpen = false,
-  onOpenChange,
-  side = "bottom",
-  align = "start",
-  children,
-  className,
-}: PopoverProps) {
-  const [internalOpen, setInternalOpen] = useState(defaultOpen);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const isControlled = open !== undefined;
-  const isOpen = isControlled ? open : internalOpen;
-
-  const setOpen = useCallback((next: boolean) => {
-    if (!isControlled) setInternalOpen(next);
-    onOpenChange?.(next);
-  }, [isControlled, onOpenChange]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleOutside = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-
-    window.addEventListener("mousedown", handleOutside);
-    window.addEventListener("keydown", handleEscape);
-
-    return () => {
-      window.removeEventListener("mousedown", handleOutside);
-      window.removeEventListener("keydown", handleEscape);
-    };
-  }, [isOpen, setOpen]);
-
-  return (
-    <PopoverContext.Provider value={{ open: isOpen, setOpen, side, align }}>
-      <div ref={containerRef} className={cn("relative inline-block", className)}>
-        {children}
-      </div>
-    </PopoverContext.Provider>
-  );
-}
-
-Popover.Trigger = function PopoverTrigger({ children, className, onClick, ...props }: PopoverTriggerProps) {
-  const { open, setOpen } = usePopoverContext();
-
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        onClick?.(event);
-        setOpen(!open);
-      }}
-      className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 transition-all",
-        "hover:bg-slate-50 dark:border-[#1f2937] dark:text-slate-200 dark:hover:bg-[#161b22]",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
-
-const SIDE_CLASS: Record<PopoverSide, string> = {
-  top: "bottom-[calc(100%+8px)]",
-  bottom: "top-[calc(100%+8px)]",
-};
-
-const ALIGN_CLASS: Record<PopoverAlign, string> = {
-  start: "left-0",
-  center: "left-1/2 -translate-x-1/2",
-  end: "right-0",
-};
-
-Popover.Content = function PopoverContent({ children, className, ...props }: PopoverContentProps) {
-  const { open, side, align } = usePopoverContext();
-
-  if (!open) return null;
-
-  return (
-    <div
-      className={cn(
-        "absolute z-50 w-72 rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-[#1f2937] dark:bg-[#161b22]",
-        SIDE_CLASS[side],
-        ALIGN_CLASS[align],
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
-
-Popover.Close = function PopoverClose({ children = "Close", className, onClick, ...props }: PopoverCloseProps) {
-  const { setOpen } = usePopoverContext();
-
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        onClick?.(event);
-        setOpen(false);
-      }}
-      className={cn("text-sm font-medium text-primary hover:underline", className)}
-      {...props}
-    >
-      {children}
-    </button>
-  );
 }`;
 
+const PROPS_ROWS = [
+  { prop: "open", type: "boolean", default: "—", description: "Controlled open state for the popover." },
+  { prop: "defaultOpen", type: "boolean", default: "false", description: "Initial open state when used uncontrolled." },
+  { prop: "onOpenChange", type: "(open: boolean) => void", default: "—", description: "Called when the popover opens or closes." },
+  { prop: "side", type: '"top" | "bottom"', default: '"bottom"', description: "Places the content above or below the trigger." },
+  { prop: "align", type: '"start" | "center" | "end"', default: '"start"', description: "Aligns the content relative to the trigger width." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the root wrapper." },
+  { prop: "Popover.Trigger", type: "ButtonHTMLAttributes<HTMLButtonElement>", default: "—", description: "Interactive element that toggles the popover." },
+  { prop: "Popover.Content", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Floating surface that holds the popover content." },
+  { prop: "Popover.Close", type: "ButtonHTMLAttributes<HTMLButtonElement>", default: '"Close"', description: "Convenience action for closing the popover from within the panel." },
+];
+
 export default function PopoverDocPage() {
+  const [open, setOpen] = useState(false);
+
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Popover</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Click-triggered floating panel for contextual actions and details.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Overlay</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Popover</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Popover
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Lightweight anchored surface for secondary actions and supporting content that should
+            stay attached to its trigger rather than interrupting the current page flow.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Animated", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="popover" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Popover>
-              <Popover.Trigger>Open profile card</Popover.Trigger>
+            <Popover open={open} onOpenChange={setOpen} side="bottom" align="start">
+              <Popover.Trigger>Open details</Popover.Trigger>
               <Popover.Content>
-                <h4 className="text-sm font-semibold text-slate-900 dark:text-white">Project Access</h4>
-                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                  Invite teammates and set role permissions.
+                <p className="text-sm font-semibold text-slate-900 dark:text-white">Deployment notes</p>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+                  The next release window starts in 15 minutes. Confirm the checklist before you
+                  continue.
                 </p>
-                <div className="mt-3">
-                  <Popover.Close>Done</Popover.Close>
+                <div className="mt-4 flex items-center justify-between">
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    Status: {open ? "Open" : "Closed"}
+                  </span>
+                  <Popover.Close>Close</Popover.Close>
                 </div>
               </Popover.Content>
             </Popover>
@@ -217,13 +114,55 @@ export default function PopoverDocPage() {
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Popover.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Popover.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/progress/page.tsx
+++ b/src/app/docs/progress/page.tsx
@@ -10,6 +10,7 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Progress } from "@/ui/Progress";
@@ -46,37 +47,115 @@ export function Progress({ value, max = 100, className, ...props }: ProgressProp
   );
 }`;
 
+const PROPS_ROWS = [
+  { prop: "value", type: "number", default: "—", description: "Current progress value before clamping." },
+  { prop: "max", type: "number", default: "100", description: "Maximum progress range used to calculate the fill percentage." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the progress track." },
+];
+
 export default function ProgressDocPage() {
   const [value, setValue] = useState(35);
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Progress</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Linear progress indicator for loading and completion states.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Feedback</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Progress</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Progress
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Linear progress indicator for uploads, task completion, and loading states that need a
+            clear sense of advancement inside page content.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Animated"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="progress" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Progress value={value} />
             <div className="flex items-center gap-2">
-              <Button size="sm" onClick={() => setValue((v) => Math.max(v - 10, 0))}>-10</Button>
-              <Button size="sm" onClick={() => setValue((v) => Math.min(v + 10, 100))}>+10</Button>
+              <Button size="sm" onClick={() => setValue((current) => Math.max(current - 10, 0))}>-10</Button>
+              <Button size="sm" onClick={() => setValue((current) => Math.min(current + 10, 100))}>+10</Button>
               <span className="text-xs text-slate-500 dark:text-slate-400">{value}%</span>
             </div>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Progress.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Progress.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-600 dark:text-slate-400">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/radio-group/page.tsx
+++ b/src/app/docs/radio-group/page.tsx
@@ -9,6 +9,7 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { RadioGroup } from "@/ui/RadioGroup";
@@ -28,105 +29,18 @@ export interface RadioGroupProps extends HTMLAttributes<HTMLDivElement> {
   onValueChange?: (value: string) => void;
   name?: string;
   children: ReactNode;
-}
-
-export interface RadioGroupItemProps extends HTMLAttributes<HTMLButtonElement> {
-  value: string;
-  disabled?: boolean;
-  label?: string;
-  description?: string;
-}
-
-interface RadioGroupContextValue {
-  value: string;
-  name: string;
-  setValue: (value: string) => void;
-}
-
-const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
-
-function useRadioGroupContext() {
-  const context = useContext(RadioGroupContext);
-  if (!context) {
-    throw new Error("RadioGroup sub-components must be used inside <RadioGroup>");
-  }
-  return context;
-}
-
-export function RadioGroup({
-  value,
-  defaultValue = "",
-  onValueChange,
-  name,
-  children,
-  className,
-  ...props
-}: RadioGroupProps) {
-  const [internalValue, setInternalValue] = useState(defaultValue);
-  const autoName = useId();
-  const isControlled = value !== undefined;
-  const active = isControlled ? value : internalValue;
-
-  const setValue = (next: string) => {
-    if (!isControlled) setInternalValue(next);
-    onValueChange?.(next);
-  };
-
-  return (
-    <RadioGroupContext.Provider value={{ value: active, setValue, name: name ?? autoName }}>
-      <div className={cn("space-y-2", className)} role="radiogroup" {...props}>
-        {children}
-      </div>
-    </RadioGroupContext.Provider>
-  );
-}
-
-RadioGroup.Item = function RadioGroupItem({
-  value,
-  disabled = false,
-  label,
-  description,
-  children,
-  className,
-  ...props
-}: RadioGroupItemProps) {
-  const context = useRadioGroupContext();
-  const checked = context.value === value;
-
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => !disabled && context.setValue(value)}
-      className={cn(
-        "flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all",
-        checked
-          ? "border-primary bg-primary/5"
-          : "border-slate-200 bg-white hover:border-slate-300 dark:border-[#1f2937] dark:bg-[#0d1117] dark:hover:border-slate-600",
-        disabled && "cursor-not-allowed opacity-50",
-        className
-      )}
-      {...props}
-    >
-      <span
-        className={cn(
-          "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
-          checked ? "border-primary" : "border-slate-400 dark:border-slate-500"
-        )}
-      >
-        {checked && <span className="h-2 w-2 rounded-full bg-primary" />}
-      </span>
-      <span className="min-w-0 flex-1">
-        {label && <span className="block text-sm font-medium text-slate-900 dark:text-white">{label}</span>}
-        {description && <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">{description}</span>}
-        {children}
-      </span>
-      <input readOnly tabIndex={-1} type="radio" name={context.name} value={value} checked={checked} className="sr-only" />
-    </button>
-  );
 }`;
+
+const PROPS_ROWS = [
+  { prop: "value", type: "string", default: "—", description: "Controlled selected value for the root radio group." },
+  { prop: "defaultValue", type: "string", default: '""', description: "Initial selected value when the group is uncontrolled." },
+  { prop: "onValueChange", type: "(value: string) => void", default: "—", description: "Called when users pick a different radio option." },
+  { prop: "name", type: "string", default: "Generated id", description: "Sets the shared hidden input name for the group." },
+  { prop: "RadioGroup.Item.value", type: "string", default: "—", description: "Unique item value submitted when the option is selected." },
+  { prop: "RadioGroup.Item.disabled", type: "boolean", default: "false", description: "Disables an individual option and prevents interaction." },
+  { prop: "RadioGroup.Item.label", type: "string", default: "—", description: "Primary label text rendered inside the option card." },
+  { prop: "RadioGroup.Item.description", type: "string", default: "—", description: "Secondary helper text rendered below the label." },
+];
 
 export default function RadioGroupDocPage() {
   const [plan, setPlan] = useState("pro");
@@ -134,32 +48,103 @@ export default function RadioGroupDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Radio Group</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Mutually exclusive options with clear active state and descriptive labels.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Radio Group</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Radio Group
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Single-choice selection pattern for plans, preferences, and mutually exclusive options
+            with accessible radio semantics and keyboard-friendly structure.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="radio-group" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <RadioGroup value={plan} onValueChange={setPlan}>
               <RadioGroup.Item value="starter" label="Starter" description="Best for side projects" />
               <RadioGroup.Item value="pro" label="Pro" description="For production apps" />
               <RadioGroup.Item value="enterprise" label="Enterprise" description="Advanced controls" />
             </RadioGroup>
+            <p className="text-xs text-slate-500 dark:text-slate-400">Selected plan: {plan}</p>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/RadioGroup.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="RadioGroup.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/select/page.tsx
+++ b/src/app/docs/select/page.tsx
@@ -4,24 +4,33 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Select } from "@/ui/Select";
+import type { SelectSize } from "@/ui/Select";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const SIZES: SelectSize[] = ["sm", "md", "lg"];
+const OPTIONS = [
+  { label: "Next.js", value: "next" },
+  { label: "Vite", value: "vite" },
+  { label: "Remix", value: "remix" },
 ];
 
 const CODE_SNIPPET = `import { Select } from "@/ui/Select";
 
 <Select
   label="Framework"
-  value={framework}
-  onChange={(event) => setFramework(event.target.value)}
   options={[
     { label: "Next.js", value: "next" },
     { label: "Vite", value: "vite" },
     { label: "Remix", value: "remix" },
   ]}
+  size="md"
 />`;
 
 const COPY_PASTE_SNIPPET = `import { forwardRef, type SelectHTMLAttributes } from "react";
@@ -42,94 +51,181 @@ export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement
   size?: SelectSize;
   options?: SelectOption[];
   placeholder?: string;
-}
+}`;
 
-const SIZE_CLASSES: Record<SelectSize, string> = {
-  sm: "h-8 px-3 pr-9 text-xs",
-  md: "h-10 px-3.5 pr-10 text-sm",
-  lg: "h-12 px-4 pr-11 text-base",
-};
+const PROPS_ROWS = [
+  { prop: "label", type: "string", default: "—", description: "Field label rendered above the select input." },
+  { prop: "description", type: "string", default: "—", description: "Helper text shown below the select when no error is present." },
+  { prop: "error", type: "string", default: "—", description: "Error text that replaces the description and applies error styles." },
+  { prop: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Changes the select height, padding, and text size." },
+  { prop: "options", type: "SelectOption[]", default: "—", description: "Convenience array for rendering option elements." },
+  { prop: "placeholder", type: "string", default: "—", description: "Placeholder option label rendered with an empty value." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the root wrapper." },
+];
 
-export const Select = forwardRef<HTMLSelectElement, SelectProps>(function SelectRoot(
-  { label, description, error, size = "md", options, placeholder, className, id, children, ...props },
-  ref
-) {
-  const inputId = id ?? (label ? label.toLowerCase().replace(/\\s+/g, "-") : undefined);
+function ThemedSelectPanel({ dark }: { dark: boolean }) {
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-white";
 
   return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
-      {label && <label htmlFor={inputId} className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</label>}
-
-      <div className="relative">
-        <select
-          ref={ref}
-          id={inputId}
-          className={cn(
-            "w-full appearance-none rounded-lg border bg-white outline-hidden transition-all",
-            "border-slate-200 text-slate-900 hover:border-slate-300",
-            "focus:border-primary focus:ring-2 focus:ring-primary/20",
-            "dark:border-[#1f2937] dark:bg-[#0d1117] dark:text-white dark:hover:border-slate-600",
-            error && "border-red-400 focus:border-red-400 focus:ring-red-400/20 dark:border-red-500",
-            SIZE_CLASSES[size]
-          )}
-          {...props}
-        >
-          {placeholder && <option value="">{placeholder}</option>}
-          {options?.map((option) => (
-            <option key={option.value} value={option.value} disabled={option.disabled}>
-              {option.label}
-            </option>
-          ))}
-          {children}
-        </select>
-        <span className="material-symbols-outlined pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[18px] text-slate-400">
-          expand_more
-        </span>
-      </div>
-
-      {description && !error && <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>}
-      {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
+    <div className={`rounded-xl border p-6 space-y-4 ${shell}`}>
+      {SIZES.map((size) => (
+        <Select
+          key={size}
+          label={`Size ${size}`}
+          size={size}
+          options={OPTIONS}
+          defaultValue="next"
+        />
+      ))}
     </div>
   );
-});`;
+}
 
 export default function SelectDocPage() {
   const [framework, setFramework] = useState("next");
+  const [size, setSize] = useState<SelectSize>("md");
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Select</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Styled native select for predictable keyboard behavior and minimal setup.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Select</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Select
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Styled native select input for predictable keyboard interaction, forms, and simple
+            option lists that benefit from platform behavior.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "3 Sizes", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="select" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedSelectPanel dark={false} />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedSelectPanel dark />
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Size</span>
+              <div className="flex gap-2">
+                {SIZES.map((entry) => (
+                  <button
+                    key={entry}
+                    type="button"
+                    onClick={() => setSize(entry)}
+                    className={`rounded-lg px-3 py-1 text-xs font-semibold transition-all ${size === entry ? "bg-primary text-white" : "bg-slate-100 text-slate-600 dark:bg-[#1f2937] dark:text-slate-400"}`}
+                  >
+                    {entry}
+                  </button>
+                ))}
+              </div>
+            </div>
             <Select
               label="Framework"
               value={framework}
               onChange={(event) => setFramework(event.target.value)}
-              options={[
-                { label: "Next.js", value: "next" },
-                { label: "Vite", value: "vite" },
-                { label: "Remix", value: "remix" },
-              ]}
+              options={OPTIONS}
+              size={size}
             />
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Select.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Select.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/separator/page.tsx
+++ b/src/app/docs/separator/page.tsx
@@ -8,6 +8,7 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Separator } from "@/ui/Separator";
@@ -48,17 +49,53 @@ export function Separator({
   );
 }`;
 
+const PROPS_ROWS = [
+  { prop: "orientation", type: '"horizontal" | "vertical"', default: '"horizontal"', description: "Switches between horizontal and vertical dividers." },
+  { prop: "decorative", type: "boolean", default: "true", description: "Controls whether the separator is announced to assistive technologies." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the divider element." },
+];
+
 export default function SeparatorDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Separator</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Visual divider for grouping related content.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">General</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Separator</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Separator
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Thin visual divider used to group related content, split toolbar items, and create
+            clearer boundaries between adjacent sections.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="separator" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <p className="text-sm font-medium text-slate-900 dark:text-white">Profile Settings</p>
             <Separator />
@@ -72,13 +109,72 @@ export default function SeparatorDocPage() {
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
-          <CodeBlock filename="src/ui/Separator.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
+          <CodeBlock filename="src/ui/Separator.tsx" copyText={CODE_SNIPPET}>
+            {CODE_SNIPPET}
+          </CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
-          <CodeBlock filename="Separator.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+              Copy-Paste (Single File)
+            </h2>
+          </div>
+          <CodeBlock filename="Separator.tsx" copyText={COPY_PASTE_SNIPPET}>
+            {COPY_PASTE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th
+                      key={heading}
+                      className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                    >
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono font-semibold text-primary">{row.prop}</code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-600 dark:text-slate-400">{row.type}</code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code>
+                    </td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/skeleton/page.tsx
+++ b/src/app/docs/skeleton/page.tsx
@@ -3,11 +3,20 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Skeleton } from "@/ui/Skeleton";
+import type { SkeletonVariant } from "@/ui/Skeleton";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const VARIANTS: { variant: SkeletonVariant; label: string }[] = [
+  { variant: "line", label: "Line" },
+  { variant: "rect", label: "Rect" },
+  { variant: "circle", label: "Circle" },
 ];
 
 const CODE_SNIPPET = `import { Skeleton } from "@/ui/Skeleton";
@@ -27,57 +36,167 @@ export interface SkeletonProps {
   width?: number | string;
   height?: number | string;
   className?: string;
-}
-
-export function Skeleton({ variant = "line", width, height, className }: SkeletonProps) {
-  return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        "inline-block animate-pulse bg-slate-200 dark:bg-[#1f2937]",
-        variant === "line" && "h-4 w-40 rounded-md",
-        variant === "rect" && "h-24 w-full rounded-xl",
-        variant === "circle" && "h-10 w-10 rounded-full",
-        className
-      )}
-      style={{ width, height }}
-    />
-  );
 }`;
+
+const PROPS_ROWS = [
+  { prop: "variant", type: '"line" | "rect" | "circle"', default: '"line"', description: "Switches between text-line, block, and circular placeholder shapes." },
+  { prop: "width", type: "number | string", default: "—", description: "Optional inline width override for the placeholder." },
+  { prop: "height", type: "number | string", default: "—", description: "Optional inline height override for the placeholder." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the skeleton element." },
+];
+
+function ThemedSkeletonPanel({ theme }: { theme: "light" | "dark" }) {
+  const dark = theme === "dark";
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-white";
+
+  return (
+    <div className={`rounded-xl border p-6 space-y-4 ${shell}`}>
+      <Skeleton variant="line" width="70%" />
+      <Skeleton variant="line" width="45%" />
+      <Skeleton variant="rect" className="h-24" />
+      <div className="flex items-center gap-3">
+        <Skeleton variant="circle" />
+        <div className="flex-1 space-y-2">
+          <Skeleton variant="line" width="50%" />
+          <Skeleton variant="line" width="35%" />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function SkeletonDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Skeleton</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Loading placeholder to maintain layout stability while data is being fetched.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Feedback</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Skeleton</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Skeleton
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Animated loading placeholder that preserves layout while content is fetching and gives
+            users a clearer sense of what is about to appear.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "3 Variants", "Animated"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="skeleton" />
 
-        <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <div className="flex items-center gap-3">
-              <Skeleton variant="circle" />
-              <div className="flex-1 space-y-2">
-                <Skeleton variant="line" width="50%" />
-                <Skeleton variant="line" width="35%" />
-              </div>
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
             </div>
-            <Skeleton variant="rect" className="h-24" />
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedSkeletonPanel theme="light" />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedSkeletonPanel theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+            <div className="flex items-center gap-4">
+              {VARIANTS.map(({ variant, label }) => (
+                <div key={variant} className="space-y-3 text-center">
+                  <div className="rounded-xl border border-dashed border-slate-200 p-4 dark:border-[#1f2937]">
+                    {variant === "line" ? <Skeleton variant="line" width={120} /> : null}
+                    {variant === "rect" ? <Skeleton variant="rect" className="h-24 w-32" /> : null}
+                    {variant === "circle" ? <Skeleton variant="circle" className="h-16 w-16" /> : null}
+                  </div>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Skeleton.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Skeleton.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/skeleton/page.tsx
+++ b/src/app/docs/skeleton/page.tsx
@@ -13,7 +13,7 @@ const TOC_ITEMS = [
   { label: "Props", href: "#props" },
 ];
 
-const VARIANTS: { variant: SkeletonVariant; label: string }[] = [
+const VARIANTS: Array<{ variant: SkeletonVariant; label: string }> = [
   { variant: "line", label: "Line" },
   { variant: "rect", label: "Rect" },
   { variant: "circle", label: "Circle" },

--- a/src/app/docs/slider/page.tsx
+++ b/src/app/docs/slider/page.tsx
@@ -9,6 +9,7 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
 
 const CODE_SNIPPET = `import { Slider } from "@/ui/Slider";
@@ -78,19 +79,61 @@ export function Slider({
   );
 }`;
 
+const PROPS_ROWS = [
+  { prop: "value", type: "number", default: "—", description: "Controlled slider value." },
+  { prop: "defaultValue", type: "number", default: "50", description: "Initial value when the slider is uncontrolled." },
+  { prop: "min", type: "number", default: "0", description: "Minimum selectable value." },
+  { prop: "max", type: "number", default: "100", description: "Maximum selectable value." },
+  { prop: "step", type: "number", default: "1", description: "Increment size between slider positions." },
+  { prop: "onValueChange", type: "(value: number) => void", default: "—", description: "Called whenever the range input value changes." },
+  { prop: "label", type: "string", default: "—", description: "Optional label displayed above the slider track." },
+  { prop: "showValue", type: "boolean", default: "true", description: "Displays the current numeric value alongside the label." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the root wrapper." },
+];
+
 export default function SliderDocPage() {
   const [volume, setVolume] = useState(40);
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Slider</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">Range input for numeric value adjustment with immediate feedback.</p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Slider</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Slider
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Numeric range input with immediate feedback for tuning values like volume, thresholds,
+            and preference intensity.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="slider" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Slider label="Volume" value={volume} onValueChange={setVolume} />
             <p className="text-xs text-slate-500 dark:text-slate-400">Current value: {volume}</p>
@@ -98,13 +141,55 @@ export default function SliderDocPage() {
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Slider.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Slider.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/switch/page.tsx
+++ b/src/app/docs/switch/page.tsx
@@ -4,12 +4,17 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Switch } from "@/ui/Switch";
+import type { SwitchSize } from "@/ui/Switch";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
+
+const SIZES: SwitchSize[] = ["sm", "md", "lg"];
 
 const CODE_SNIPPET = `import { Switch } from "@/ui/Switch";
 
@@ -34,118 +39,182 @@ export interface SwitchProps {
   label?: string;
   description?: string;
   className?: string;
-}
+}`;
 
-const TRACK_SIZES: Record<SwitchSize, string> = {
-  sm: "h-5 w-9",
-  md: "h-6 w-11",
-  lg: "h-7 w-14",
-};
+const PROPS_ROWS = [
+  { prop: "checked", type: "boolean", default: "—", description: "Controlled on or off state." },
+  { prop: "defaultChecked", type: "boolean", default: "false", description: "Initial state when the switch is uncontrolled." },
+  { prop: "onChange", type: "(checked: boolean) => void", default: "—", description: "Called whenever the switch toggles." },
+  { prop: "disabled", type: "boolean", default: "false", description: "Prevents interaction and reduces opacity." },
+  { prop: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Changes the track and thumb dimensions." },
+  { prop: "label", type: "string", default: "—", description: "Primary label rendered next to the control." },
+  { prop: "description", type: "string", default: "—", description: "Secondary helper text rendered below the label." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the root wrapper." },
+];
 
-const THUMB_SIZES: Record<SwitchSize, string> = {
-  sm: "h-4 w-4 data-[checked=true]:translate-x-4",
-  md: "h-5 w-5 data-[checked=true]:translate-x-5",
-  lg: "h-6 w-6 data-[checked=true]:translate-x-7",
-};
-
-export function Switch({
-  checked,
-  defaultChecked = false,
-  onChange,
-  disabled = false,
-  size = "md",
-  label,
-  description,
-  className,
-}: SwitchProps) {
-  const [internal, setInternal] = useState(defaultChecked);
-  const isControlled = checked !== undefined;
-  const isOn = isControlled ? checked : internal;
-
-  const stateLabel = useMemo(() => (isOn ? "enabled" : "disabled"), [isOn]);
-
-  const toggle = () => {
-    if (disabled) return;
-    const next = !isOn;
-    if (!isControlled) setInternal(next);
-    onChange?.(next);
-  };
+function ThemedSwitchPanel({ dark }: { dark: boolean }) {
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-white";
 
   return (
-    <div className={cn("inline-flex items-start gap-3", className)}>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={isOn}
-        aria-label={label ?? "Switch"}
-        aria-disabled={disabled}
-        data-state={isOn ? "checked" : "unchecked"}
-        onClick={toggle}
-        className={cn(
-          "relative shrink-0 rounded-full p-0.5 transition-all outline-hidden",
-          "focus-visible:ring-2 focus-visible:ring-primary/40",
-          TRACK_SIZES[size],
-          isOn ? "bg-primary" : "bg-slate-300 dark:bg-slate-700",
-          disabled && "cursor-not-allowed opacity-50"
-        )}
-      >
-        <span
-          data-checked={isOn}
-          className={cn(
-            "block rounded-full bg-white shadow-sm transition-transform duration-200",
-            THUMB_SIZES[size]
-          )}
+    <div className={`rounded-xl border p-6 space-y-4 ${shell}`}>
+      {SIZES.map((size) => (
+        <Switch
+          key={size}
+          defaultChecked={size !== "sm"}
+          size={size}
+          label={`Notifications ${size}`}
+          description={`Preview of the ${size} switch size.`}
         />
-      </button>
-
-      {(label ?? description) && (
-        <div className="min-w-0">
-          {label && <p className="text-sm font-medium text-slate-900 dark:text-white">{label}</p>}
-          {description && (
-            <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-              {description} ({stateLabel})
-            </p>
-          )}
-        </div>
-      )}
+      ))}
     </div>
   );
-}`;
+}
 
 export default function SwitchDocPage() {
   const [enabled, setEnabled] = useState(true);
+  const [size, setSize] = useState<SwitchSize>("md");
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Switch</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Binary toggle for on/off settings with optional label and helper text.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Switch</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Switch
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Binary toggle control for settings and preferences where users need an immediate on or
+            off action with optional descriptive context.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "3 Sizes", "Animated", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="switch" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedSwitchPanel dark={false} />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedSwitchPanel dark />
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Size</span>
+              <div className="flex gap-2">
+                {SIZES.map((entry) => (
+                  <button
+                    key={entry}
+                    type="button"
+                    onClick={() => setSize(entry)}
+                    className={`rounded-lg px-3 py-1 text-xs font-semibold transition-all ${size === entry ? "bg-primary text-white" : "bg-slate-100 text-slate-600 dark:bg-[#1f2937] dark:text-slate-400"}`}
+                  >
+                    {entry}
+                  </button>
+                ))}
+              </div>
+            </div>
             <Switch
               checked={enabled}
               onChange={setEnabled}
+              size={size}
               label="Enable analytics"
               description={enabled ? "Analytics is active" : "Analytics is disabled"}
             />
-            <Switch defaultChecked={false} label="Email alerts" description="Receive weekly summary emails." />
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Switch.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Switch.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/textarea/page.tsx
+++ b/src/app/docs/textarea/page.tsx
@@ -4,12 +4,18 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Textarea } from "@/ui/Textarea";
+import type { TextareaSize, TextareaVariant } from "@/ui/Textarea";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
+
+const VARIANTS: TextareaVariant[] = ["default", "filled", "ghost"];
+const SIZES: TextareaSize[] = ["sm", "md", "lg"];
 
 const CODE_SNIPPET = `import { Textarea } from "@/ui/Textarea";
 
@@ -33,114 +39,188 @@ export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaE
   size?: TextareaSize;
   variant?: TextareaVariant;
   children?: ReactNode;
-}
+}`;
 
-const SIZE_CLASSES: Record<TextareaSize, string> = {
-  sm: "min-h-20 px-3 py-2 text-xs",
-  md: "min-h-24 px-3.5 py-2.5 text-sm",
-  lg: "min-h-32 px-4 py-3 text-base",
-};
+const PROPS_ROWS = [
+  { prop: "label", type: "string", default: "—", description: "Field label shown above the textarea." },
+  { prop: "description", type: "string", default: "—", description: "Helper text displayed below the field when there is no error." },
+  { prop: "error", type: "string", default: "—", description: "Validation message that replaces the description and applies error styling." },
+  { prop: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls the minimum height, padding, and text size." },
+  { prop: "variant", type: '"default" | "filled" | "ghost"', default: '"default"', description: "Changes the surface treatment of the textarea." },
+  { prop: "disabled", type: "boolean", default: "false", description: "Disables input interaction and dims the field." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes merged into the root wrapper." },
+];
 
-const VARIANT_CLASSES: Record<TextareaVariant, string> = {
-  default:
-    "border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#0d1117] hover:border-slate-300 dark:hover:border-slate-600",
-  filled:
-    "border border-transparent bg-slate-100 dark:bg-[#161b22] hover:bg-slate-200/80 dark:hover:bg-[#1f2937]",
-  ghost:
-    "border border-transparent bg-transparent hover:bg-slate-50 dark:hover:bg-[#161b22]",
-};
-
-const ERROR_CLASSES =
-  "border-red-400 dark:border-red-500 focus-within:border-red-400 dark:focus-within:border-red-500 focus-within:ring-red-400/20";
-
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function TextareaRoot(
-  {
-    label,
-    description,
-    error,
-    size = "md",
-    variant = "default",
-    disabled,
-    className,
-    id,
-    ...props
-  },
-  ref
-) {
-  const inputId = id ?? (label ? label.toLowerCase().replace(/\\s+/g, "-") : undefined);
+function ThemedTextareaPanel({ dark }: { dark: boolean }) {
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-white";
 
   return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
-      {label && (
-        <label
-          htmlFor={inputId}
-          className={cn("text-sm font-medium text-slate-700 dark:text-slate-300", disabled && "opacity-50")}
-        >
-          {label}
-        </label>
-      )}
-
-      <div
-        className={cn(
-          "rounded-lg transition-all focus-within:ring-2 focus-within:ring-primary/20 focus-within:border-primary dark:focus-within:border-primary",
-          VARIANT_CLASSES[variant],
-          error && ERROR_CLASSES,
-          disabled && "opacity-50"
-        )}
-      >
-        <textarea
-          ref={ref}
-          id={inputId}
-          disabled={disabled}
-          className={cn(
-            "w-full resize-y rounded-lg bg-transparent outline-hidden",
-            "text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500",
-            SIZE_CLASSES[size]
-          )}
-          {...props}
+    <div className={`rounded-xl border p-6 space-y-4 ${shell}`}>
+      {VARIANTS.map((variant) => (
+        <Textarea
+          key={variant}
+          label={`${variant} variant`}
+          variant={variant}
+          defaultValue="Document the migration steps and rollout notes."
+          description="Theme preview"
         />
-      </div>
-
-      {description && !error && <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>}
-      {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
+      ))}
     </div>
   );
-});`;
+}
 
 export default function TextareaDocPage() {
   const [value, setValue] = useState("");
+  const [size, setSize] = useState<TextareaSize>("md");
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Textarea</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Multi-line input for longer content with label, helper text, and error states.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Form</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Textarea</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Textarea
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Multi-line text input for notes, descriptions, and longer form content with variant,
+            size, helper text, and validation support.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "3 Variants", "3 Sizes"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="textarea" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedTextareaPanel dark={false} />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedTextareaPanel dark />
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Textarea
-              label="Project notes"
-              description={`${value.length} characters`}
-              placeholder="Document what changed today..."
-              value={value}
-              onChange={(event) => setValue(event.target.value)}
-            />
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Size</span>
+              <div className="flex gap-2">
+                {SIZES.map((entry) => (
+                  <button
+                    key={entry}
+                    type="button"
+                    onClick={() => setSize(entry)}
+                    className={`rounded-lg px-3 py-1 text-xs font-semibold transition-all ${size === entry ? "bg-primary text-white" : "bg-slate-100 text-slate-600 dark:bg-[#1f2937] dark:text-slate-400"}`}
+                  >
+                    {entry}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-4">
+              {VARIANTS.map((variant) => (
+                <Textarea
+                  key={variant}
+                  label={`${variant} variant`}
+                  description={`${value.length} characters`}
+                  placeholder="Document what changed today..."
+                  value={value}
+                  onChange={(event) => setValue(event.target.value)}
+                  variant={variant}
+                  size={size}
+                />
+              ))}
+            </div>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Textarea.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Textarea.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[240px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/toast/page.tsx
+++ b/src/app/docs/toast/page.tsx
@@ -15,7 +15,7 @@ const TOC_ITEMS = [
   { label: "Props", href: "#props" },
 ];
 
-const VARIANTS: { variant: ToastVariant; label: string; title: string; description: string }[] = [
+const VARIANTS: Array<{ variant: ToastVariant; label: string; title: string; description: string }> = [
   {
     variant: "default",
     label: "Default",

--- a/src/app/docs/toast/page.tsx
+++ b/src/app/docs/toast/page.tsx
@@ -5,12 +5,57 @@ import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Button } from "@/ui/Button";
 import { Toast } from "@/ui/Toast";
+import type { ToastPosition, ToastVariant } from "@/ui/Toast";
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
 ];
+
+const VARIANTS: { variant: ToastVariant; label: string; title: string; description: string }[] = [
+  {
+    variant: "default",
+    label: "Default",
+    title: "Draft saved",
+    description: "Your local changes were stored automatically.",
+  },
+  {
+    variant: "success",
+    label: "Success",
+    title: "Published successfully",
+    description: "Your latest release is now visible to your team.",
+  },
+  {
+    variant: "warning",
+    label: "Warning",
+    title: "Action required",
+    description: "Reconnect your integration to keep sync running.",
+  },
+  {
+    variant: "error",
+    label: "Error",
+    title: "Upload failed",
+    description: "The file could not be processed. Try again in a moment.",
+  },
+];
+
+const FORCED_SURFACE: Record<"light" | "dark", Record<ToastVariant, string>> = {
+  light: {
+    default: "border-slate-200 bg-white",
+    success: "border-green-300 bg-green-50",
+    warning: "border-amber-300 bg-amber-50",
+    error: "border-red-300 bg-red-50",
+  },
+  dark: {
+    default: "border-[#1f2937] bg-[#161b22]",
+    success: "border-green-900 bg-green-950/30",
+    warning: "border-amber-900 bg-amber-950/30",
+    error: "border-red-900 bg-red-950/30",
+  },
+};
 
 const CODE_SNIPPET = `import { Toast } from "@/ui/Toast";
 
@@ -114,83 +159,222 @@ export function Toast({
     </ToastContext.Provider>,
     document.body
   );
-}
-
-Toast.Title = function ToastTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
-  return <h4 className={cn("text-sm font-semibold text-slate-900 dark:text-white", className)} {...props} />;
-}
-
-Toast.Description = function ToastDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn("mt-1 text-xs text-slate-600 dark:text-slate-400", className)} {...props} />;
-}
-
-Toast.Action = function ToastAction({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      type="button"
-      className={cn("rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90", className)}
-      {...props}
-    />
-  );
-}
-
-Toast.Close = function ToastClose({ className, onClick, children = "Dismiss", ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
-  const { onClose } = useToastContext();
-
-  return (
-    <button
-      type="button"
-      onClick={(event) => {
-        onClick?.(event);
-        onClose();
-      }}
-      className={cn("text-xs font-medium text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200", className)}
-      {...props}
-    >
-      {children}
-    </button>
-  );
-}
-
-Toast.Footer = function ToastFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("mt-3 flex items-center justify-end gap-2", className)} {...props} />;
 }`;
 
+const PROPS_ROWS = [
+  { prop: "open", type: "boolean", default: "—", description: "Controls whether the toast is mounted and visible." },
+  { prop: "onOpenChange", type: "(open: boolean) => void", default: "—", description: "Called when auto-dismiss, Escape, or close actions change visibility." },
+  { prop: "variant", type: '"default" | "success" | "warning" | "error"', default: '"default"', description: "Changes the semantic surface colors of the toast." },
+  { prop: "position", type: '"top-right" | "bottom-right" | "top-left" | "bottom-left"', default: '"top-right"', description: "Places the portal-mounted toast in one of four screen corners." },
+  { prop: "duration", type: "number", default: "3000", description: "Auto-dismiss delay in milliseconds. Use 0 or less to disable auto close." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the toast surface." },
+];
+
+function ThemedToastPanel({ theme }: { theme: "light" | "dark" }) {
+  const dark = theme === "dark";
+  const shell = dark ? "border-[#1f2937] bg-[#0d1117]" : "border-slate-200 bg-slate-50";
+  const text = dark ? "text-slate-400" : "text-slate-500";
+
+  return (
+    <div className={`rounded-xl border p-5 space-y-4 ${shell}`}>
+      {VARIANTS.map(({ variant, title, description }) => (
+        <div key={variant} className={`rounded-xl border p-4 shadow-sm ${FORCED_SURFACE[theme][variant]}`}>
+          <p className={`text-sm font-semibold ${dark ? "text-white" : "text-slate-900"}`}>{title}</p>
+          <p className={`mt-1 text-xs ${text}`}>{description}</p>
+          <div className="mt-3 flex justify-end">
+            <span className={`text-xs font-medium ${text}`}>Dismiss</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function ToastDocPage() {
-  const [open, setOpen] = useState(false);
+  const [openStates, setOpenStates] = useState<Record<ToastVariant, boolean>>({
+    default: false,
+    success: false,
+    warning: false,
+    error: false,
+  });
+
+  const updateToast = (variant: ToastVariant, next: boolean) => {
+    setOpenStates((current) => ({ ...current, [variant]: next }));
+  };
 
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Toast</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Lightweight notification for async feedback and quick confirmations.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Overlay</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Toast</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Toast
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Lightweight notification surface for async feedback, confirmations, and background
+            status updates. It supports four semantic variants, animated entry and exit, and portal
+            rendering for reliable stacking.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "4 Variants", "Animated", "Portal"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="toast" />
 
+        <section id="comparison" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            All four variants are shown in forced light and dark surfaces so the semantic color
+            differences remain visible regardless of the current app theme.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-amber-400 shadow-xs shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedToastPanel theme="light" />
+            </div>
+            <div>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="h-3 w-3 rounded-full bg-indigo-500 shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedToastPanel theme="dark" />
+            </div>
+          </div>
+        </section>
+
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Button onClick={() => setOpen(true)}>Show success toast</Button>
-            <Toast open={open} onOpenChange={setOpen} variant="success">
-              <Toast.Title>Saved successfully</Toast.Title>
-              <Toast.Description>Your profile changes are now live.</Toast.Description>
-              <Toast.Footer>
-                <Toast.Close>Dismiss</Toast.Close>
-              </Toast.Footer>
-            </Toast>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-4">
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Each trigger opens a dedicated toast variant. Watch the viewport corners to see the
+              portal-mounted notification appear and dismiss.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {VARIANTS.map(({ variant, label, title, description }, index) => {
+                const position: ToastPosition = index % 2 === 0 ? "top-right" : "bottom-right";
+
+                return (
+                  <div key={variant}>
+                    <Button variant={variant === "error" ? "destructive" : variant === "warning" ? "outline" : variant === "success" ? "primary" : "secondary"} onClick={() => updateToast(variant, true)}>
+                      Show {label}
+                    </Button>
+                    <Toast
+                      open={openStates[variant]}
+                      onOpenChange={(next) => updateToast(variant, next)}
+                      variant={variant}
+                      position={position}
+                    >
+                      <Toast.Title>{title}</Toast.Title>
+                      <Toast.Description>{description}</Toast.Description>
+                      <Toast.Footer>
+                        {variant === "warning" ? <Toast.Action>Reconnect</Toast.Action> : null}
+                        <Toast.Close>Dismiss</Toast.Close>
+                      </Toast.Footer>
+                    </Toast>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
-          <CodeBlock filename="src/ui/Toast.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
+          <CodeBlock filename="src/ui/Toast.tsx" copyText={CODE_SNIPPET}>
+            {CODE_SNIPPET}
+          </CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
-          <CodeBlock filename="Toast.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">
+              Copy-Paste (Single File)
+            </h2>
+          </div>
+          <CodeBlock filename="Toast.tsx" copyText={COPY_PASTE_SNIPPET}>
+            {COPY_PASTE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">05</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th
+                      key={heading}
+                      className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+                    >
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono font-semibold text-primary">{row.prop}</code>
+                    </td>
+                    <td className="px-4 py-3 max-w-[240px]">
+                      <code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">
+                        {row.type}
+                      </code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code>
+                    </td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/app/docs/tooltip/page.tsx
+++ b/src/app/docs/tooltip/page.tsx
@@ -8,6 +8,14 @@ const TOC_ITEMS = [
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const TOOLTIP_SIDES = [
+  { side: "top" as const, label: "Top" },
+  { side: "bottom" as const, label: "Bottom" },
+  { side: "left" as const, label: "Left" },
+  { side: "right" as const, label: "Right" },
 ];
 
 const CODE_SNIPPET = `import { Tooltip } from "@/ui/Tooltip";
@@ -43,100 +51,126 @@ export interface TooltipProps {
   side?: TooltipSide;
   children: ReactNode;
   className?: string;
-}
-
-export interface TooltipTriggerProps extends HTMLAttributes<HTMLSpanElement> {
-  children: ReactNode;
-}
-
-export interface TooltipContentProps extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
-}
-
-export function Tooltip({ defaultOpen = false, side = "top", children, className }: TooltipProps) {
-  const [open, setOpen] = useState(defaultOpen);
-
-  return (
-    <TooltipContext.Provider value={{ open, setOpen, side }}>
-      <span className={cn("relative inline-flex", className)}>{children}</span>
-    </TooltipContext.Provider>
-  );
-}
-
-Tooltip.Trigger = function TooltipTrigger({ children, className, ...props }: TooltipTriggerProps) {
-  const { setOpen } = useTooltipContext();
-
-  return (
-    <span
-      className={cn("inline-flex", className)}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-      onFocus={() => setOpen(true)}
-      onBlur={() => setOpen(false)}
-      {...props}
-    >
-      {children}
-    </span>
-  );
-}
-
-const SIDE_CLASSES: Record<TooltipSide, string> = {
-  top: "bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2",
-  bottom: "top-[calc(100%+8px)] left-1/2 -translate-x-1/2",
-  left: "right-[calc(100%+8px)] top-1/2 -translate-y-1/2",
-  right: "left-[calc(100%+8px)] top-1/2 -translate-y-1/2",
-};
-
-Tooltip.Content = function TooltipContent({ children, className, ...props }: TooltipContentProps) {
-  const { open, side } = useTooltipContext();
-
-  return (
-    <div
-      role="tooltip"
-      className={cn(
-        "pointer-events-none absolute z-50 rounded-md bg-slate-900 px-2.5 py-1.5 text-xs text-white shadow-lg transition-all",
-        SIDE_CLASSES[side],
-        open ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
 }`;
+
+const PROPS_ROWS = [
+  { prop: "defaultOpen", type: "boolean", default: "false", description: "Controls the initial open state before hover or focus interactions occur." },
+  { prop: "side", type: '"top" | "bottom" | "left" | "right"', default: '"top"', description: "Positions the tooltip relative to its trigger." },
+  { prop: "className", type: "string", default: "—", description: "Additional classes applied to the tooltip root wrapper." },
+  { prop: "Tooltip.Trigger", type: "HTMLAttributes<HTMLSpanElement>", default: "—", description: "Wraps the interactive element that opens the tooltip on hover or focus." },
+  { prop: "Tooltip.Content", type: "HTMLAttributes<HTMLDivElement>", default: "—", description: "Renders the floating tooltip message surface." },
+];
 
 export default function TooltipDocPage() {
   return (
     <DocsPageLayout tocItems={TOC_ITEMS}>
       <div className="max-w-4xl">
-        <h1 className="mb-3 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">Tooltip</h1>
-        <p className="mb-10 text-lg text-slate-600 dark:text-slate-400">
-          Contextual hint on hover/focus for compact interfaces.
-        </p>
+        <nav className="mb-8 flex items-center gap-2 text-sm font-medium text-slate-500">
+          <span className="hover:text-primary cursor-pointer transition-colors">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="hover:text-primary cursor-pointer transition-colors">Overlay</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Tooltip</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Tooltip
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Contextual helper text for compact actions and icon-only controls. Tooltips appear on
+            hover and focus while keeping the surrounding layout unchanged.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            {["Accessible", "Dark Mode", "Animated", "Keyboard Nav"].map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
 
         <CliInstallBlock name="tooltip" />
 
         <section id="demo" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">01 Live Demo</h2>
-          <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
-            <Tooltip side="top">
-              <Tooltip.Trigger>
-                <button type="button" className="rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-[#1f2937]">Hover for hint</button>
-              </Tooltip.Trigger>
-              <Tooltip.Content>Only project owners can publish changes</Tooltip.Content>
-            </Tooltip>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22] sm:grid-cols-2">
+            {TOOLTIP_SIDES.map(({ side, label }) => (
+              <div key={side} className="flex min-h-24 items-center justify-center rounded-xl border border-dashed border-slate-200 dark:border-[#1f2937]">
+                <Tooltip side={side}>
+                  <Tooltip.Trigger>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-[#1f2937]"
+                    >
+                      {label} tooltip
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content>{label} aligned guidance</Tooltip.Content>
+                </Tooltip>
+              </div>
+            ))}
           </div>
         </section>
 
         <section id="snippet" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">02 Code Snippet</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
           <CodeBlock filename="src/ui/Tooltip.tsx" copyText={CODE_SNIPPET}>{CODE_SNIPPET}</CodeBlock>
         </section>
 
         <section id="copy-paste" className="mb-16">
-          <h2 className="mb-4 text-2xl font-bold text-slate-900 dark:text-white">03 Copy-Paste (Single File)</h2>
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
           <CodeBlock filename="Tooltip.tsx" copyText={COPY_PASTE_SNIPPET}>{COPY_PASTE_SNIPPET}</CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((heading) => (
+                    <th key={heading} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3"><code className="text-xs font-mono font-semibold text-primary">{row.prop}</code></td>
+                    <td className="px-4 py-3 max-w-[260px]"><code className="text-xs font-mono text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code></td>
+                    <td className="px-4 py-3"><code className="text-xs font-mono text-slate-500 dark:text-slate-400">{row.default}</code></td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">{row.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       </div>
     </DocsPageLayout>

--- a/src/features/docs/components/docs-nav.ts
+++ b/src/features/docs/components/docs-nav.ts
@@ -40,6 +40,7 @@ export const DOCS_NAV: NavGroup[] = [
       { label: "Form", href: "/docs/forms" },
       { label: "Input", href: "/docs/input" },
       { label: "Pagination", href: "/docs/pagination" },
+      { label: "Page Progress", href: "/docs/page-progress" },
       { label: "Popover", href: "/docs/popover" },
       { label: "Progress", href: "/docs/progress" },
       { label: "Radio Group", href: "/docs/radio-group" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export { useAppStore, useFilterStore, useHasActiveFilters, useSearchStore } from
 
 // Components
 export { EmptyState, ErrorBoundary, LoadingState } from "./shared/components";
+export { PageProgress, type PageProgressProps } from "./ui/PageProgress";
 
 // Lib
 export { createApiClient, type ApiClient, type ApiClientConfig, type RequestOptions } from "./lib/exportable";

--- a/src/shared/components/NavigationProgress.tsx
+++ b/src/shared/components/NavigationProgress.tsx
@@ -2,10 +2,10 @@
 
 import { usePathname } from "next/navigation";
 import { useProgressBar } from "@/shared/hooks/useProgressBar";
-import { ProgressBar } from "@/ui/ProgressBar";
+import { PageProgress } from "@/ui/PageProgress";
 
 export function NavigationProgress() {
   const pathname = usePathname();
   const { progress, visible } = useProgressBar(pathname);
-  return <ProgressBar progress={progress} visible={visible} />;
+  return <PageProgress progress={progress} visible={visible} />;
 }

--- a/src/ui/Drawer.tsx
+++ b/src/ui/Drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
+import { useEffect, type HTMLAttributes, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
@@ -98,7 +98,6 @@ Drawer.Footer = function DrawerFooter({ children, className, ...props }: DrawerF
 // ─── Drawer ───────────────────────────────────────────────────────────────────
 
 export function Drawer({ open, onClose, side = "right", size = "md", children, className }: DrawerProps) {
-  const backdropRef = useRef<HTMLDivElement>(null);
   const { mounted, visible } = useAnimatedMount(open, 300);
 
   useEffect(() => {
@@ -122,19 +121,14 @@ export function Drawer({ open, onClose, side = "right", size = "md", children, c
   const { panel, hidden } = SIDE_CLASSES[side];
 
   const drawer = (
-    <div
-      ref={backdropRef}
-      className="fixed inset-0 z-50 flex"
-      onClick={(e) => {
-        if (e.target === backdropRef.current) onClose();
-      }}
-    >
+    <div className="fixed inset-0 z-50 flex">
       {/* Backdrop */}
       <div
         className={cn(
           "absolute inset-0 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
           visible ? "opacity-100" : "opacity-0"
         )}
+        onClick={onClose}
       />
 
       {/* Panel */}

--- a/src/ui/PageProgress.stories.tsx
+++ b/src/ui/PageProgress.stories.tsx
@@ -1,17 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { ProgressBar } from "./ProgressBar";
+import { PageProgress } from "./PageProgress";
 import { StorySurface } from "./storybook-utils";
 
 const meta = {
-  title: "UI/ProgressBar",
-  component: ProgressBar,
+  title: "UI/PageProgress",
+  component: PageProgress,
   args: {
     progress: 72,
     visible: true,
   },
   render: (args) => (
     <div className="relative h-20 w-[420px] overflow-hidden rounded-2xl border border-slate-200 bg-white dark:border-[#1f2937] dark:bg-[#0b0e14]">
-      <ProgressBar {...args} />
+      <PageProgress {...args} />
       <StorySurface className="h-full rounded-none border-none bg-transparent shadow-none">
         <p className="text-sm text-slate-600 dark:text-slate-400">
           Thin top progress indicator for navigation feedback.
@@ -19,7 +19,7 @@ const meta = {
       </StorySurface>
     </div>
   ),
-} satisfies Meta<typeof ProgressBar>;
+} satisfies Meta<typeof PageProgress>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/ui/PageProgress.tsx
+++ b/src/ui/PageProgress.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/shared/utils/cn";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export interface ProgressBarProps {
+export interface PageProgressProps {
   /** Current progress 0–100 */
   progress: number;
   /** Whether the bar is visible (false triggers fade-out) */
@@ -15,7 +15,7 @@ export interface ProgressBarProps {
  * Thin top-of-page progress bar for navigation feedback.
  * Pair with `useProgressBar` hook.
  */
-export function ProgressBar({ progress, visible }: ProgressBarProps) {
+export function PageProgress({ progress, visible }: PageProgressProps) {
   return (
     <div
       role="progressbar"

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -66,16 +66,24 @@ const SIDE_CLASSES: Record<TooltipSide, string> = {
   right: "left-[calc(100%+8px)] top-1/2 -translate-y-1/2",
 };
 
+const SIDE_ANIMATION_CLASSES: Record<TooltipSide, { open: string; closed: string }> = {
+  top: { open: "translate-y-0", closed: "translate-y-1" },
+  bottom: { open: "translate-y-0", closed: "-translate-y-1" },
+  left: { open: "translate-x-0", closed: "translate-x-1" },
+  right: { open: "translate-x-0", closed: "-translate-x-1" },
+};
+
 Tooltip.Content = function TooltipContent({ children, className, ...props }: TooltipContentProps) {
   const { open, side } = useTooltipContext();
+  const animationClasses = SIDE_ANIMATION_CLASSES[side];
 
   return (
     <div
       role="tooltip"
       className={cn(
-        "pointer-events-none absolute z-50 rounded-md bg-slate-900 px-2.5 py-1.5 text-xs text-white shadow-lg transition-all",
+        "pointer-events-none absolute z-50 whitespace-nowrap rounded-md bg-slate-900 px-2.5 py-1.5 text-xs text-white shadow-lg transition-all",
         SIDE_CLASSES[side],
-        open ? "translate-y-0 opacity-100" : "translate-y-1 opacity-0",
+        open ? `${animationClasses.open} opacity-100` : `${animationClasses.closed} opacity-0`,
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- fix Tooltip wrapping and side-aware motion plus Drawer backdrop close behavior
- rename `ProgressBar` to `PageProgress`, add docs page, and sync CLI registry/template/docs
- bring docs pages for issues #70-#88 up to the `CONTRIBUTING.md` standard

## Verification
- `pnpm typecheck`
- `pnpm lint` (passes with pre-existing warnings in CLI/scripts)

## Scope
Addresses issues #69 through #90 with separate commits per issue on the branch history.