### PR TITLE
feat: add Storybook links to docs

### DIFF
--- a/src/app/docs/accordion/page.tsx
+++ b/src/app/docs/accordion/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Accordion } from "@/ui/Accordion";
 import type { AccordionType } from "@/ui/Accordion";
 
@@ -419,11 +422,26 @@ export default function AccordionDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("accordion")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
 

--- a/src/app/docs/alert-dialog/page.tsx
+++ b/src/app/docs/alert-dialog/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { AlertDialog } from "@/ui/AlertDialog";
 import { Button } from "@/ui/Button";
@@ -433,11 +435,26 @@ export default function AlertDialogDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("alert-dialog")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-5">
 

--- a/src/app/docs/alert/page.tsx
+++ b/src/app/docs/alert/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Alert } from "@/ui/Alert";
 import type { AlertVariant } from "@/ui/Alert";
 
@@ -120,11 +123,26 @@ export default function AlertDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("alert")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             {VARIANTS.map(({ variant, title, description }) => (

--- a/src/app/docs/avatar/page.tsx
+++ b/src/app/docs/avatar/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Avatar } from "@/ui/Avatar";
 import type { AvatarSize } from "@/ui/Avatar";
 
@@ -134,11 +137,26 @@ export default function AvatarDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("avatar")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <div className="flex items-center gap-3">

--- a/src/app/docs/badge/page.tsx
+++ b/src/app/docs/badge/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Badge } from "@/ui/Badge";
 import type { BadgeVariant, BadgeSize } from "@/ui/Badge";
 
@@ -209,11 +212,26 @@ export default function BadgeDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("badge")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
             {/* Size selector */}

--- a/src/app/docs/breadcrumb/page.tsx
+++ b/src/app/docs/breadcrumb/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Breadcrumb } from "@/ui/Breadcrumb";
 
 const TOC_ITEMS = [
@@ -102,11 +105,26 @@ export default function BreadcrumbDocPage() {
         <CliInstallBlock name="breadcrumb" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("breadcrumb")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Breadcrumb>

--- a/src/app/docs/button/page.tsx
+++ b/src/app/docs/button/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Button } from "@/ui/Button";
 import type { ButtonVariant, ButtonSize } from "@/ui/Button";
@@ -250,11 +252,26 @@ export default function ButtonDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("button")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
             {/* Controls */}

--- a/src/app/docs/card/page.tsx
+++ b/src/app/docs/card/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Card } from "@/ui/Card";
 import { Button } from "@/ui/Button";
@@ -254,11 +256,26 @@ export default function CardDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("card")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
             {/* Variant selector */}

--- a/src/app/docs/checkbox/page.tsx
+++ b/src/app/docs/checkbox/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Checkbox } from "@/ui/Checkbox";
 import type { CheckboxSize } from "@/ui/Checkbox";
 
@@ -331,11 +334,26 @@ export default function CheckboxDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("checkbox")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
             {/* Size selector */}

--- a/src/app/docs/combobox/page.tsx
+++ b/src/app/docs/combobox/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Combobox } from "@/ui/Combobox";
 
 const TOC_ITEMS = [
@@ -100,11 +103,26 @@ export default function ComboboxDocPage() {
         <CliInstallBlock name="combobox" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("combobox")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Combobox

--- a/src/app/docs/command/page.tsx
+++ b/src/app/docs/command/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Command } from "@/ui/Command";
 
 const TOC_ITEMS = [
@@ -78,11 +81,26 @@ export default function CommandDocPage() {
         <CliInstallBlock name="command" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("command")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Command>

--- a/src/app/docs/date-picker/page.tsx
+++ b/src/app/docs/date-picker/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { DatePicker } from "@/ui/DatePicker";
 
 const TOC_ITEMS = [
@@ -73,11 +76,26 @@ export default function DatePickerDocPage() {
         <CliInstallBlock name="date-picker" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("date-picker")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <DatePicker

--- a/src/app/docs/dialog/page.tsx
+++ b/src/app/docs/dialog/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Dialog } from "@/ui/Dialog";
 import { Button } from "@/ui/Button";
@@ -348,11 +350,26 @@ export default function DialogDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("dialog")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-4">
             <p className="text-sm text-slate-500 dark:text-slate-400">Click a button to open the corresponding dialog.</p>

--- a/src/app/docs/drawer/page.tsx
+++ b/src/app/docs/drawer/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Drawer } from "@/ui/Drawer";
 import { Button } from "@/ui/Button";
@@ -429,11 +431,26 @@ export default function DrawerDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("drawer")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-5">
 

--- a/src/app/docs/dropdown-menu/page.tsx
+++ b/src/app/docs/dropdown-menu/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { DropdownMenu } from "@/ui/DropdownMenu";
 
 const TOC_ITEMS = [
@@ -81,11 +84,26 @@ export default function DropdownMenuDocPage() {
         <CliInstallBlock name="dropdown-menu" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("dropdown-menu")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <DropdownMenu>

--- a/src/app/docs/input/page.tsx
+++ b/src/app/docs/input/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Input } from "@/ui/Input";
 import type { InputSize, InputVariant } from "@/ui/Input";
 
@@ -390,11 +393,26 @@ export default function InputDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("input")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-6">
 

--- a/src/app/docs/pagination/page.tsx
+++ b/src/app/docs/pagination/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Pagination } from "@/ui/Pagination";
 
 const TOC_ITEMS = [
@@ -115,11 +118,26 @@ export default function PaginationDocPage() {
         <CliInstallBlock name="pagination" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("pagination")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Pagination page={page} totalPages={12} onPageChange={setPage} />

--- a/src/app/docs/popover/page.tsx
+++ b/src/app/docs/popover/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Popover } from "@/ui/Popover";
 
 const TOC_ITEMS = [
@@ -87,11 +90,26 @@ export default function PopoverDocPage() {
         <CliInstallBlock name="popover" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("popover")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Popover open={open} onOpenChange={setOpen} side="bottom" align="start">

--- a/src/app/docs/progress/page.tsx
+++ b/src/app/docs/progress/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Button } from "@/ui/Button";
 import { Progress } from "@/ui/Progress";
@@ -90,11 +92,26 @@ export default function ProgressDocPage() {
         <CliInstallBlock name="progress" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("progress")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Progress value={value} />

--- a/src/app/docs/radio-group/page.tsx
+++ b/src/app/docs/radio-group/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { RadioGroup } from "@/ui/RadioGroup";
 
 const TOC_ITEMS = [
@@ -79,11 +82,26 @@ export default function RadioGroupDocPage() {
         <CliInstallBlock name="radio-group" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("radio-group")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <RadioGroup value={plan} onValueChange={setPlan}>

--- a/src/app/docs/select/page.tsx
+++ b/src/app/docs/select/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Select } from "@/ui/Select";
 import type { SelectSize } from "@/ui/Select";
 
@@ -144,11 +147,26 @@ export default function SelectDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("select")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <div className="flex items-center gap-3">

--- a/src/app/docs/separator/page.tsx
+++ b/src/app/docs/separator/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Separator } from "@/ui/Separator";
 
 const TOC_ITEMS = [
@@ -90,11 +93,26 @@ export default function SeparatorDocPage() {
         <CliInstallBlock name="separator" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("separator")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <p className="text-sm font-medium text-slate-900 dark:text-white">Profile Settings</p>

--- a/src/app/docs/skeleton/page.tsx
+++ b/src/app/docs/skeleton/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Skeleton } from "@/ui/Skeleton";
 import type { SkeletonVariant } from "@/ui/Skeleton";
 
@@ -125,11 +128,26 @@ export default function SkeletonDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("skeleton")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <div className="flex items-center gap-4">

--- a/src/app/docs/slider/page.tsx
+++ b/src/app/docs/slider/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Slider } from "@/ui/Slider";
 
 const TOC_ITEMS = [
@@ -128,11 +131,26 @@ export default function SliderDocPage() {
         <CliInstallBlock name="slider" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("slider")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <Slider label="Volume" value={volume} onValueChange={setVolume} />

--- a/src/app/docs/switch/page.tsx
+++ b/src/app/docs/switch/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Switch } from "@/ui/Switch";
 import type { SwitchSize } from "@/ui/Switch";
 
@@ -133,11 +136,26 @@ export default function SwitchDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("switch")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <div className="flex items-center gap-3">

--- a/src/app/docs/tabs/page.tsx
+++ b/src/app/docs/tabs/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Tabs } from "@/ui/Tabs";
 import { Badge } from "@/ui/Badge";
 import type { TabsVariant } from "@/ui/Tabs";
@@ -380,11 +383,26 @@ export default function TabsDocPage() {
 
         {/* 02 Live Demo */}
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("tabs")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-8">
 

--- a/src/app/docs/textarea/page.tsx
+++ b/src/app/docs/textarea/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Textarea } from "@/ui/Textarea";
 import type { TextareaSize, TextareaVariant } from "@/ui/Textarea";
 
@@ -132,11 +135,26 @@ export default function TextareaDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("textarea")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22]">
             <div className="flex items-center gap-3">

--- a/src/app/docs/toast/page.tsx
+++ b/src/app/docs/toast/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Button } from "@/ui/Button";
 import { Toast } from "@/ui/Toast";
@@ -266,11 +268,26 @@ export default function ToastDocPage() {
         </section>
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">02</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("toast")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs space-y-4">
             <p className="text-sm text-slate-600 dark:text-slate-400">

--- a/src/app/docs/tooltip/page.tsx
+++ b/src/app/docs/tooltip/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { getStorybookComponentUrl } from "@/features/docs/lib/storybook";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { Button } from "@/ui/Button";
 import { Tooltip } from "@/ui/Tooltip";
 
 const TOC_ITEMS = [
@@ -96,11 +99,26 @@ export default function TooltipDocPage() {
         <CliInstallBlock name="tooltip" />
 
         <section id="demo" className="mb-16">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">01</span>
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+                    <span className="text-sm font-bold">01</span>
+                  </div>
+                  <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link
+                href={getStorybookComponentUrl("tooltip")}
+              target="_blank"
+              rel="noopener noreferrer"
+                className="inline-flex"
+              >
+                Open in Storybook
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </Button>
           </div>
           <div className="grid gap-4 rounded-xl border border-slate-200 bg-white p-6 dark:border-[#1f2937] dark:bg-[#161b22] sm:grid-cols-2">
             {TOOLTIP_SIDES.map(({ side, label }) => (

--- a/src/features/docs/components/DocsSidebar.test.tsx
+++ b/src/features/docs/components/DocsSidebar.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { DocsSidebar } from "./DocsSidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/docs/button",
+}));
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+describe("DocsSidebar", () => {
+  it("renders a static Storybook footer link on docs pages", () => {
+    render(<DocsSidebar />);
+
+    const link = screen.getByRole("link", { name: /storybook/i });
+
+    expect(link).toHaveAttribute("href", "https://storybook.reactprinciples.dev");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/src/features/docs/components/DocsSidebar.tsx
+++ b/src/features/docs/components/DocsSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/shared/utils/cn";
+import { STORYBOOK_BASE_URL } from "@/features/docs/lib/storybook";
 import { DOCS_NAV } from "./docs-nav";
 import { RECIPES } from "@/features/cookbook/data/cookbook-data";
 
@@ -49,7 +50,7 @@ export function DocsSidebar() {
 
   return (
     <aside className="sidebar-scroll sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 overflow-y-auto border-r border-slate-200 dark:border-[#1f2937] py-8 pr-6 lg:block">
-      <div ref={navRef} className="relative flex flex-col gap-8">
+      <div ref={navRef} className="relative flex min-h-full flex-col gap-8">
         {/* Sliding active indicator */}
         <div
           aria-hidden
@@ -104,6 +105,21 @@ export function DocsSidebar() {
                 </ul>
               </div>
             ))}
+
+            <div className="mt-auto pt-2">
+              <div className="mb-4 h-px bg-slate-200 dark:bg-[#1f2937]" />
+              <Link
+                href={STORYBOOK_BASE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative z-10 flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+              >
+                <span>Storybook</span>
+                <span className="material-symbols-outlined text-[18px]" aria-hidden="true">
+                  open_in_new
+                </span>
+              </Link>
+            </div>
           </>
         ) : (
           /* Cookbook nav */

--- a/src/features/docs/lib/storybook.test.ts
+++ b/src/features/docs/lib/storybook.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getStorybookComponentUrl, STORYBOOK_BASE_URL } from "./storybook";
+
+describe("getStorybookComponentUrl", () => {
+  it("builds the default story URL from a component slug", () => {
+    expect(getStorybookComponentUrl("button")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-button--default`,
+    );
+  });
+
+  it("preserves hyphenated slugs", () => {
+    expect(getStorybookComponentUrl("alert-dialog")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-alertdialog--destructive`,
+    );
+  });
+
+  it("maps multi-word Storybook titles to their actual story ids", () => {
+    expect(getStorybookComponentUrl("date-picker")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-datepicker--default`,
+    );
+    expect(getStorybookComponentUrl("dropdown-menu")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-dropdownmenu--default`,
+    );
+    expect(getStorybookComponentUrl("radio-group")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-radiogroup--default`,
+    );
+  });
+
+  it("maps components without a Default story to the closest primary story", () => {
+    expect(getStorybookComponentUrl("separator")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-separator--horizontal`,
+    );
+    expect(getStorybookComponentUrl("tabs")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-tabs--underline`,
+    );
+    expect(getStorybookComponentUrl("tooltip")).toBe(
+      `${STORYBOOK_BASE_URL}/?path=/story/ui-tooltip--top`,
+    );
+  });
+});

--- a/src/features/docs/lib/storybook.ts
+++ b/src/features/docs/lib/storybook.ts
@@ -1,0 +1,24 @@
+const STORYBOOK_BASE_URL = "https://storybook.reactprinciples.dev";
+
+const STORYBOOK_TITLE_SEGMENT_BY_COMPONENT: Record<string, string> = {
+  "alert-dialog": "alertdialog",
+  "date-picker": "datepicker",
+  "dropdown-menu": "dropdownmenu",
+  "radio-group": "radiogroup",
+};
+
+const STORYBOOK_STORY_SEGMENT_BY_COMPONENT: Record<string, string> = {
+  "alert-dialog": "destructive",
+  separator: "horizontal",
+  tabs: "underline",
+  tooltip: "top",
+};
+
+export function getStorybookComponentUrl(componentSlug: string) {
+  const titleSegment = STORYBOOK_TITLE_SEGMENT_BY_COMPONENT[componentSlug] ?? componentSlug;
+  const storySegment = STORYBOOK_STORY_SEGMENT_BY_COMPONENT[componentSlug] ?? "default";
+
+  return `${STORYBOOK_BASE_URL}/?path=/story/ui-${titleSegment}--${storySegment}`;
+}
+
+export { STORYBOOK_BASE_URL };

--- a/src/ui/Button.test.tsx
+++ b/src/ui/Button.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("can render a link child without nesting a button element", () => {
+    render(
+      <Button asChild variant="ghost" size="sm">
+        <a href="https://storybook.reactprinciples.dev">Open in Storybook</a>
+      </Button>,
+    );
+
+    expect(screen.getByRole("link", { name: "Open in Storybook" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open in Storybook" })).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,4 +1,5 @@
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { cloneElement, isValidElement } from "react";
+import type { ButtonHTMLAttributes, ReactElement, ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "destructive" | "outline";
@@ -8,6 +9,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   isLoading?: boolean;
+  asChild?: boolean;
   children: ReactNode;
 }
 
@@ -43,23 +45,40 @@ export function Button({
   variant = "primary",
   size = "md",
   isLoading = false,
+  asChild = false,
   disabled,
   children,
   className,
   ...props
 }: ButtonProps) {
+  const classes = cn(
+    "inline-flex items-center justify-center font-semibold rounded-lg transition-all",
+    "focus-visible:outline-hidden focus-visible:ring-2",
+    "disabled:opacity-50 disabled:cursor-not-allowed",
+    VARIANT_CLASSES[variant],
+    SIZE_CLASSES[size],
+    className,
+  );
+
+  if (asChild && isValidElement(children)) {
+    const child = children as ReactElement<{ className?: string; children?: ReactNode }>;
+
+    return cloneElement(child, {
+      className: cn(classes, child.props.className),
+      children: (
+        <>
+          {isLoading && <Spinner />}
+          {child.props.children}
+        </>
+      ),
+    });
+  }
+
   return (
     <button
       {...props}
       disabled={disabled || isLoading}
-      className={cn(
-        "inline-flex items-center justify-center font-semibold rounded-lg transition-all",
-        "focus-visible:outline-hidden focus-visible:ring-2",
-        "disabled:opacity-50 disabled:cursor-not-allowed",
-        VARIANT_CLASSES[variant],
-        SIZE_CLASSES[size],
-        className,
-      )}
+      className={classes}
     >
       {isLoading && <Spinner />}
       {children}


### PR DESCRIPTION
## Summary
- add a static Storybook footer link to the docs sidebar
- add per-component "Open in Storybook" links across the component docs live demo sections
- map Storybook URLs to the actual story ids and fix the docs button pattern with `Button asChild`

## Validation
- `rtk pnpm test src/ui/Button.test.tsx src/features/docs/lib/storybook.test.ts src/features/docs/components/DocsSidebar.test.tsx`
- `rtk pnpm lint`
- `rtk pnpm typecheck`
