### PR TITLE
add docs playground experience

### DIFF
--- a/src/app/docs/playground/page.tsx
+++ b/src/app/docs/playground/page.tsx
@@ -1,0 +1,5 @@
+import { PlaygroundPage } from "@/features/playground/components/PlaygroundPage";
+
+export default function DocsPlaygroundPage() {
+  return <PlaygroundPage />;
+}

--- a/src/features/docs/components/docs-nav.ts
+++ b/src/features/docs/components/docs-nav.ts
@@ -15,6 +15,7 @@ export const DOCS_NAV: NavGroup[] = [
     items: [
       { label: "Introduction", href: "/docs/introduction" },
       { label: "Installation", href: "/docs/installation" },
+      { label: "Playground", href: "/docs/playground" },
       { label: "Theming", href: "/docs/theming" },
       { label: "Dark Mode", href: "/docs/dark-mode" },
     ],

--- a/src/features/docs/lib/storybook.test.ts
+++ b/src/features/docs/lib/storybook.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getStorybookComponentUrl, STORYBOOK_BASE_URL } from "./storybook";
+import {
+  getStorybookComponentUrl,
+  getStorybookEmbedUrl,
+  STORYBOOK_BASE_URL,
+} from "./storybook";
 
 describe("getStorybookComponentUrl", () => {
   it("builds the default story URL from a component slug", () => {
@@ -35,6 +39,15 @@ describe("getStorybookComponentUrl", () => {
     );
     expect(getStorybookComponentUrl("tooltip")).toBe(
       `${STORYBOOK_BASE_URL}/?path=/story/ui-tooltip--top`,
+    );
+  });
+
+  it("builds iframe-friendly storybook URLs for embedded previews", () => {
+    expect(getStorybookEmbedUrl("button")).toBe(
+      `${STORYBOOK_BASE_URL}/iframe.html?id=ui-button--default&viewMode=story`,
+    );
+    expect(getStorybookEmbedUrl("alert-dialog")).toBe(
+      `${STORYBOOK_BASE_URL}/iframe.html?id=ui-alertdialog--destructive&viewMode=story`,
     );
   });
 });

--- a/src/features/docs/lib/storybook.ts
+++ b/src/features/docs/lib/storybook.ts
@@ -14,11 +14,19 @@ const STORYBOOK_STORY_SEGMENT_BY_COMPONENT: Record<string, string> = {
   tooltip: "top",
 };
 
-export function getStorybookComponentUrl(componentSlug: string) {
+function getStorybookStoryId(componentSlug: string) {
   const titleSegment = STORYBOOK_TITLE_SEGMENT_BY_COMPONENT[componentSlug] ?? componentSlug;
   const storySegment = STORYBOOK_STORY_SEGMENT_BY_COMPONENT[componentSlug] ?? "default";
 
-  return `${STORYBOOK_BASE_URL}/?path=/story/ui-${titleSegment}--${storySegment}`;
+  return `ui-${titleSegment}--${storySegment}`;
+}
+
+export function getStorybookComponentUrl(componentSlug: string) {
+  return `${STORYBOOK_BASE_URL}/?path=/story/${getStorybookStoryId(componentSlug)}`;
+}
+
+export function getStorybookEmbedUrl(componentSlug: string) {
+  return `${STORYBOOK_BASE_URL}/iframe.html?id=${getStorybookStoryId(componentSlug)}&viewMode=story`;
 }
 
 export { STORYBOOK_BASE_URL };

--- a/src/features/landing/components/ComponentShowcaseSection.tsx
+++ b/src/features/landing/components/ComponentShowcaseSection.tsx
@@ -214,6 +214,12 @@ export function ComponentShowcaseSection() {
               Browse docs
             </Link>
             <Link
+              href="/docs/playground"
+              className="inline-flex items-center justify-center rounded-xl border border-primary/20 bg-primary/8 px-5 py-3 text-sm font-bold text-primary transition-colors hover:bg-primary/12"
+            >
+              Launch playground
+            </Link>
+            <Link
               href="/nextjs/cookbook"
               className="inline-flex items-center justify-center rounded-xl border border-slate-300 bg-white px-5 py-3 text-sm font-bold text-slate-900 transition-colors hover:border-slate-400 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-white dark:hover:bg-slate-800"
             >

--- a/src/features/playground/components/PlaygroundPage.tsx
+++ b/src/features/playground/components/PlaygroundPage.tsx
@@ -1,0 +1,1213 @@
+"use client";
+
+import Link from "next/link";
+import {
+  startTransition,
+  type CSSProperties,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import {
+  CliInstallBlock,
+  DocsHeader,
+  MobileNav,
+} from "@/features/docs/components";
+import { cn } from "@/shared/utils/cn";
+import { AlertDialog } from "@/ui/AlertDialog";
+import { Alert } from "@/ui/Alert";
+import { Accordion } from "@/ui/Accordion";
+import { Avatar } from "@/ui/Avatar";
+import { Badge } from "@/ui/Badge";
+import { Breadcrumb } from "@/ui/Breadcrumb";
+import { Button } from "@/ui/Button";
+import { Card } from "@/ui/Card";
+import { Checkbox } from "@/ui/Checkbox";
+import { Combobox } from "@/ui/Combobox";
+import { Command } from "@/ui/Command";
+import { DatePicker } from "@/ui/DatePicker";
+import { Dialog } from "@/ui/Dialog";
+import { Drawer } from "@/ui/Drawer";
+import { DropdownMenu } from "@/ui/DropdownMenu";
+import { Input } from "@/ui/Input";
+import { Pagination } from "@/ui/Pagination";
+import { PageProgress } from "@/ui/PageProgress";
+import { Popover } from "@/ui/Popover";
+import { Progress } from "@/ui/Progress";
+import { RadioGroup } from "@/ui/RadioGroup";
+import { Select } from "@/ui/Select";
+import { SearchDialog } from "@/ui/SearchDialog";
+import { Separator } from "@/ui/Separator";
+import { Skeleton } from "@/ui/Skeleton";
+import { Slider } from "@/ui/Slider";
+import { Switch } from "@/ui/Switch";
+import { Tabs } from "@/ui/Tabs";
+import { Textarea } from "@/ui/Textarea";
+import { Toast } from "@/ui/Toast";
+import { Tooltip } from "@/ui/Tooltip";
+import {
+  buildUsageSnippet,
+  type PlaygroundColorScheme,
+  getDefaultPlaygroundEntry,
+  getPlaygroundEntries,
+  type PlaygroundControlDefinition,
+  type PlaygroundControlState,
+  type PlaygroundEntry,
+  type PlaygroundFramework,
+  type PlaygroundTheme,
+} from "../data/registry";
+
+type CodePanelTab = "usage" | "source";
+type PreviewTab = "quick" | "storybook";
+
+const FRAMEWORK_OPTIONS = [
+  { label: "Next.js", value: "nextjs" },
+  { label: "Vite", value: "vitejs" },
+];
+
+const PREVIEW_THEME_OPTIONS = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+];
+
+const COLOR_SCHEME_OPTIONS = [
+  { label: "Indigo", value: "indigo" },
+  { label: "Emerald", value: "emerald" },
+  { label: "Amber", value: "amber" },
+  { label: "Rose", value: "rose" },
+];
+
+const COLOR_SCHEME_VALUE: Record<PlaygroundColorScheme, string> = {
+  indigo: "#4628f1",
+  emerald: "#059669",
+  amber: "#d97706",
+  rose: "#e11d48",
+};
+
+const SELECT_SAMPLE_OPTIONS = [
+  { label: "Next.js", value: "nextjs" },
+  { label: "Vite", value: "vitejs" },
+  { label: "Storybook", value: "storybook" },
+];
+
+function getStringControl(state: PlaygroundControlState, id: string, fallback: string) {
+  const value = state[id];
+  return typeof value === "string" ? value : fallback;
+}
+
+function getBooleanControl(state: PlaygroundControlState, id: string, fallback = false) {
+  const value = state[id];
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function PlaygroundPreview({
+  entry,
+  state,
+  theme,
+  colorScheme,
+}: {
+  entry: PlaygroundEntry;
+  state: PlaygroundControlState;
+  theme: PlaygroundTheme;
+  colorScheme: PlaygroundColorScheme;
+}) {
+  const isDark = theme === "dark";
+  const shellClassName = isDark ? "dark" : "";
+  const previewStyle = {
+    ["--color-primary" as const]: COLOR_SCHEME_VALUE[colorScheme],
+  } as CSSProperties;
+
+  return (
+    <div className={shellClassName} style={previewStyle}>
+      <div className="min-h-[280px] rounded-[28px] border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/40 dark:border-white/10 dark:bg-[#0b0e14] dark:shadow-black/20">
+        <div className="mb-5 flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+              Quick preview
+            </p>
+            <h3 className="mt-2 text-xl font-black tracking-tight text-slate-900 dark:text-white">
+              {entry.name}
+            </h3>
+          </div>
+          <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 dark:border-white/10 dark:bg-slate-900 dark:text-slate-300">
+            {theme} mode
+          </span>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950">
+          {entry.slug === "accordion" && (
+            <Accordion
+              type={getStringControl(state, "type", "single") as "single" | "multiple"}
+              defaultValue={
+                getStringControl(state, "type", "single") === "multiple"
+                  ? (getBooleanControl(state, "openSecond") ? ["item-2"] : [])
+                  : (getBooleanControl(state, "openSecond") ? "item-2" : "")
+              }
+            >
+              <Accordion.Item value="item-1">
+                <Accordion.Trigger>What does the playground solve?</Accordion.Trigger>
+                <Accordion.Content>
+                  It lets you browse, configure, and copy component usage without leaving the docs site.
+                </Accordion.Content>
+              </Accordion.Item>
+              <Accordion.Item value="item-2">
+                <Accordion.Trigger>How does it stay aligned with the CLI?</Accordion.Trigger>
+                <Accordion.Content>
+                  Both surfaces read from the same internal registry metadata.
+                </Accordion.Content>
+              </Accordion.Item>
+            </Accordion>
+          )}
+
+          {entry.slug === "alert" && (
+            <Alert variant={getStringControl(state, "variant", "default") as "default" | "success" | "warning" | "error" | "info"}>
+              <Alert.Title>{getStringControl(state, "title", "Deployment status")}</Alert.Title>
+              <Alert.Description>
+                {getStringControl(state, "description", "Everything shipped successfully.")}
+              </Alert.Description>
+              {getBooleanControl(state, "showAction") && (
+                <Alert.Footer>
+                  <Alert.Action>Review changes</Alert.Action>
+                </Alert.Footer>
+              )}
+            </Alert>
+          )}
+
+          {entry.slug === "alert-dialog" && (
+            <div className="rounded-xl border border-dashed border-slate-300 p-4 dark:border-white/10">
+              <AlertDialog
+                open={getBooleanControl(state, "open")}
+                onClose={() => {}}
+                onConfirm={() => {}}
+                variant={getStringControl(state, "variant", "default") as "default" | "warning" | "destructive"}
+                isLoading={getBooleanControl(state, "isLoading")}
+                title="Delete component preset?"
+                description="This removes the saved playground preset from your workspace."
+                confirmLabel="Delete preset"
+              />
+            </div>
+          )}
+
+          {entry.slug === "badge" && (
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge
+                variant={getStringControl(state, "variant", "default") as "default" | "success" | "warning" | "error" | "info" | "outline"}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+              >
+                {getStringControl(state, "label", "Early access")}
+              </Badge>
+            </div>
+          )}
+
+          {entry.slug === "avatar" && (
+            <Avatar size={getStringControl(state, "size", "md") as "sm" | "md" | "lg" | "xl"}>
+              {getBooleanControl(state, "showImage") && (
+                <Avatar.Image src="https://i.pravatar.cc/160?img=12" alt="Profile" />
+              )}
+              <Avatar.Fallback>{getStringControl(state, "fallback", "RP")}</Avatar.Fallback>
+            </Avatar>
+          )}
+
+          {entry.slug === "button" && (
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                variant={getStringControl(state, "variant", "primary") as "primary" | "secondary" | "ghost" | "destructive" | "outline"}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+                isLoading={getBooleanControl(state, "isLoading")}
+                disabled={getBooleanControl(state, "disabled")}
+              >
+                {getStringControl(state, "label", "Create recipe")}
+              </Button>
+            </div>
+          )}
+
+          {entry.slug === "card" && (
+            <Card
+              variant={getStringControl(state, "variant", "default") as "default" | "elevated" | "flat"}
+              className="max-w-xl"
+            >
+              <Card.Header>
+                <Card.Title>{getStringControl(state, "title", "Conversion snapshot")}</Card.Title>
+                <Card.Description>
+                  {getStringControl(state, "description", "Weekly signups are ahead of target.")}
+                </Card.Description>
+              </Card.Header>
+              <Card.Content>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-xl bg-primary/10 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                      MRR
+                    </p>
+                    <p className="mt-2 text-2xl font-black text-slate-900 dark:text-white">
+                      $48.2k
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-emerald-500/10 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-400">
+                      Conversion
+                    </p>
+                    <p className="mt-2 text-2xl font-black text-slate-900 dark:text-white">
+                      6.8%
+                    </p>
+                  </div>
+                </div>
+              </Card.Content>
+              {getBooleanControl(state, "showFooter") && (
+                <Card.Footer>
+                  <Button size="sm">Review</Button>
+                  <Button size="sm" variant="ghost">
+                    Dismiss
+                  </Button>
+                </Card.Footer>
+              )}
+            </Card>
+          )}
+
+          {entry.slug === "breadcrumb" && (
+            <Breadcrumb>
+              <Breadcrumb.List>
+                <Breadcrumb.Item>
+                  <Breadcrumb.Link href="#">Docs</Breadcrumb.Link>
+                </Breadcrumb.Item>
+                <Breadcrumb.Separator>
+                  {getStringControl(state, "separator", "/")}
+                </Breadcrumb.Separator>
+                <Breadcrumb.Item>
+                  <Breadcrumb.Link href="#">Playground</Breadcrumb.Link>
+                </Breadcrumb.Item>
+                <Breadcrumb.Separator>
+                  {getStringControl(state, "separator", "/")}
+                </Breadcrumb.Separator>
+                <Breadcrumb.Item>
+                  <Breadcrumb.Page>Button</Breadcrumb.Page>
+                </Breadcrumb.Item>
+              </Breadcrumb.List>
+            </Breadcrumb>
+          )}
+
+          {entry.slug === "checkbox" && (
+            <Checkbox
+              checked={getBooleanControl(state, "checked")}
+              indeterminate={getBooleanControl(state, "indeterminate")}
+              size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+              label={getStringControl(state, "label", "Ship docs examples")}
+              description={getStringControl(
+                state,
+                "description",
+                "Enable polished examples in the docs site.",
+              )}
+              onChange={() => {}}
+            />
+          )}
+
+          {entry.slug === "combobox" && (
+            <div className="max-w-md">
+              <Combobox
+                label={getStringControl(state, "label", "Stack")}
+                value={getStringControl(state, "value", "nextjs")}
+                onValueChange={() => {}}
+                options={[
+                  { label: "Next.js", value: "nextjs", description: "App Router and server rendering." },
+                  { label: "Vite", value: "vitejs", description: "Fast local iteration for SPA workflows." },
+                  { label: "Storybook", value: "storybook", description: "Visual review and component development." },
+                ]}
+              />
+            </div>
+          )}
+
+          {entry.slug === "command" && (
+            <div className="max-w-md">
+              <Command initialQuery={getStringControl(state, "query", "docs")}>
+                <Command.Input
+                  placeholder="Search docs, patterns, components..."
+                />
+                <Command.List>
+                  <Command.Group>
+                    <Command.Label>Docs</Command.Label>
+                    <Command.Item value="button" keywords={["action", "cta"]}>
+                      Button
+                    </Command.Item>
+                    <Command.Item value="dialog" keywords={["modal", "overlay"]}>
+                      Dialog
+                    </Command.Item>
+                  </Command.Group>
+                </Command.List>
+              </Command>
+            </div>
+          )}
+
+          {entry.slug === "date-picker" && (
+            <div className="max-w-md">
+              <DatePicker
+                label={getStringControl(state, "label", "Publish date")}
+                value={getStringControl(state, "value", "2026-04-14")}
+                description="Used to schedule the component release."
+                error={getBooleanControl(state, "showError") ? "Choose a valid publication date." : undefined}
+                onChange={() => {}}
+              />
+            </div>
+          )}
+
+          {entry.slug === "dialog" && (
+            <div className="rounded-xl border border-dashed border-slate-300 p-4 dark:border-white/10">
+              <Dialog
+                open={getBooleanControl(state, "open")}
+                onClose={() => {}}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg" | "xl"}
+              >
+                <Dialog.Header>
+                  <Dialog.Title>Review generated output</Dialog.Title>
+                  <Dialog.Description>
+                    Check the snippet before you copy it into your project.
+                  </Dialog.Description>
+                </Dialog.Header>
+                <Dialog.Content>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Dialogs work well for focused confirmation and detail-heavy tasks.
+                  </p>
+                </Dialog.Content>
+                <Dialog.Footer>
+                  <Button size="sm" variant="ghost">Cancel</Button>
+                  <Button size="sm">Continue</Button>
+                </Dialog.Footer>
+              </Dialog>
+            </div>
+          )}
+
+          {entry.slug === "drawer" && (
+            <div className="rounded-xl border border-dashed border-slate-300 p-4 dark:border-white/10">
+              <Drawer
+                open={getBooleanControl(state, "open")}
+                onClose={() => {}}
+                side={getStringControl(state, "side", "right") as "right" | "left"}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg" | "full"}
+              >
+                <Drawer.Header>
+                  <Drawer.Title>Component settings</Drawer.Title>
+                  <Drawer.Description>
+                    Adjust visual options without leaving the current page.
+                  </Drawer.Description>
+                </Drawer.Header>
+                <Drawer.Content>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    Drawers work well for side-by-side editing flows.
+                  </p>
+                </Drawer.Content>
+                <Drawer.Footer>
+                  <Button size="sm" variant="ghost">Close</Button>
+                </Drawer.Footer>
+              </Drawer>
+            </div>
+          )}
+
+          {entry.slug === "dropdown-menu" && (
+            <DropdownMenu open={getBooleanControl(state, "open")} onOpenChange={() => {}}>
+              <DropdownMenu.Trigger>Open menu</DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                {getBooleanControl(state, "showLabel") && (
+                  <DropdownMenu.Label>Actions</DropdownMenu.Label>
+                )}
+                <DropdownMenu.Item>Duplicate</DropdownMenu.Item>
+                <DropdownMenu.Item>Edit</DropdownMenu.Item>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item>Archive</DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          )}
+
+          {entry.slug === "input" && (
+            <div className="max-w-md">
+              <Input
+                variant={getStringControl(state, "variant", "default") as "default" | "filled" | "ghost"}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+                label={getStringControl(state, "label", "Email address")}
+                placeholder={getStringControl(state, "placeholder", "name@company.com")}
+                description="We only use this for product updates."
+                error={getBooleanControl(state, "showError") ? "Enter a valid email address." : undefined}
+              />
+            </div>
+          )}
+
+          {entry.slug === "pagination" && (
+            <Pagination
+              page={Number(getStringControl(state, "page", "3"))}
+              totalPages={Number(getStringControl(state, "totalPages", "8"))}
+              siblingCount={Number(getStringControl(state, "siblingCount", "1"))}
+              onPageChange={() => {}}
+            />
+          )}
+
+          {entry.slug === "page-progress" && (
+            <div className="relative h-12 w-full rounded-xl border border-dashed border-slate-300 bg-white dark:border-white/10 dark:bg-slate-900">
+              <PageProgress
+                progress={Number(getStringControl(state, "progress", "45"))}
+                visible={getBooleanControl(state, "visible")}
+              />
+              <div className="px-4 pt-5 text-xs text-slate-500 dark:text-slate-400">
+                Simulated top navigation progress
+              </div>
+            </div>
+          )}
+
+          {entry.slug === "popover" && (
+            <Popover
+              open={getBooleanControl(state, "open")}
+              onOpenChange={() => {}}
+              side={getStringControl(state, "side", "bottom") as "top" | "bottom"}
+              align={getStringControl(state, "align", "start") as "start" | "center" | "end"}
+            >
+              <Popover.Trigger>Open settings</Popover.Trigger>
+              <Popover.Content>
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                  Tune component options without leaving the current page.
+                </p>
+                <div className="mt-3">
+                  <Popover.Close>Done</Popover.Close>
+                </div>
+              </Popover.Content>
+            </Popover>
+          )}
+
+          {entry.slug === "progress" && (
+            <div className="max-w-md">
+              <div className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+                Upload progress
+              </div>
+              <Progress
+                value={Number(getStringControl(state, "value", "60"))}
+                max={Number(getStringControl(state, "max", "100"))}
+              />
+            </div>
+          )}
+
+          {entry.slug === "radio-group" && (
+            <div className="max-w-xl">
+              <RadioGroup
+                value={getStringControl(state, "value", "nextjs")}
+                onValueChange={() => {}}
+              >
+                <RadioGroup.Item
+                  value="nextjs"
+                  label="Next.js"
+                  description={
+                    getBooleanControl(state, "showDescriptions")
+                      ? "App Router, server rendering, and integrated routing."
+                      : undefined
+                  }
+                />
+                <RadioGroup.Item
+                  value="vitejs"
+                  label="Vite"
+                  description={
+                    getBooleanControl(state, "showDescriptions")
+                      ? "Lean client-side tooling with fast local iteration."
+                      : undefined
+                  }
+                />
+                <RadioGroup.Item
+                  value="remix"
+                  label="Remix"
+                  description={
+                    getBooleanControl(state, "showDescriptions")
+                      ? "Nested routes with server-first data workflows."
+                      : undefined
+                  }
+                />
+              </RadioGroup>
+            </div>
+          )}
+
+          {entry.slug === "select" && (
+            <div className="max-w-md">
+              <Select
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+                label={getStringControl(state, "label", "Framework")}
+                placeholder={getStringControl(state, "placeholder", "Choose framework")}
+                description={
+                  getBooleanControl(state, "showDescription")
+                    ? "Keep generated examples aligned with your app shell."
+                    : undefined
+                }
+                options={SELECT_SAMPLE_OPTIONS}
+                defaultValue="nextjs"
+              />
+            </div>
+          )}
+
+          {entry.slug === "search-dialog" && (
+            <div className="relative h-[440px] w-full overflow-hidden rounded-xl border border-dashed border-slate-300 dark:border-white/10">
+              <SearchDialog
+                open={getBooleanControl(state, "open")}
+                initialQuery={getStringControl(state, "query", "button")}
+                items={[
+                  { title: "Button", href: "/docs/button", group: "Docs", section: "Components" },
+                  { title: "Dialog", href: "/docs/dialog", group: "Docs", section: "Components" },
+                  {
+                    title: "Form Validation",
+                    href: "/nextjs/cookbook/form-validation",
+                    group: "Cookbook",
+                    description: "Schema-first forms with React Hook Form",
+                  },
+                ]}
+                onClose={() => {}}
+                onNavigate={() => {}}
+              />
+            </div>
+          )}
+
+          {entry.slug === "separator" && (
+            <div
+              className={cn(
+                "flex items-center justify-center rounded-xl border border-dashed border-slate-300 p-6 dark:border-white/10",
+                getStringControl(state, "orientation", "horizontal") === "horizontal"
+                  ? "w-full"
+                  : "h-40",
+              )}
+            >
+              <Separator
+                orientation={getStringControl(state, "orientation", "horizontal") as "horizontal" | "vertical"}
+              />
+            </div>
+          )}
+
+          {entry.slug === "skeleton" && (
+            <div className="flex items-center gap-4">
+              <Skeleton
+                variant={getStringControl(state, "variant", "line") as "line" | "rect" | "circle"}
+                width={Number(getStringControl(state, "width", "160"))}
+              />
+            </div>
+          )}
+
+          {entry.slug === "slider" && (
+            <div className="max-w-md">
+              <Slider
+                label={getStringControl(state, "label", "Volume")}
+                value={Number(getStringControl(state, "value", "50"))}
+                showValue={getBooleanControl(state, "showValue", true)}
+                onValueChange={() => {}}
+              />
+            </div>
+          )}
+
+          {entry.slug === "switch" && (
+            <Switch
+              size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+              label={getStringControl(state, "label", "Enable notifications")}
+              description={getStringControl(
+                state,
+                "description",
+                "Ship product alerts to the current workspace.",
+              )}
+              checked={getBooleanControl(state, "checked")}
+              onChange={() => {}}
+            />
+          )}
+
+          {entry.slug === "tabs" && (
+            <div className="max-w-xl">
+              <Tabs
+                defaultValue="overview"
+                variant={getStringControl(state, "variant", "underline") as "underline" | "pills"}
+              >
+                <Tabs.List>
+                  <Tabs.Trigger value="overview">
+                    {getStringControl(state, "firstLabel", "Overview")}
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value="api">
+                    {getStringControl(state, "secondLabel", "API")}
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value="examples">
+                    {getStringControl(state, "thirdLabel", "Examples")}
+                  </Tabs.Trigger>
+                </Tabs.List>
+                <Tabs.Content value="overview">
+                  <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                    Start with intent, constraints, and the mental model for the component.
+                  </p>
+                </Tabs.Content>
+                <Tabs.Content value="api">
+                  <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                    Document props, variants, and safe defaults for production usage.
+                  </p>
+                </Tabs.Content>
+                <Tabs.Content value="examples">
+                  <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+                    Show real combinations that match the generated usage snippet.
+                  </p>
+                </Tabs.Content>
+              </Tabs>
+            </div>
+          )}
+
+          {entry.slug === "textarea" && (
+            <div className="max-w-xl">
+              <Textarea
+                variant={getStringControl(state, "variant", "default") as "default" | "filled" | "ghost"}
+                size={getStringControl(state, "size", "md") as "sm" | "md" | "lg"}
+                label={getStringControl(state, "label", "Release notes")}
+                placeholder={getStringControl(
+                  state,
+                  "placeholder",
+                  "Summarize what changed in this release...",
+                )}
+                description="This summary appears in changelog emails and product updates."
+                error={getBooleanControl(state, "showError") ? "Please add enough detail before publishing." : undefined}
+              />
+            </div>
+          )}
+
+          {entry.slug === "toast" && (
+            <div className="max-w-md">
+              <div className="rounded-xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-slate-900">
+                <Toast
+                  open
+                  onOpenChange={() => {}}
+                  duration={0}
+                  variant={getStringControl(state, "variant", "default") as "default" | "success" | "warning" | "error"}
+                  position={getStringControl(state, "position", "top-right") as "top-right" | "bottom-right" | "top-left" | "bottom-left"}
+                  className="relative inset-auto translate-y-0 opacity-100 shadow-none"
+                >
+                  <Toast.Title>{getStringControl(state, "title", "Changes saved")}</Toast.Title>
+                  <Toast.Description>
+                    {getStringControl(state, "description", "Your component settings are ready to ship.")}
+                  </Toast.Description>
+                  <Toast.Footer>
+                    <Toast.Close />
+                  </Toast.Footer>
+                </Toast>
+              </div>
+            </div>
+          )}
+
+          {entry.slug === "tooltip" && (
+            <Tooltip
+              side={getStringControl(state, "side", "top") as "top" | "bottom" | "left" | "right"}
+              defaultOpen={getBooleanControl(state, "defaultOpen")}
+            >
+              <Tooltip.Trigger>
+                <Button variant="outline" size="sm">Hover target</Button>
+              </Tooltip.Trigger>
+              <Tooltip.Content>
+                {getStringControl(state, "label", "Copy install command")}
+              </Tooltip.Content>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ControlField({
+  control,
+  value,
+  onChange,
+}: {
+  control: PlaygroundControlDefinition;
+  value: string | boolean | undefined;
+  onChange: (value: string | boolean) => void;
+}) {
+  if (control.type === "boolean") {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-slate-900">
+        <Checkbox
+          checked={Boolean(value)}
+          label={control.label}
+          description={control.helperText}
+          onChange={onChange}
+        />
+      </div>
+    );
+  }
+
+  if (control.type === "select") {
+    return (
+      <Select
+        label={control.label}
+        options={control.options}
+        value={typeof value === "string" ? value : ""}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <Input
+      label={control.label}
+      value={typeof value === "string" ? value : ""}
+      placeholder={control.placeholder}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}
+
+export function PlaygroundPage() {
+  const entries = useMemo(() => getPlaygroundEntries(), []);
+  const defaultEntry = useMemo(() => getDefaultPlaygroundEntry(), []);
+  const [framework, setFramework] = useState<PlaygroundFramework>("nextjs");
+  const [previewTheme, setPreviewTheme] = useState<PlaygroundTheme>("dark");
+  const [colorScheme, setColorScheme] = useState<PlaygroundColorScheme>("indigo");
+  const [codeTab, setCodeTab] = useState<CodePanelTab>("usage");
+  const [previewTab, setPreviewTab] = useState<PreviewTab>("quick");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedSlug, setSelectedSlug] = useState(defaultEntry?.slug ?? "");
+  const [controlStates, setControlStates] = useState<Record<string, PlaygroundControlState>>(
+    () =>
+      Object.fromEntries(entries.map((entry) => [entry.slug, { ...entry.initialState }])),
+  );
+  const deferredSearch = useDeferredValue(searchQuery);
+
+  const filteredEntries = useMemo(() => {
+    const normalizedQuery = deferredSearch.trim().toLowerCase();
+
+    if (!normalizedQuery) return entries;
+
+    return entries.filter((entry) => {
+      const haystack = [
+        entry.name,
+        entry.slug,
+        entry.category,
+        entry.description,
+        ...entry.tags,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [deferredSearch, entries]);
+
+  useEffect(() => {
+    if (!filteredEntries.length) return;
+
+    const selectedStillVisible = filteredEntries.some((entry) => entry.slug === selectedSlug);
+    if (!selectedStillVisible) {
+      setSelectedSlug(filteredEntries[0]?.slug ?? "");
+    }
+  }, [filteredEntries, selectedSlug]);
+
+  const selectedEntry = useMemo(
+    () =>
+      filteredEntries.find((entry) => entry.slug === selectedSlug)
+      ?? entries.find((entry) => entry.slug === selectedSlug)
+      ?? defaultEntry,
+    [defaultEntry, entries, filteredEntries, selectedSlug],
+  );
+
+  const currentState = selectedEntry
+    ? controlStates[selectedEntry.slug] ?? selectedEntry.initialState
+    : {};
+
+  const usageSnippet = selectedEntry
+    ? buildUsageSnippet(selectedEntry, framework, currentState)
+    : "";
+
+  function updateControl(entry: PlaygroundEntry, controlId: string, value: string | boolean) {
+    setControlStates((previousState) => ({
+      ...previousState,
+      [entry.slug]: {
+        ...entry.initialState,
+        ...previousState[entry.slug],
+        [controlId]: value,
+      },
+    }));
+  }
+
+  return (
+    <div className="font-display min-h-screen bg-white text-slate-900 antialiased dark:bg-[#0b0e14] dark:text-[#e2e8f0]">
+      <DocsHeader />
+      <main className="mx-auto max-w-[1680px] px-4 py-8 sm:px-6 lg:px-8 lg:py-10">
+        <div className="mx-auto max-w-[1540px]">
+        <div className="mb-10 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-3xl">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/8 px-4 py-2 text-sm font-semibold text-primary">
+              <span className="material-symbols-outlined text-base">deployed_code</span>
+              Component playground
+            </div>
+            <h1 className="text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+              Configure components before you copy a single line.
+            </h1>
+            <p className="mt-4 max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+              Browse the full UI catalog, preview components, tune the common props, and
+              generate usage code that stays aligned with the registry behind the CLI.
+            </p>
+          </div>
+
+          <div className="grid gap-3 rounded-3xl border border-slate-200 bg-slate-50/90 p-4 backdrop-blur dark:border-white/10 dark:bg-slate-950/70 lg:grid-cols-3">
+            <Select
+              label="Framework"
+              options={FRAMEWORK_OPTIONS}
+              value={framework}
+              onChange={(event) => setFramework(event.target.value as PlaygroundFramework)}
+              description="Mengubah bentuk snippet yang digenerate untuk konteks Next.js atau Vite."
+            />
+            <Select
+              label="Preview theme"
+              options={PREVIEW_THEME_OPTIONS}
+              value={previewTheme}
+              onChange={(event) => setPreviewTheme(event.target.value as PlaygroundTheme)}
+              description="Quick preview respects the selected surface theme."
+            />
+            <Select
+              label="Color scheme"
+              options={COLOR_SCHEME_OPTIONS}
+              value={colorScheme}
+              onChange={(event) => setColorScheme(event.target.value as PlaygroundColorScheme)}
+              description="Mengubah aksen warna preview playground."
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-6 2xl:grid-cols-[320px_minmax(0,1fr)]">
+          <section className="space-y-4 xl:sticky xl:top-20 xl:self-start">
+            <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+              <Input
+                label="Search components"
+                placeholder="Button, overlay, forms..."
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+              />
+              <div className="mt-4 flex items-center justify-between text-xs font-medium uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
+                <span>Catalog</span>
+                <span>{filteredEntries.length} items</span>
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2 2xl:grid-cols-1 2xl:max-h-[calc(100vh-15rem)] 2xl:overflow-y-auto 2xl:pr-1">
+              {filteredEntries.map((entry) => {
+                const isActive = selectedEntry?.slug === entry.slug;
+
+                return (
+                  <button
+                    key={entry.slug}
+                    type="button"
+                    onClick={() => {
+                      startTransition(() => {
+                        setSelectedSlug(entry.slug);
+                        setCodeTab("usage");
+                        setPreviewTab(entry.supportsQuickPreview ? "quick" : "storybook");
+                      });
+                    }}
+                    className={cn(
+                      "w-full rounded-3xl border p-4 text-left transition-all",
+                      isActive
+                        ? "border-primary bg-primary/6 shadow-lg shadow-primary/10"
+                        : "border-slate-200 bg-white hover:-translate-y-0.5 hover:border-slate-300 dark:border-white/10 dark:bg-slate-950 dark:hover:border-white/20",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                          {entry.category}
+                        </p>
+                        <h2 className="mt-2 text-lg font-black tracking-tight text-slate-900 dark:text-white">
+                          {entry.name}
+                        </h2>
+                      </div>
+                      {entry.supportsQuickPreview && (
+                        <span className="rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-400">
+                          Configurable
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-slate-600 dark:text-slate-400">
+                      {entry.description}
+                    </p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {entry.tags.slice(0, 3).map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-500 dark:border-white/10 dark:bg-slate-900 dark:text-slate-400"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                );
+              })}
+
+              {!filteredEntries.length && (
+                <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 p-6 text-sm leading-6 text-slate-500 dark:border-white/10 dark:bg-slate-950 dark:text-slate-400">
+                  No components match that query. Try a component name like `button`, a category such as `forms`, or a tag like `overlay`.
+                </div>
+              )}
+            </div>
+          </section>
+
+          {selectedEntry && (
+            <div className="space-y-8">
+              <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+                <div className="space-y-4">
+                  <div className="rounded-[28px] border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="outline">{selectedEntry.category}</Badge>
+                          <Badge variant="info">{selectedEntry.slug}</Badge>
+                        </div>
+                        <h2 className="mt-4 text-3xl font-black tracking-tight text-slate-900 dark:text-white">
+                          {selectedEntry.name}
+                        </h2>
+                        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-400">
+                          {selectedEntry.description}
+                        </p>
+                      </div>
+
+                      <div className="flex flex-wrap items-center gap-3 xl:max-w-[420px] xl:justify-end">
+                        {selectedEntry.supportsQuickPreview && (
+                          <div className="inline-flex rounded-full border border-slate-200 bg-slate-50 p-1 dark:border-white/10 dark:bg-slate-900">
+                            <button
+                              type="button"
+                              onClick={() => setPreviewTab("quick")}
+                              className={cn(
+                                "rounded-full px-4 py-2 text-sm font-semibold transition-colors",
+                                previewTab === "quick"
+                                  ? "bg-primary text-white"
+                                  : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
+                              )}
+                            >
+                              Quick preview
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setPreviewTab("storybook")}
+                              className={cn(
+                                "rounded-full px-4 py-2 text-sm font-semibold transition-colors",
+                                previewTab === "storybook"
+                                  ? "bg-primary text-white"
+                                  : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
+                              )}
+                            >
+                              Storybook
+                            </button>
+                          </div>
+                        )}
+
+                        <Link
+                          href={selectedEntry.docsHref}
+                          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:border-primary hover:text-primary dark:border-white/10 dark:bg-slate-900 dark:text-slate-300"
+                        >
+                          Docs
+                          <span className="material-symbols-outlined text-base">arrow_outward</span>
+                        </Link>
+                        <Link
+                          href={selectedEntry.storybookHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:border-primary hover:text-primary dark:border-white/10 dark:bg-slate-900 dark:text-slate-300"
+                        >
+                          Storybook
+                          <span className="material-symbols-outlined text-base">open_in_new</span>
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+
+                  {previewTab === "quick" && selectedEntry.supportsQuickPreview ? (
+                    <PlaygroundPreview
+                      entry={selectedEntry}
+                      state={currentState}
+                      theme={previewTheme}
+                      colorScheme={colorScheme}
+                    />
+                  ) : (
+                    <div className="overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-lg shadow-slate-200/40 dark:border-white/10 dark:bg-slate-950 dark:shadow-black/20">
+                      <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-5 py-4 dark:border-white/10">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                            Storybook preview
+                          </p>
+                          <h3 className="mt-2 text-xl font-black tracking-tight text-slate-900 dark:text-white">
+                            {selectedEntry.name}
+                          </h3>
+                        </div>
+                        <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 dark:border-white/10 dark:bg-slate-900 dark:text-slate-300">
+                          External preview
+                        </span>
+                      </div>
+                      <iframe
+                        title={`${selectedEntry.name} Storybook preview`}
+                        src={selectedEntry.storybookEmbedHref}
+                        className="h-[640px] w-full bg-white"
+                      />
+                    </div>
+                  )}
+
+                </div>
+
+                <aside className="space-y-4 xl:sticky xl:top-20 xl:self-start">
+                  <div className="rounded-[28px] border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                          Registry
+                        </p>
+                        <h3 className="mt-2 text-lg font-black tracking-tight text-slate-900 dark:text-white">
+                          Internal metadata
+                        </h3>
+                      </div>
+                      <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-500 dark:border-white/10 dark:bg-slate-900 dark:text-slate-400">
+                        {selectedEntry.outputFile}
+                      </span>
+                    </div>
+
+                    <dl className="mt-5 grid gap-4 text-sm">
+                      <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-900">
+                        <dt className="font-semibold text-slate-500 dark:text-slate-400">
+                          CLI command
+                        </dt>
+                        <dd className="mt-2 font-mono text-slate-900 dark:text-slate-100">
+                          {selectedEntry.cliCommand}
+                        </dd>
+                      </div>
+                      <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-900">
+                        <dt className="font-semibold text-slate-500 dark:text-slate-400">
+                          Internal deps
+                        </dt>
+                        <dd className="mt-2 flex flex-wrap gap-2">
+                          {(selectedEntry.resolvedDeps.length
+                            ? selectedEntry.resolvedDeps
+                            : ["none"]).map((dependency) => (
+                            <span
+                              key={dependency}
+                              className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 dark:border-white/10 dark:bg-slate-950 dark:text-slate-300"
+                            >
+                              {dependency}
+                            </span>
+                          ))}
+                        </dd>
+                      </div>
+                      <div className="rounded-2xl bg-slate-50 p-4 dark:bg-slate-900">
+                        <dt className="font-semibold text-slate-500 dark:text-slate-400">
+                          npm deps
+                        </dt>
+                        <dd className="mt-2 flex flex-wrap gap-2">
+                          {(selectedEntry.npmDeps.length
+                            ? selectedEntry.npmDeps
+                            : ["none"]).map((dependency) => (
+                            <span
+                              key={dependency}
+                              className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 dark:border-white/10 dark:bg-slate-950 dark:text-slate-300"
+                            >
+                              {dependency}
+                            </span>
+                          ))}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <div className="rounded-[28px] border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                          Controls
+                        </p>
+                        <h3 className="mt-2 text-lg font-black tracking-tight text-slate-900 dark:text-white">
+                          Quick config
+                        </h3>
+                      </div>
+                      <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-500 dark:border-white/10 dark:bg-slate-900 dark:text-slate-400">
+                        {selectedEntry.controls.length} fields
+                      </span>
+                    </div>
+
+                    {selectedEntry.controls.length ? (
+                      <div className="mt-5 grid gap-4">
+                        {selectedEntry.controls.map((control) => (
+                          <ControlField
+                            key={control.id}
+                            control={control}
+                            value={currentState[control.id]}
+                            onChange={(value) => updateControl(selectedEntry, control.id, value)}
+                          />
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-4 text-sm leading-6 text-slate-500 dark:border-white/10 dark:bg-slate-900 dark:text-slate-400">
+                        This component is browseable in the playground, but it does not have quick controls yet. Use the embedded Storybook preview or open the docs for its recommended composition.
+                      </div>
+                    )}
+                  </div>
+                </aside>
+              </section>
+
+              <section className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                      Code output
+                    </p>
+                    <h2 className="mt-2 text-2xl font-black tracking-tight text-slate-900 dark:text-white">
+                      Ready to copy
+                    </h2>
+                  </div>
+                  <div className="inline-flex rounded-full border border-slate-200 bg-white p-1 dark:border-white/10 dark:bg-slate-950">
+                    <button
+                      type="button"
+                      onClick={() => setCodeTab("usage")}
+                      className={cn(
+                        "rounded-full px-4 py-2 text-sm font-semibold transition-colors",
+                        codeTab === "usage"
+                          ? "bg-primary text-white"
+                          : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
+                      )}
+                    >
+                      Usage
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setCodeTab("source")}
+                      className={cn(
+                        "rounded-full px-4 py-2 text-sm font-semibold transition-colors",
+                        codeTab === "source"
+                          ? "bg-primary text-white"
+                          : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
+                      )}
+                    >
+                      Source
+                    </button>
+                  </div>
+                </div>
+
+                <CodeBlock
+                  filename={
+                    codeTab === "usage"
+                      ? `${selectedEntry.slug}.example.tsx`
+                      : selectedEntry.outputFile
+                  }
+                  copyText={codeTab === "usage" ? usageSnippet : selectedEntry.sourceCode}
+                >
+                  {codeTab === "usage" ? usageSnippet : selectedEntry.sourceCode}
+                </CodeBlock>
+
+                <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+                  <div className="rounded-[28px] border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                      Workflow
+                    </p>
+                    <ol className="mt-4 grid gap-3 text-sm leading-6 text-slate-600 dark:text-slate-400">
+                      <li>1. Install the component with the CLI command shown below.</li>
+                      <li>2. Drop the generated usage snippet into your feature or demo page.</li>
+                      <li>3. Open the docs or Storybook link if you need deeper prop coverage.</li>
+                    </ol>
+                  </div>
+
+                  <div className="rounded-[28px] border border-slate-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-slate-950">
+                    <CliInstallBlock name={selectedEntry.slug} />
+                  </div>
+                </div>
+              </section>
+            </div>
+          )}
+        </div>
+        </div>
+      </main>
+      <MobileNav />
+    </div>
+  );
+}

--- a/src/features/playground/data/registry.test.ts
+++ b/src/features/playground/data/registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUsageSnippet,
+  getDefaultPlaygroundEntry,
+  getPlaygroundEntries,
+} from "./registry";
+
+describe("playground registry", () => {
+  it("exposes component entries from the internal registry", () => {
+    const entries = getPlaygroundEntries();
+
+    expect(entries.length).toBeGreaterThan(20);
+    expect(entries.some((entry) => entry.slug === "button")).toBe(true);
+    expect(entries.some((entry) => entry.slug === "dialog")).toBe(true);
+  });
+
+  it("returns button as the default playground entry", () => {
+    expect(getDefaultPlaygroundEntry()?.slug).toBe("button");
+  });
+
+  it("builds usage snippets from control state for configurable components", () => {
+    const button = getPlaygroundEntries().find((entry) => entry.slug === "button");
+    const radioGroup = getPlaygroundEntries().find((entry) => entry.slug === "radio-group");
+    const command = getPlaygroundEntries().find((entry) => entry.slug === "command");
+    const searchDialog = getPlaygroundEntries().find((entry) => entry.slug === "search-dialog");
+
+    expect(button).toBeDefined();
+    expect(radioGroup).toBeDefined();
+    expect(command).toBeDefined();
+    expect(searchDialog).toBeDefined();
+
+    if (!button || !radioGroup || !command || !searchDialog) {
+      throw new Error("Expected playground entries to exist");
+    }
+
+    const buttonSnippet = buildUsageSnippet(button, "nextjs", {
+      variant: "outline",
+      size: "lg",
+      label: "Ship now",
+      isLoading: true,
+      disabled: false,
+    });
+    const radioSnippet = buildUsageSnippet(radioGroup, "vitejs", {
+      value: "vitejs",
+      showDescriptions: true,
+    });
+    const commandSnippet = buildUsageSnippet(command, "nextjs", {
+      query: "dialog",
+    });
+    const searchDialogSnippet = buildUsageSnippet(searchDialog, "vitejs", {
+      open: true,
+      query: "button",
+    });
+
+    expect(buttonSnippet).toContain('<Button variant="outline" size="lg" isLoading>');
+    expect(buttonSnippet).toContain("Ship now");
+    expect(buttonSnippet).toContain('"use client";');
+    expect(buttonSnippet).toContain('import { Button } from "@/components/ui/Button"');
+    expect(radioSnippet).toContain('<RadioGroup value="vitejs"');
+    expect(radioSnippet).toContain('description="Lean client-side tooling with fast local iteration."');
+    expect(radioSnippet).toContain('import { RadioGroup } from "@/components/ui/RadioGroup"');
+    expect(radioSnippet).not.toContain('"use client";');
+    expect(commandSnippet).toContain('<Command initialQuery="dialog">');
+    expect(searchDialogSnippet).toContain('initialQuery="button"');
+  });
+});

--- a/src/features/playground/data/registry.ts
+++ b/src/features/playground/data/registry.ts
@@ -1,0 +1,1791 @@
+import { getStorybookComponentUrl, getStorybookEmbedUrl } from "@/features/docs/lib/storybook";
+import {
+  REGISTRY,
+  getTemplate,
+  resolve,
+  type RegistryEntry,
+} from "../../../../packages/cli/src/registry";
+
+export type PlaygroundFramework = "nextjs" | "vitejs";
+export type PlaygroundTheme = "light" | "dark";
+export type PlaygroundColorScheme = "indigo" | "emerald" | "amber" | "rose";
+export type PlaygroundControlValue = string | boolean;
+export type PlaygroundControlState = Record<string, PlaygroundControlValue>;
+
+export interface PlaygroundControlOption {
+  label: string;
+  value: string;
+}
+
+export interface PlaygroundControlDefinition {
+  id: string;
+  label: string;
+  type: "select" | "boolean" | "text";
+  options?: PlaygroundControlOption[];
+  placeholder?: string;
+  helperText?: string;
+}
+
+export interface PlaygroundEntry {
+  slug: string;
+  name: string;
+  description: string;
+  category: string;
+  tags: string[];
+  docsHref: string;
+  storybookHref: string;
+  storybookEmbedHref: string;
+  cliCommand: string;
+  outputFile: string;
+  templateKey: string;
+  sourceCode: string;
+  npmDeps: string[];
+  internalDeps: string[];
+  resolvedDeps: string[];
+  controls: PlaygroundControlDefinition[];
+  initialState: PlaygroundControlState;
+  supportsQuickPreview: boolean;
+}
+
+const CATEGORY_BY_SLUG: Record<string, string> = {
+  accordion: "Navigation",
+  alert: "Feedback",
+  "alert-dialog": "Overlays",
+  avatar: "Data Display",
+  badge: "Feedback",
+  breadcrumb: "Navigation",
+  button: "Actions",
+  card: "Data Display",
+  checkbox: "Forms",
+  combobox: "Forms",
+  command: "Navigation",
+  "date-picker": "Forms",
+  dialog: "Overlays",
+  drawer: "Overlays",
+  "dropdown-menu": "Overlays",
+  input: "Forms",
+  pagination: "Navigation",
+  popover: "Overlays",
+  progress: "Feedback",
+  "page-progress": "Feedback",
+  "radio-group": "Forms",
+  "search-dialog": "Overlays",
+  select: "Forms",
+  separator: "Layout",
+  skeleton: "Feedback",
+  slider: "Forms",
+  switch: "Forms",
+  tabs: "Navigation",
+  textarea: "Forms",
+  toast: "Feedback",
+  tooltip: "Overlays",
+};
+
+const TAGS_BY_SLUG: Record<string, string[]> = {
+  accordion: ["collapsible", "faq"],
+  alert: ["status", "inline"],
+  "alert-dialog": ["confirmation", "destructive"],
+  avatar: ["identity", "profile"],
+  badge: ["status", "tags"],
+  breadcrumb: ["hierarchy", "routing"],
+  button: ["cta", "loading"],
+  card: ["container", "layout"],
+  checkbox: ["selection", "forms"],
+  combobox: ["search", "selection"],
+  command: ["palette", "search"],
+  "date-picker": ["date", "forms"],
+  dialog: ["modal", "focus"],
+  drawer: ["panel", "slideover"],
+  "dropdown-menu": ["menu", "actions"],
+  input: ["forms", "text"],
+  pagination: ["listing", "navigation"],
+  popover: ["floating", "contextual"],
+  progress: ["loading", "status"],
+  "page-progress": ["navigation", "loading"],
+  "radio-group": ["forms", "single-choice"],
+  "search-dialog": ["search", "overlay"],
+  select: ["forms", "native"],
+  separator: ["layout", "divider"],
+  skeleton: ["loading", "placeholder"],
+  slider: ["range", "input"],
+  switch: ["toggle", "boolean"],
+  tabs: ["navigation", "content"],
+  textarea: ["forms", "multiline"],
+  toast: ["notification", "ephemeral"],
+  tooltip: ["help", "hover"],
+};
+
+const CONTROL_DEFINITIONS_BY_SLUG: Record<string, PlaygroundControlDefinition[]> = {
+  accordion: [
+    {
+      id: "type",
+      label: "Type",
+      type: "select",
+      options: [
+        { label: "Single", value: "single" },
+        { label: "Multiple", value: "multiple" },
+      ],
+    },
+    {
+      id: "openSecond",
+      label: "Open second item",
+      type: "boolean",
+    },
+  ],
+  "alert-dialog": [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Warning", value: "warning" },
+        { label: "Destructive", value: "destructive" },
+      ],
+    },
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+    {
+      id: "isLoading",
+      label: "Loading",
+      type: "boolean",
+    },
+  ],
+  alert: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Success", value: "success" },
+        { label: "Warning", value: "warning" },
+        { label: "Error", value: "error" },
+        { label: "Info", value: "info" },
+      ],
+    },
+    {
+      id: "title",
+      label: "Title",
+      type: "text",
+      placeholder: "Deployment status",
+    },
+    {
+      id: "description",
+      label: "Description",
+      type: "text",
+      placeholder: "Everything shipped successfully.",
+    },
+    {
+      id: "showAction",
+      label: "Show action",
+      type: "boolean",
+    },
+  ],
+  avatar: [
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+        { label: "XL", value: "xl" },
+      ],
+    },
+    {
+      id: "fallback",
+      label: "Fallback text",
+      type: "text",
+      placeholder: "RP",
+    },
+    {
+      id: "showImage",
+      label: "Show image",
+      type: "boolean",
+    },
+  ],
+  badge: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Success", value: "success" },
+        { label: "Warning", value: "warning" },
+        { label: "Error", value: "error" },
+        { label: "Info", value: "info" },
+        { label: "Outline", value: "outline" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Beta access",
+    },
+  ],
+  button: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Primary", value: "primary" },
+        { label: "Secondary", value: "secondary" },
+        { label: "Ghost", value: "ghost" },
+        { label: "Outline", value: "outline" },
+        { label: "Destructive", value: "destructive" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Create recipe",
+    },
+    {
+      id: "isLoading",
+      label: "Loading state",
+      type: "boolean",
+    },
+    {
+      id: "disabled",
+      label: "Disabled",
+      type: "boolean",
+    },
+  ],
+  breadcrumb: [
+    {
+      id: "separator",
+      label: "Separator",
+      type: "select",
+      options: [
+        { label: "Slash", value: "/" },
+        { label: "Chevron", value: ">" },
+        { label: "Dot", value: "•" },
+      ],
+    },
+  ],
+  card: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Elevated", value: "elevated" },
+        { label: "Flat", value: "flat" },
+      ],
+    },
+    {
+      id: "title",
+      label: "Title",
+      type: "text",
+      placeholder: "Conversion snapshot",
+    },
+    {
+      id: "description",
+      label: "Description",
+      type: "text",
+      placeholder: "Weekly signups are ahead of target.",
+    },
+    {
+      id: "showFooter",
+      label: "Show footer actions",
+      type: "boolean",
+    },
+  ],
+  checkbox: [
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Ship docs examples",
+    },
+    {
+      id: "description",
+      label: "Description",
+      type: "text",
+      placeholder: "Enable polished examples in the docs site.",
+    },
+    {
+      id: "checked",
+      label: "Checked",
+      type: "boolean",
+    },
+    {
+      id: "indeterminate",
+      label: "Indeterminate",
+      type: "boolean",
+      helperText: "Useful for partial selection states.",
+    },
+  ],
+  combobox: [
+    {
+      id: "value",
+      label: "Selected option",
+      type: "select",
+      options: [
+        { label: "Next.js", value: "nextjs" },
+        { label: "Vite", value: "vitejs" },
+        { label: "Storybook", value: "storybook" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Stack",
+    },
+  ],
+  command: [
+    {
+      id: "query",
+      label: "Initial query",
+      type: "text",
+      placeholder: "search docs",
+    },
+  ],
+  "date-picker": [
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Publish date",
+    },
+    {
+      id: "value",
+      label: "Value",
+      type: "text",
+      placeholder: "2026-04-14",
+    },
+    {
+      id: "showError",
+      label: "Show error",
+      type: "boolean",
+    },
+  ],
+  input: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Filled", value: "filled" },
+        { label: "Ghost", value: "ghost" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Email address",
+    },
+    {
+      id: "placeholder",
+      label: "Placeholder",
+      type: "text",
+      placeholder: "name@company.com",
+    },
+    {
+      id: "showError",
+      label: "Show error",
+      type: "boolean",
+    },
+  ],
+  dialog: [
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+        { label: "XL", value: "xl" },
+      ],
+    },
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+  ],
+  drawer: [
+    {
+      id: "side",
+      label: "Side",
+      type: "select",
+      options: [
+        { label: "Right", value: "right" },
+        { label: "Left", value: "left" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+        { label: "Full", value: "full" },
+      ],
+    },
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+  ],
+  "dropdown-menu": [
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+    {
+      id: "showLabel",
+      label: "Show section label",
+      type: "boolean",
+    },
+  ],
+  "page-progress": [
+    {
+      id: "progress",
+      label: "Progress",
+      type: "select",
+      options: [
+        { label: "15", value: "15" },
+        { label: "45", value: "45" },
+        { label: "80", value: "80" },
+        { label: "100", value: "100" },
+      ],
+    },
+    {
+      id: "visible",
+      label: "Visible",
+      type: "boolean",
+    },
+  ],
+  pagination: [
+    {
+      id: "page",
+      label: "Current page",
+      type: "select",
+      options: [
+        { label: "1", value: "1" },
+        { label: "2", value: "2" },
+        { label: "3", value: "3" },
+        { label: "4", value: "4" },
+        { label: "5", value: "5" },
+      ],
+    },
+    {
+      id: "totalPages",
+      label: "Total pages",
+      type: "select",
+      options: [
+        { label: "5", value: "5" },
+        { label: "8", value: "8" },
+        { label: "12", value: "12" },
+      ],
+    },
+    {
+      id: "siblingCount",
+      label: "Sibling count",
+      type: "select",
+      options: [
+        { label: "1", value: "1" },
+        { label: "2", value: "2" },
+      ],
+    },
+  ],
+  progress: [
+    {
+      id: "value",
+      label: "Value",
+      type: "select",
+      options: [
+        { label: "10", value: "10" },
+        { label: "35", value: "35" },
+        { label: "60", value: "60" },
+        { label: "85", value: "85" },
+      ],
+    },
+    {
+      id: "max",
+      label: "Max",
+      type: "select",
+      options: [
+        { label: "100", value: "100" },
+        { label: "120", value: "120" },
+      ],
+    },
+  ],
+  popover: [
+    {
+      id: "side",
+      label: "Side",
+      type: "select",
+      options: [
+        { label: "Bottom", value: "bottom" },
+        { label: "Top", value: "top" },
+      ],
+    },
+    {
+      id: "align",
+      label: "Align",
+      type: "select",
+      options: [
+        { label: "Start", value: "start" },
+        { label: "Center", value: "center" },
+        { label: "End", value: "end" },
+      ],
+    },
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+  ],
+  "radio-group": [
+    {
+      id: "value",
+      label: "Selected option",
+      type: "select",
+      options: [
+        { label: "Next.js", value: "nextjs" },
+        { label: "Vite", value: "vitejs" },
+        { label: "Remix", value: "remix" },
+      ],
+    },
+    {
+      id: "showDescriptions",
+      label: "Show descriptions",
+      type: "boolean",
+    },
+  ],
+  select: [
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Framework",
+    },
+    {
+      id: "placeholder",
+      label: "Placeholder",
+      type: "text",
+      placeholder: "Choose framework",
+    },
+    {
+      id: "showDescription",
+      label: "Show description",
+      type: "boolean",
+    },
+  ],
+  "search-dialog": [
+    {
+      id: "open",
+      label: "Open",
+      type: "boolean",
+    },
+    {
+      id: "query",
+      label: "Seed query",
+      type: "text",
+      placeholder: "button",
+    },
+  ],
+  separator: [
+    {
+      id: "orientation",
+      label: "Orientation",
+      type: "select",
+      options: [
+        { label: "Horizontal", value: "horizontal" },
+        { label: "Vertical", value: "vertical" },
+      ],
+    },
+  ],
+  skeleton: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Line", value: "line" },
+        { label: "Rectangle", value: "rect" },
+        { label: "Circle", value: "circle" },
+      ],
+    },
+    {
+      id: "width",
+      label: "Width",
+      type: "select",
+      options: [
+        { label: "80", value: "80" },
+        { label: "160", value: "160" },
+        { label: "240", value: "240" },
+      ],
+    },
+  ],
+  slider: [
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Volume",
+    },
+    {
+      id: "value",
+      label: "Value",
+      type: "select",
+      options: [
+        { label: "10", value: "10" },
+        { label: "25", value: "25" },
+        { label: "50", value: "50" },
+        { label: "75", value: "75" },
+        { label: "90", value: "90" },
+      ],
+    },
+    {
+      id: "showValue",
+      label: "Show numeric value",
+      type: "boolean",
+    },
+  ],
+  switch: [
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Enable notifications",
+    },
+    {
+      id: "description",
+      label: "Description",
+      type: "text",
+      placeholder: "Ship product alerts to the current workspace.",
+    },
+    {
+      id: "checked",
+      label: "Enabled",
+      type: "boolean",
+    },
+  ],
+  tabs: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Underline", value: "underline" },
+        { label: "Pills", value: "pills" },
+      ],
+    },
+    {
+      id: "firstLabel",
+      label: "First tab",
+      type: "text",
+      placeholder: "Overview",
+    },
+    {
+      id: "secondLabel",
+      label: "Second tab",
+      type: "text",
+      placeholder: "API",
+    },
+    {
+      id: "thirdLabel",
+      label: "Third tab",
+      type: "text",
+      placeholder: "Examples",
+    },
+  ],
+  textarea: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Filled", value: "filled" },
+        { label: "Ghost", value: "ghost" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Size",
+      type: "select",
+      options: [
+        { label: "Small", value: "sm" },
+        { label: "Medium", value: "md" },
+        { label: "Large", value: "lg" },
+      ],
+    },
+    {
+      id: "label",
+      label: "Label",
+      type: "text",
+      placeholder: "Release notes",
+    },
+    {
+      id: "placeholder",
+      label: "Placeholder",
+      type: "text",
+      placeholder: "Summarize what changed in this release...",
+    },
+    {
+      id: "showError",
+      label: "Show error",
+      type: "boolean",
+    },
+  ],
+  toast: [
+    {
+      id: "variant",
+      label: "Variant",
+      type: "select",
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Success", value: "success" },
+        { label: "Warning", value: "warning" },
+        { label: "Error", value: "error" },
+      ],
+    },
+    {
+      id: "position",
+      label: "Position",
+      type: "select",
+      options: [
+        { label: "Top right", value: "top-right" },
+        { label: "Bottom right", value: "bottom-right" },
+        { label: "Top left", value: "top-left" },
+        { label: "Bottom left", value: "bottom-left" },
+      ],
+    },
+    {
+      id: "title",
+      label: "Title",
+      type: "text",
+      placeholder: "Changes saved",
+    },
+    {
+      id: "description",
+      label: "Description",
+      type: "text",
+      placeholder: "Your component settings are ready to ship.",
+    },
+  ],
+  tooltip: [
+    {
+      id: "side",
+      label: "Side",
+      type: "select",
+      options: [
+        { label: "Top", value: "top" },
+        { label: "Bottom", value: "bottom" },
+        { label: "Left", value: "left" },
+        { label: "Right", value: "right" },
+      ],
+    },
+    {
+      id: "defaultOpen",
+      label: "Open by default",
+      type: "boolean",
+    },
+    {
+      id: "label",
+      label: "Tooltip text",
+      type: "text",
+      placeholder: "Copy install command",
+    },
+  ],
+};
+
+const INITIAL_STATE_BY_SLUG: Record<string, PlaygroundControlState> = {
+  accordion: {
+    type: "single",
+    openSecond: true,
+  },
+  "alert-dialog": {
+    variant: "destructive",
+    open: true,
+    isLoading: false,
+  },
+  alert: {
+    variant: "success",
+    title: "Deployment status",
+    description: "Everything shipped successfully to staging.",
+    showAction: true,
+  },
+  avatar: {
+    size: "lg",
+    fallback: "RP",
+    showImage: true,
+  },
+  badge: {
+    variant: "info",
+    size: "md",
+    label: "Early access",
+  },
+  breadcrumb: {
+    separator: "/",
+  },
+  button: {
+    variant: "primary",
+    size: "md",
+    label: "Create recipe",
+    isLoading: false,
+    disabled: false,
+  },
+  card: {
+    variant: "elevated",
+    title: "Conversion snapshot",
+    description: "Weekly signups are ahead of target and churn remains stable.",
+    showFooter: true,
+  },
+  checkbox: {
+    size: "md",
+    label: "Ship docs examples",
+    description: "Enable polished examples in the docs site.",
+    checked: true,
+    indeterminate: false,
+  },
+  combobox: {
+    value: "nextjs",
+    label: "Stack",
+  },
+  command: {
+    query: "docs",
+  },
+  "date-picker": {
+    label: "Publish date",
+    value: "2026-04-14",
+    showError: false,
+  },
+  dialog: {
+    size: "md",
+    open: true,
+  },
+  drawer: {
+    side: "right",
+    size: "md",
+    open: true,
+  },
+  "dropdown-menu": {
+    open: true,
+    showLabel: true,
+  },
+  input: {
+    variant: "default",
+    size: "md",
+    label: "Email address",
+    placeholder: "name@company.com",
+    showError: false,
+  },
+  pagination: {
+    page: "3",
+    totalPages: "8",
+    siblingCount: "1",
+  },
+  "page-progress": {
+    progress: "45",
+    visible: true,
+  },
+  popover: {
+    side: "bottom",
+    align: "start",
+    open: true,
+  },
+  progress: {
+    value: "60",
+    max: "100",
+  },
+  "radio-group": {
+    value: "nextjs",
+    showDescriptions: true,
+  },
+  select: {
+    size: "md",
+    label: "Framework",
+    placeholder: "Choose framework",
+    showDescription: true,
+  },
+  "search-dialog": {
+    open: true,
+    query: "button",
+  },
+  separator: {
+    orientation: "horizontal",
+  },
+  skeleton: {
+    variant: "line",
+    width: "160",
+  },
+  slider: {
+    label: "Volume",
+    value: "50",
+    showValue: true,
+  },
+  switch: {
+    size: "md",
+    label: "Enable notifications",
+    description: "Ship product alerts to the current workspace.",
+    checked: true,
+  },
+  tabs: {
+    variant: "underline",
+    firstLabel: "Overview",
+    secondLabel: "API",
+    thirdLabel: "Examples",
+  },
+  textarea: {
+    variant: "default",
+    size: "md",
+    label: "Release notes",
+    placeholder: "Summarize what changed in this release...",
+    showError: false,
+  },
+  toast: {
+    variant: "success",
+    position: "top-right",
+    title: "Changes saved",
+    description: "Your component settings are ready to ship.",
+  },
+  tooltip: {
+    side: "top",
+    defaultOpen: true,
+    label: "Copy install command",
+  },
+};
+
+function titleize(slug: string) {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function getFrameworkImportPath(framework: PlaygroundFramework, outputFile: string) {
+  const basePath = "@/components/ui";
+
+  return `${basePath}/${outputFile.replace(/\.tsx$/, "")}`;
+}
+
+function getPlaygroundCategory(entry: RegistryEntry) {
+  return CATEGORY_BY_SLUG[entry.name] ?? "Components";
+}
+
+function getPlaygroundTags(entry: RegistryEntry) {
+  return TAGS_BY_SLUG[entry.name] ?? [entry.target];
+}
+
+const PLAYGROUND_ENTRIES: PlaygroundEntry[] = REGISTRY
+  .filter((entry) => entry.target === "components")
+  .map((entry) => {
+    const dependencies = resolve(entry.name)
+      .filter((resolvedEntry) => resolvedEntry.name !== entry.name)
+      .map((resolvedEntry) => resolvedEntry.name);
+
+    return {
+      slug: entry.name,
+      name: titleize(entry.name),
+      description: entry.description,
+      category: getPlaygroundCategory(entry),
+      tags: getPlaygroundTags(entry),
+      docsHref: `/docs/${entry.name}`,
+      storybookHref: getStorybookComponentUrl(entry.name),
+      storybookEmbedHref: getStorybookEmbedUrl(entry.name),
+      cliCommand: `npx react-principles add ${entry.name}`,
+      outputFile: entry.outputFile,
+      templateKey: entry.templateKey,
+      sourceCode: getTemplate(entry.templateKey),
+      npmDeps: entry.npmDeps,
+      internalDeps: entry.internalDeps,
+      resolvedDeps: dependencies,
+      controls: CONTROL_DEFINITIONS_BY_SLUG[entry.name] ?? [],
+      initialState: INITIAL_STATE_BY_SLUG[entry.name] ?? {},
+      supportsQuickPreview: entry.name in CONTROL_DEFINITIONS_BY_SLUG,
+    };
+  })
+  .sort((left, right) => left.name.localeCompare(right.name));
+
+export function getPlaygroundEntries() {
+  return PLAYGROUND_ENTRIES;
+}
+
+export function getPlaygroundEntry(slug: string) {
+  return PLAYGROUND_ENTRIES.find((entry) => entry.slug === slug);
+}
+
+export function getDefaultPlaygroundEntry() {
+  return getPlaygroundEntry("button") ?? PLAYGROUND_ENTRIES[0];
+}
+
+function stringifyAttribute(name: string, value: string | boolean) {
+  if (typeof value === "boolean") {
+    return value ? ` ${name}` : "";
+  }
+
+  return value ? ` ${name}="${value}"` : "";
+}
+
+export function buildUsageSnippet(
+  entry: PlaygroundEntry,
+  framework: PlaygroundFramework,
+  state: PlaygroundControlState,
+) {
+  const importPath = getFrameworkImportPath(framework, entry.outputFile);
+  const importPrefix = framework === "nextjs" ? `"use client";\n\nimport` : "import";
+
+  switch (entry.slug) {
+    case "accordion": {
+      const type = String(state.type ?? "single");
+      const openSecond = Boolean(state.openSecond);
+
+      return `${importPrefix} { Accordion } from "${importPath}";
+
+export function Example() {
+  return (
+    <Accordion type="${type}" defaultValue={${type === "multiple" ? openSecond ? '["item-2"]' : "[]" : openSecond ? '"item-2"' : '""'}}>
+      <Accordion.Item value="item-1">
+        <Accordion.Trigger>What does the playground solve?</Accordion.Trigger>
+        <Accordion.Content>
+          It lets you browse, configure, and copy component usage without leaving the docs site.
+        </Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item value="item-2">
+        <Accordion.Trigger>How does it stay aligned with the CLI?</Accordion.Trigger>
+        <Accordion.Content>
+          Both surfaces read from the same internal registry metadata.
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}`;
+    }
+
+    case "alert-dialog": {
+      const variant = String(state.variant ?? "default");
+      const open = Boolean(state.open);
+      const isLoading = Boolean(state.isLoading);
+
+      return `${importPrefix} { AlertDialog } from "${importPath}";
+
+export function Example() {
+  return (
+    <AlertDialog
+      open={${open}}
+      onClose={() => {}}
+      onConfirm={() => {}}
+      variant="${variant}"
+      isLoading={${isLoading}}
+      title="Delete component preset?"
+      description="This removes the saved playground preset from your workspace."
+      confirmLabel="Delete preset"
+    />
+  );
+}`;
+    }
+
+    case "alert": {
+      const title = String(state.title ?? "Deployment status");
+      const description = String(state.description ?? "Everything shipped successfully.");
+      const variant = String(state.variant ?? "default");
+      const showAction = Boolean(state.showAction);
+
+      return `${importPrefix} { Alert } from "${importPath}";
+
+export function Example() {
+  return (
+    <Alert variant="${variant}">
+      <Alert.Title>${title}</Alert.Title>
+      <Alert.Description>
+        ${description}
+      </Alert.Description>${showAction ? `
+      <Alert.Footer>
+        <Alert.Action>Review changes</Alert.Action>
+      </Alert.Footer>` : ""}
+    </Alert>
+  );
+}`;
+    }
+
+    case "avatar": {
+      const size = String(state.size ?? "md");
+      const fallback = String(state.fallback ?? "RP");
+      const showImage = Boolean(state.showImage);
+
+      return `${importPrefix} { Avatar } from "${importPath}";
+
+export function Example() {
+  return (
+    <Avatar size="${size}">
+      ${showImage ? '<Avatar.Image src="https://i.pravatar.cc/160?img=12" alt="Profile" />\n      ' : ""}<Avatar.Fallback>${fallback}</Avatar.Fallback>
+    </Avatar>
+  );
+}`;
+    }
+
+    case "badge": {
+      const variant = String(state.variant ?? "default");
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Early access");
+
+      return `${importPrefix} { Badge } from "${importPath}";
+
+export function Example() {
+  return <Badge variant="${variant}" size="${size}">${label}</Badge>;
+}`;
+    }
+
+    case "breadcrumb": {
+      const separator = String(state.separator ?? "/");
+
+      return `${importPrefix} { Breadcrumb } from "${importPath}";
+
+export function Example() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#">Docs</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator>${separator}</Breadcrumb.Separator>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="#">Playground</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator>${separator}</Breadcrumb.Separator>
+        <Breadcrumb.Item>
+          <Breadcrumb.Page>Button</Breadcrumb.Page>
+        </Breadcrumb.Item>
+      </Breadcrumb.List>
+    </Breadcrumb>
+  );
+}`;
+    }
+
+    case "button": {
+      const variant = String(state.variant ?? "primary");
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Create recipe");
+      const isLoading = Boolean(state.isLoading);
+      const disabled = Boolean(state.disabled);
+
+      return `${importPrefix} { Button } from "${importPath}";
+
+export function Example() {
+  return (
+    <Button${stringifyAttribute("variant", variant)}${stringifyAttribute("size", size)}${stringifyAttribute("isLoading", isLoading)}${stringifyAttribute("disabled", disabled)}>
+      ${label}
+    </Button>
+  );
+}`;
+    }
+
+    case "card": {
+      const variant = String(state.variant ?? "default");
+      const title = String(state.title ?? "Conversion snapshot");
+      const description = String(state.description ?? "Weekly signups are ahead of target.");
+      const showFooter = Boolean(state.showFooter);
+
+      return `${importPrefix} { Card } from "${importPath}";
+import { Button } from "@/components/ui/Button";
+
+export function Example() {
+  return (
+    <Card variant="${variant}">
+      <Card.Header>
+        <Card.Title>${title}</Card.Title>
+        <Card.Description>${description}</Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Drop metrics, summaries, or content blocks here.
+        </p>
+      </Card.Content>${showFooter ? `
+      <Card.Footer>
+        <Button size="sm">Review</Button>
+        <Button size="sm" variant="ghost">Dismiss</Button>
+      </Card.Footer>` : ""}
+    </Card>
+  );
+}`;
+    }
+
+    case "checkbox": {
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Ship docs examples");
+      const description = String(state.description ?? "Enable polished examples in the docs site.");
+      const checked = Boolean(state.checked);
+      const indeterminate = Boolean(state.indeterminate);
+
+      return `${importPrefix} { Checkbox } from "${importPath}";
+
+export function Example() {
+  return (
+    <Checkbox
+      size="${size}"
+      label="${label}"
+      description="${description}"
+      checked={${checked}}
+      indeterminate={${indeterminate}}
+      onChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "combobox": {
+      const value = String(state.value ?? "nextjs");
+      const label = String(state.label ?? "Stack");
+
+      return `${importPrefix} { Combobox } from "${importPath}";
+
+const options = [
+  { label: "Next.js", value: "nextjs", description: "App Router and server rendering." },
+  { label: "Vite", value: "vitejs", description: "Fast local iteration for SPA workflows." },
+  { label: "Storybook", value: "storybook", description: "Visual review and component development." },
+];
+
+export function Example() {
+  return (
+    <Combobox
+      label="${label}"
+      options={options}
+      value="${value}"
+      onValueChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "command": {
+      const query = String(state.query ?? "docs");
+
+      return `${importPrefix} { Command } from "${importPath}";
+
+export function Example() {
+  return (
+    <Command initialQuery="${query}">
+      <Command.Input placeholder="Search docs, patterns, components..." />
+      <Command.List>
+        <Command.Group>
+          <Command.Label>Docs</Command.Label>
+          <Command.Item value="button" keywords={["action", "cta"]}>Button</Command.Item>
+          <Command.Item value="dialog" keywords={["modal", "overlay"]}>Dialog</Command.Item>
+        </Command.Group>
+      </Command.List>
+    </Command>
+  );
+}`;
+    }
+
+    case "date-picker": {
+      const label = String(state.label ?? "Publish date");
+      const value = String(state.value ?? "2026-04-14");
+      const showError = Boolean(state.showError);
+
+      return `${importPrefix} { DatePicker } from "${importPath}";
+
+export function Example() {
+  return (
+    <DatePicker
+      label="${label}"
+      value="${value}"
+      ${showError ? 'error="Choose a valid publication date."' : 'description="Used to schedule the component release."'}
+      onChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "dialog": {
+      const size = String(state.size ?? "md");
+      const open = Boolean(state.open);
+
+      return `${importPrefix} { Dialog } from "${importPath}";
+
+export function Example() {
+  return (
+    <Dialog open={${open}} onClose={() => {}} size="${size}">
+      <Dialog.Header>
+        <Dialog.Title>Review generated output</Dialog.Title>
+        <Dialog.Description>
+          Check the snippet before you copy it into your project.
+        </Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Content>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Dialogs work well for focused confirmation and detail-heavy tasks.
+        </p>
+      </Dialog.Content>
+      <Dialog.Footer>
+        <button type="button">Cancel</button>
+        <button type="button">Continue</button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+}`;
+    }
+
+    case "drawer": {
+      const side = String(state.side ?? "right");
+      const size = String(state.size ?? "md");
+      const open = Boolean(state.open);
+
+      return `${importPrefix} { Drawer } from "${importPath}";
+
+export function Example() {
+  return (
+    <Drawer open={${open}} onClose={() => {}} side="${side}" size="${size}">
+      <Drawer.Header>
+        <Drawer.Title>Component settings</Drawer.Title>
+        <Drawer.Description>
+          Adjust visual options without leaving the current page.
+        </Drawer.Description>
+      </Drawer.Header>
+      <Drawer.Content>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Drawers work well for side-by-side editing flows.
+        </p>
+      </Drawer.Content>
+      <Drawer.Footer>
+        <button type="button">Close</button>
+      </Drawer.Footer>
+    </Drawer>
+  );
+}`;
+    }
+
+    case "dropdown-menu": {
+      const open = Boolean(state.open);
+      const showLabel = Boolean(state.showLabel);
+
+      return `${importPrefix} { DropdownMenu } from "${importPath}";
+
+export function Example() {
+  return (
+    <DropdownMenu open={${open}} onOpenChange={() => {}}>
+      <DropdownMenu.Trigger>Open menu</DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        ${showLabel ? "<DropdownMenu.Label>Actions</DropdownMenu.Label>\n        " : ""}<DropdownMenu.Item>Duplicate</DropdownMenu.Item>
+        <DropdownMenu.Item>Edit</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>Archive</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}`;
+    }
+
+    case "input": {
+      const variant = String(state.variant ?? "default");
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Email address");
+      const placeholder = String(state.placeholder ?? "name@company.com");
+      const showError = Boolean(state.showError);
+
+      return `${importPrefix} { Input } from "${importPath}";
+
+export function Example() {
+  return (
+    <Input
+      variant="${variant}"
+      size="${size}"
+      label="${label}"
+      placeholder="${placeholder}"
+      ${showError ? 'error="Enter a valid email address."' : 'description="We only use this for product updates."'}
+    />
+  );
+}`;
+    }
+
+    case "pagination": {
+      const page = Number(state.page ?? 3);
+      const totalPages = Number(state.totalPages ?? 8);
+      const siblingCount = Number(state.siblingCount ?? 1);
+
+      return `${importPrefix} { Pagination } from "${importPath}";
+
+export function Example() {
+  return (
+    <Pagination
+      page={${page}}
+      totalPages={${totalPages}}
+      siblingCount={${siblingCount}}
+      onPageChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "page-progress": {
+      const progress = Number(state.progress ?? 45);
+      const visible = Boolean(state.visible);
+
+      return `${importPrefix} { PageProgress } from "${importPath}";
+
+export function Example() {
+  return <PageProgress progress={${progress}} visible={${visible}} />;
+}`;
+    }
+
+    case "progress": {
+      const value = Number(state.value ?? 60);
+      const max = Number(state.max ?? 100);
+
+      return `${importPrefix} { Progress } from "${importPath}";
+
+export function Example() {
+  return <Progress value={${value}} max={${max}} />;
+}`;
+    }
+
+    case "popover": {
+      const side = String(state.side ?? "bottom");
+      const align = String(state.align ?? "start");
+      const open = Boolean(state.open);
+
+      return `${importPrefix} { Popover } from "${importPath}";
+
+export function Example() {
+  return (
+    <Popover open={${open}} onOpenChange={() => {}} side="${side}" align="${align}">
+      <Popover.Trigger>Open settings</Popover.Trigger>
+      <Popover.Content>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Tune component options without leaving the current page.
+        </p>
+        <div className="mt-3">
+          <Popover.Close>Done</Popover.Close>
+        </div>
+      </Popover.Content>
+    </Popover>
+  );
+}`;
+    }
+
+    case "radio-group": {
+      const value = String(state.value ?? "nextjs");
+      const showDescriptions = Boolean(state.showDescriptions);
+
+      return `${importPrefix} { RadioGroup } from "${importPath}";
+
+export function Example() {
+  return (
+    <RadioGroup value="${value}" onValueChange={() => {}}>
+      <RadioGroup.Item
+        value="nextjs"
+        label="Next.js"${showDescriptions ? `
+        description="App Router, server rendering, and integrated routing."` : ""}
+      />
+      <RadioGroup.Item
+        value="vitejs"
+        label="Vite"${showDescriptions ? `
+        description="Lean client-side tooling with fast local iteration."` : ""}
+      />
+      <RadioGroup.Item
+        value="remix"
+        label="Remix"${showDescriptions ? `
+        description="Nested routes with server-first data workflows."` : ""}
+      />
+    </RadioGroup>
+  );
+}`;
+    }
+
+    case "select": {
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Framework");
+      const placeholder = String(state.placeholder ?? "Choose framework");
+      const showDescription = Boolean(state.showDescription);
+
+      return `${importPrefix} { Select } from "${importPath}";
+
+const frameworkOptions = [
+  { label: "Next.js", value: "nextjs" },
+  { label: "Vite", value: "vite" },
+  { label: "Storybook", value: "storybook" },
+];
+
+export function Example() {
+  return (
+    <Select
+      size="${size}"
+      label="${label}"
+      placeholder="${placeholder}"
+      options={frameworkOptions}
+      ${showDescription ? 'description="Keep generated examples aligned with your app shell."' : ""}
+    />
+  );
+}`;
+    }
+
+    case "search-dialog": {
+      const open = Boolean(state.open);
+      const query = String(state.query ?? "button");
+
+      return `${importPrefix} { SearchDialog } from "${importPath}";
+
+const items = [
+  { title: "Button", href: "/docs/button", group: "Docs", section: "Components" },
+  { title: "Dialog", href: "/docs/dialog", group: "Docs", section: "Components" },
+  { title: "Form Validation", href: "/nextjs/cookbook/form-validation", group: "Cookbook", description: "Schema-first forms with React Hook Form" },
+];
+
+export function Example() {
+  return (
+    <SearchDialog
+      open={${open}}
+      items={items}
+      initialQuery="${query}"
+      onClose={() => {}}
+      onNavigate={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "separator": {
+      const orientation = String(state.orientation ?? "horizontal");
+
+      return `${importPrefix} { Separator } from "${importPath}";
+
+export function Example() {
+  return (
+    <div className="${orientation === "horizontal" ? "w-full" : "h-24"}">
+      <Separator orientation="${orientation}" />
+    </div>
+  );
+}`;
+    }
+
+    case "skeleton": {
+      const variant = String(state.variant ?? "line");
+      const width = Number(state.width ?? 160);
+
+      return `${importPrefix} { Skeleton } from "${importPath}";
+
+export function Example() {
+  return <Skeleton variant="${variant}" width={${width}} />;
+}`;
+    }
+
+    case "slider": {
+      const label = String(state.label ?? "Volume");
+      const value = Number(state.value ?? 50);
+      const showValue = Boolean(state.showValue);
+
+      return `${importPrefix} { Slider } from "${importPath}";
+
+export function Example() {
+  return (
+    <Slider
+      label="${label}"
+      defaultValue={${value}}
+      showValue={${showValue}}
+      onValueChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "switch": {
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Enable notifications");
+      const description = String(
+        state.description ?? "Ship product alerts to the current workspace.",
+      );
+      const checked = Boolean(state.checked);
+
+      return `${importPrefix} { Switch } from "${importPath}";
+
+export function Example() {
+  return (
+    <Switch
+      size="${size}"
+      label="${label}"
+      description="${description}"
+      checked={${checked}}
+      onChange={() => {}}
+    />
+  );
+}`;
+    }
+
+    case "tabs": {
+      const variant = String(state.variant ?? "underline");
+      const firstLabel = String(state.firstLabel ?? "Overview");
+      const secondLabel = String(state.secondLabel ?? "API");
+      const thirdLabel = String(state.thirdLabel ?? "Examples");
+
+      return `${importPrefix} { Tabs } from "${importPath}";
+
+export function Example() {
+  return (
+    <Tabs defaultValue="overview" variant="${variant}">
+      <Tabs.List>
+        <Tabs.Trigger value="overview">${firstLabel}</Tabs.Trigger>
+        <Tabs.Trigger value="api">${secondLabel}</Tabs.Trigger>
+        <Tabs.Trigger value="examples">${thirdLabel}</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="overview">Start with intent and behavior.</Tabs.Content>
+      <Tabs.Content value="api">Document props, variants, and defaults.</Tabs.Content>
+      <Tabs.Content value="examples">Show production-ready combinations.</Tabs.Content>
+    </Tabs>
+  );
+}`;
+    }
+
+    case "textarea": {
+      const variant = String(state.variant ?? "default");
+      const size = String(state.size ?? "md");
+      const label = String(state.label ?? "Release notes");
+      const placeholder = String(
+        state.placeholder ?? "Summarize what changed in this release...",
+      );
+      const showError = Boolean(state.showError);
+
+      return `${importPrefix} { Textarea } from "${importPath}";
+
+export function Example() {
+  return (
+    <Textarea
+      variant="${variant}"
+      size="${size}"
+      label="${label}"
+      placeholder="${placeholder}"
+      ${showError ? 'error="Please add enough detail before publishing."' : 'description="This summary appears in changelog emails and product updates."'}
+    />
+  );
+}`;
+    }
+
+    case "toast": {
+      const variant = String(state.variant ?? "default");
+      const position = String(state.position ?? "top-right");
+      const title = String(state.title ?? "Changes saved");
+      const description = String(
+        state.description ?? "Your component settings are ready to ship.",
+      );
+
+      return `${importPrefix} { Toast } from "${importPath}";
+import { useState } from "react";
+
+export function Example() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Toast open={open} onOpenChange={setOpen} variant="${variant}" position="${position}">
+      <Toast.Title>${title}</Toast.Title>
+      <Toast.Description>${description}</Toast.Description>
+      <Toast.Footer>
+        <Toast.Close />
+      </Toast.Footer>
+    </Toast>
+  );
+}`;
+    }
+
+    case "tooltip": {
+      const side = String(state.side ?? "top");
+      const defaultOpen = Boolean(state.defaultOpen);
+      const label = String(state.label ?? "Copy install command");
+
+      return `${importPrefix} { Tooltip } from "${importPath}";
+
+export function Example() {
+  return (
+    <Tooltip side="${side}" defaultOpen={${defaultOpen}}>
+      <Tooltip.Trigger>
+        <span>Hover target</span>
+      </Tooltip.Trigger>
+      <Tooltip.Content>${label}</Tooltip.Content>
+    </Tooltip>
+  );
+}`;
+    }
+
+    default:
+      return `${importPrefix} { ${entry.templateKey} } from "${importPath}";
+
+export function Example() {
+  return (
+    <div>
+      <p>Install this component with the CLI, then open the docs or Storybook preview for its recommended composition.</p>
+    </div>
+  );
+}`;
+  }
+}

--- a/src/ui/Command.test.tsx
+++ b/src/ui/Command.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Command } from "./Command";
+
+describe("Command", () => {
+  it("syncs the input value when initialQuery changes", () => {
+    const { rerender } = render(
+      <Command initialQuery="docs">
+        <Command.Input placeholder="Search components" />
+      </Command>,
+    );
+
+    const input = screen.getByPlaceholderText("Search components");
+
+    expect(input).toHaveValue("docs");
+
+    rerender(
+      <Command initialQuery="dialog">
+        <Command.Input placeholder="Search components" />
+      </Command>,
+    );
+
+    expect(input).toHaveValue("dialog");
+  });
+});

--- a/src/ui/Command.tsx
+++ b/src/ui/Command.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 interface CommandContextValue {
@@ -8,14 +8,22 @@ interface CommandContextValue {
 
 const CommandContext = createContext<CommandContextValue | null>(null);
 
+export interface CommandProps extends HTMLAttributes<HTMLDivElement> {
+  initialQuery?: string;
+}
+
 function useCommandContext() {
   const context = useContext(CommandContext);
   if (!context) throw new Error("Command sub-components must be used inside <Command>");
   return context;
 }
 
-export function Command({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  const [query, setQuery] = useState("");
+export function Command({ className, initialQuery = "", ...props }: CommandProps) {
+  const [query, setQuery] = useState(initialQuery);
+
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
 
   return (
     <CommandContext.Provider value={{ query, setQuery }}>

--- a/src/ui/SearchDialog.test.tsx
+++ b/src/ui/SearchDialog.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SearchDialog, type SearchItem } from "./SearchDialog";
+
+const ITEMS: SearchItem[] = [
+  {
+    title: "Button",
+    href: "/docs/button",
+    description: "Primitive action trigger",
+    group: "Docs",
+  },
+];
+
+describe("SearchDialog", () => {
+  it("hydrates the search input from initialQuery when opened", () => {
+    render(
+      <SearchDialog
+        open
+        items={ITEMS}
+        onClose={() => {}}
+        onNavigate={() => {}}
+        initialQuery="button"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Search docs, components, patterns...")).toHaveValue("button");
+  });
+});

--- a/src/ui/SearchDialog.tsx
+++ b/src/ui/SearchDialog.tsx
@@ -17,9 +17,17 @@ interface SearchDialogProps {
   onClose: () => void;
   onNavigate: (href: string) => void;
   savedSlugs?: string[];
+  initialQuery?: string;
 }
 
-export function SearchDialog({ open, items, onClose, onNavigate, savedSlugs = [] }: SearchDialogProps) {
+export function SearchDialog({
+  open,
+  items,
+  onClose,
+  onNavigate,
+  savedSlugs = [],
+  initialQuery = "",
+}: SearchDialogProps) {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -39,11 +47,11 @@ export function SearchDialog({ open, items, onClose, onNavigate, savedSlugs = []
   // Focus input and reset state on open
   useEffect(() => {
     if (open) {
-      setQuery("");
+      setQuery(initialQuery);
       setActiveIndex(0);
       setTimeout(() => inputRef.current?.focus(), 50);
     }
-  }, [open]);
+  }, [initialQuery, open]);
 
   // Reset active index when results change
   useEffect(() => {

--- a/src/ui/storybook-utils.tsx
+++ b/src/ui/storybook-utils.tsx
@@ -1,10 +1,17 @@
 import { useState, type PropsWithChildren, type ReactNode } from "react";
 
-export const SAMPLE_OPTIONS = [
+type SampleOption = {
+  label: string;
+  value: string;
+  description: string;
+  disabled?: boolean;
+};
+
+export const SAMPLE_OPTIONS: SampleOption[] = [
   { label: "Design System", value: "design-system", description: "Reusable UI building blocks" },
   { label: "Cookbook", value: "cookbook", description: "Production-ready React patterns" },
   { label: "CLI", value: "cli", description: "Copy-paste component installer" },
-  { label: "Playground", value: "playground", description: "Interactive configuration", disabled: true },
+  { label: "Playground", value: "playground", description: "Interactive configuration" },
 ];
 
 export const SEARCH_ITEMS = [


### PR DESCRIPTION
## What does this PR do?

Builds the new `/docs/playground` experience for `reactprinciples.dev` as requested in issue #35.

This adds a component browser with search, quick preview, Storybook embed, usage/source snippets, and an internal registry that drives metadata, controls, and snippet generation across the component catalog. It also wires the playground into the docs navigation and landing surface, and adds regression coverage for Storybook URLs plus the `Command` and `SearchDialog` query-driven previews.

## Checklist

- [x] TypeScript strict — no `any`
- [x] Component anatomy followed (imports → types → constants → component → export)
- [x] No direct imports between features (use `shared/` for cross-cutting)
- [x] No `console.log` in production code
- [x] Tested in both light and dark mode

Validation run:
- `rtk pnpm test -- src/ui/Command.test.tsx src/ui/SearchDialog.test.tsx src/features/playground/data/registry.test.ts`
- `rtk pnpm eslint src/ui/Command.tsx src/ui/Command.test.tsx src/ui/SearchDialog.tsx src/ui/SearchDialog.test.tsx src/features/playground/components/PlaygroundPage.tsx src/features/playground/data/registry.ts src/features/playground/data/registry.test.ts`
- `rtk pnpm typecheck`
- `rtk pnpm build`
