### PR TITLE
Sync cookbook recipes with starter template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 
 # Internal task tracking
 .tasks/
+.vercel

--- a/src/features/cookbook/data/recipes/custom-hooks.ts
+++ b/src/features/cookbook/data/recipes/custom-hooks.ts
@@ -73,19 +73,15 @@ function SearchInput() {
       code: `'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api';
-import { ENDPOINTS } from '@/lib/endpoints';
 import { queryKeys } from '@/lib/query-keys';
-import type { UsersResponse } from '@/shared/types/user';
+import { usersService } from '@/lib/services/users';
 
-// Feature hook — encapsulates query key, endpoint, and response type
+// Feature hook — encapsulates query key, service call, and caching
 // Components just call useUsers() and get typed data back
 export function useUsers(params?: { limit?: number; skip?: number }) {
   return useQuery({
     queryKey: queryKeys.users.list(params ?? {}),
-    queryFn: () => api.get<UsersResponse>(ENDPOINTS.users.list, {
-      params: { limit: params?.limit, skip: params?.skip },
-    }),
+    queryFn: () => usersService.getAll(params),
   });
 }
 

--- a/src/features/cookbook/data/recipes/custom-hooks.ts
+++ b/src/features/cookbook/data/recipes/custom-hooks.ts
@@ -5,7 +5,7 @@ export const customHooks: RecipeDetail = {
   title: "Custom Hooks",
   breadcrumbCategory: "Foundations",
   description: "The boundary between logic and rendering. When to extract a hook, what the rules are, and how to avoid the most common mistake.",
-  lastUpdated: "Apr 8, 2026",
+  lastUpdated: "Apr 11, 2026",
   principle: {
     text: "A custom hook is not just a function that starts with 'use' — it is a boundary between logic and rendering. The component handles what the user sees. The hook handles how data gets there. When you separate these two concerns, components become easier to read, logic becomes easier to test, and both become easier to change independently.",
     tip: "If you would write a unit test for the logic, it belongs in a hook. If you would write a component test for it, it belongs in the JSX.",

--- a/src/features/cookbook/data/recipes/folder-structure.ts
+++ b/src/features/cookbook/data/recipes/folder-structure.ts
@@ -40,6 +40,7 @@ export const folderStructure: RecipeDetail = {
 │   ├── providers.tsx     # Client-side context providers (QueryClient, etc.)
 │   ├── globals.css       # Global styles and Tailwind imports
 │   └── users/
+│       ├── page.tsx      # Users list page (composition: PageLayout + UserList)
 │       └── [id]/
 │           └── page.tsx  # Dynamic route — add routes here, never business logic
 │
@@ -51,7 +52,7 @@ export const folderStructure: RecipeDetail = {
 │       └── index.ts      # Barrel export — public API of the feature
 │
 ├── shared/               # Cross-feature shared code
-│   ├── components/       # Reusable components (ErrorBoundary, LoadingState, etc.)
+│   ├── components/       # Reusable components (PageLayout, Navbar, Sidebar, etc.)
 │   ├── hooks/            # Reusable hooks (useDebounce, useLocalStorage, etc.)
 │   ├── stores/           # App-wide stores (theme, sidebar, etc.)
 │   ├── types/            # Shared TypeScript types
@@ -87,7 +88,7 @@ export const folderStructure: RecipeDetail = {
 │       └── index.ts      # Barrel export — public API of the feature
 │
 ├── shared/               # Cross-feature shared code
-│   ├── components/       # Reusable components (ErrorBoundary, LoadingState, etc.)
+│   ├── components/       # Reusable components (PageLayout, Navbar, Sidebar, etc.)
 │   ├── hooks/            # Reusable hooks (useDebounce, useLocalStorage, etc.)
 │   ├── stores/           # App-wide stores (theme, sidebar, etc.)
 │   ├── types/            # Shared TypeScript types

--- a/src/features/cookbook/data/recipes/folder-structure.ts
+++ b/src/features/cookbook/data/recipes/folder-structure.ts
@@ -38,7 +38,10 @@ export const folderStructure: RecipeDetail = {
 │   ├── layout.tsx        # Root layout (fonts, providers, metadata)
 │   ├── page.tsx          # Home page
 │   ├── providers.tsx     # Client-side context providers (QueryClient, etc.)
-│   └── globals.css       # Global styles and Tailwind imports
+│   ├── globals.css       # Global styles and Tailwind imports
+│   └── users/
+│       └── [id]/
+│           └── page.tsx  # Dynamic route — add routes here, never business logic
 │
 ├── features/             # Feature modules (vertical slices)
 │   └── users/            # Each feature owns its own components, hooks, stores

--- a/src/features/cookbook/data/recipes/services-layer.ts
+++ b/src/features/cookbook/data/recipes/services-layer.ts
@@ -5,7 +5,7 @@ export const servicesLayer: RecipeDetail = {
   title: "Services Layer",
   breadcrumbCategory: "Foundations",
   description: "How to organize all backend communication in one place — so when an API changes, you fix it in one file, not twenty.",
-  lastUpdated: "Apr 8, 2026",
+  lastUpdated: "Apr 11, 2026",
   principle: {
     text: "When you fetch data directly inside a component, the component becomes responsible for knowing the URL, the HTTP method, the request format, and the error handling. That is four responsibilities too many. A services layer centralizes all backend communication — components just call a function and get data back. When the API changes, you fix it in one file, not twenty.",
     tip: "A service function should read like plain English: getUserById(id), createOrder(data), deletePost(id). If it needs more than one argument object, consider splitting it into two functions.",

--- a/src/features/cookbook/data/recipes/services-layer.ts
+++ b/src/features/cookbook/data/recipes/services-layer.ts
@@ -30,34 +30,26 @@ export const servicesLayer: RecipeDetail = {
   ],
   pattern: {
     filename: "lib/services/users.ts — service layer pattern",
-    code: `import { apiClient } from '@/lib/api-client';
-import type { User, CreateUserInput, UpdateUserInput } from '@/shared/types/user';
+    code: `import { api } from '@/lib/api';
+import { ENDPOINTS } from '@/lib/endpoints';
+import type { User, UsersResponse, CreateUserInput, UpdateUserInput } from '@/shared/types/user';
 
-// ✅ Service functions — pure API communication
+// ✅ Service functions — pure API communication (no React, no state)
 export const usersService = {
-  getAll: async (): Promise<User[]> => {
-    const response = await apiClient.get('/users');
-    return response.data;
-  },
+  getAll: (params?: { limit?: number; skip?: number }): Promise<UsersResponse> =>
+    api.get<UsersResponse>(ENDPOINTS.users.list, { params }),
 
-  getById: async (id: string): Promise<User> => {
-    const response = await apiClient.get(\`/users/\${id}\`);
-    return response.data;
-  },
+  getById: (id: number): Promise<User> =>
+    api.get<User>(ENDPOINTS.users.detail(id)),
 
-  create: async (data: CreateUserInput): Promise<User> => {
-    const response = await apiClient.post('/users', data);
-    return response.data;
-  },
+  create: (data: CreateUserInput): Promise<User> =>
+    api.post<User>(ENDPOINTS.users.create, data),
 
-  update: async (id: string, data: UpdateUserInput): Promise<User> => {
-    const response = await apiClient.patch(\`/users/\${id}\`, data);
-    return response.data;
-  },
+  update: (id: number, data: UpdateUserInput): Promise<User> =>
+    api.put<User>(ENDPOINTS.users.update(id), data),
 
-  delete: async (id: string): Promise<void> => {
-    await apiClient.delete(\`/users/\${id}\`);
-  },
+  delete: (id: number): Promise<User> =>
+    api.delete<User>(ENDPOINTS.users.delete(id)),
 };`,
   },
   implementation: {

--- a/src/features/cookbook/data/recipes/state-taxonomy.ts
+++ b/src/features/cookbook/data/recipes/state-taxonomy.ts
@@ -84,11 +84,11 @@ export const useAppStore = create<AppState>((set) => ({
 export function useUsers(params?: { limit?: number; skip?: number }) {
   return useQuery({
     queryKey: queryKeys.users.list(params ?? {}),
-    queryFn: () => api.get<UsersResponse>(ENDPOINTS.users.list, { params }),
+    queryFn: () => usersService.getAll(params),  // service → hook → component
   });
 }
-// useUser(id): single user detail
-// useCreateUser: mutation with cache invalidation`,
+// useUser(id): single user detail via usersService.getById
+// useCreateUser: mutation via usersService.create + cache invalidation`,
     },
     vite: {
       description: "In Vite, all rendering is client-side. Server state always goes through React Query, shared state through Zustand, and local state through useState.",

--- a/src/features/cookbook/data/recipes/state-taxonomy.ts
+++ b/src/features/cookbook/data/recipes/state-taxonomy.ts
@@ -5,7 +5,7 @@ export const stateTaxonomy: RecipeDetail = {
   title: "State Taxonomy",
   breadcrumbCategory: "Foundations",
   description: "Three categories of state — local, shared, and server — and exactly which tool handles each one.",
-  lastUpdated: "Apr 8, 2026",
+  lastUpdated: "Apr 11, 2026",
   principle: {
     text: "Not all state is the same. Before reaching for any state management library, ask one question: where does this data come from? Local state lives inside one component. Shared state is UI state needed by multiple components. Server state comes from an API and has its own lifecycle — loading, error, stale, and needs refreshing. Each category has a different tool, and mixing them up causes bugs that are hard to trace.",
     tip: "When you find yourself putting API data into Zustand, stop. Server state belongs in React Query. When you find yourself using React Query for a toggle or a modal, stop. UI state belongs in useState or Zustand.",

--- a/src/features/cookbook/data/recipes/typescript-for-react.ts
+++ b/src/features/cookbook/data/recipes/typescript-for-react.ts
@@ -5,7 +5,7 @@ export const typescriptForReact: RecipeDetail = {
   title: "TypeScript for React",
   breadcrumbCategory: "Foundations",
   description: "How to type component props, event handlers, and hooks correctly. The contracts that prevent silent bugs.",
-  lastUpdated: "Apr 8, 2026",
+  lastUpdated: "Apr 11, 2026",
   principle: {
     text: "Bugs caught at compile time cost nothing to fix. Bugs caught in production cost everything. TypeScript for React is not about learning the full TypeScript language — it is about writing the right contracts between your components so that mistakes are caught before the code even runs.",
     tip: "Start by typing your component props. If you can describe what a component accepts and returns, the rest of the types follow naturally.",

--- a/src/features/cookbook/data/recipes/typescript-for-react.ts
+++ b/src/features/cookbook/data/recipes/typescript-for-react.ts
@@ -58,7 +58,7 @@ const fetchUser = async (): Promise<unknown> => { ... }`,
   },
   implementation: {
     nextjs: {
-      description: "Next.js page components receive typed params and searchParams. Always type these explicitly.",
+      description: "Next.js page components receive typed params and searchParams. Always type these explicitly. URL params are always strings — convert to the expected type before use.",
       filename: "app/users/[id]/page.tsx",
       code: `// ✅ Typed Next.js page props
 interface PageProps {
@@ -68,7 +68,9 @@ interface PageProps {
 
 export default async function UserPage({ params }: PageProps) {
   const { id } = await params;
-  return <UserDetail id={id} />;
+
+  // URL params are always strings — convert to number before passing to the hook
+  return <UserDetail id={Number(id)} />;
 }
 
 // ✅ Typed Server Action


### PR DESCRIPTION
## Summary

- Sync all Foundation recipe code examples with actual `react-principles-nextjs` starter implementation
- Fix services-layer pattern from axios-like (`response.data`) to actual `createApiClient` pattern
- Update folder-structure tree to reflect new routes and shared components
- Update `lastUpdated` dates for modified recipes

## Changes

**folder-structure.ts**
- Added `users/page.tsx` and `users/[id]/page.tsx` to app/ tree
- Updated `shared/components/` description (PageLayout, Navbar, Sidebar)

**typescript-for-react.ts**
- Added `Number(id)` conversion in implementation (URL params are strings)
- Clarified description about type conversion

**custom-hooks.ts**
- Updated implementation code: `api.get()` → `usersService.getAll()` to match rewired hooks

**state-taxonomy.ts**
- Updated server state example: `api.get()` → `usersService.getAll()` for consistency

**services-layer.ts**
- Rewrote pattern section from axios-like `response.data` to actual fetch-based `api.get<T>()` with `ENDPOINTS` and `id: number`

## Related

Closes starter template sub-issues: #57, #58, #59, #60, #61, #62, #63
Parent: #43

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] Recipe pages render correctly on dev server
- [x] Code examples in recipes match actual files in `sindev08/react-principles-nextjs`