### PR TITLE
feat(configurator): redesign with bold editorial theme

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "zustand": "^5.0.0"
   },
   "dependencies": {
+    "@iconify/react": "^6.0.2",
+    "fflate": "^0.8.2",
+    "lucide-react": "^1.9.0",
     "recharts": "^3.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@iconify/react':
+        specifier: ^6.0.2
+        version: 6.0.2(react@19.2.4)
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
+      lucide-react:
+        specifier: ^1.9.0
+        version: 1.9.0(react@19.2.4)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
@@ -652,6 +661,14 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify/react@6.0.2':
+    resolution: {integrity: sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==}
+    peerDependencies:
+      react: '>=16'
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2774,6 +2791,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@1.9.0:
+    resolution: {integrity: sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4100,6 +4122,13 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify/react@6.0.2(react@19.2.4)':
+    dependencies:
+      '@iconify/types': 2.0.0
+      react: 19.2.4
+
+  '@iconify/types@2.0.0': {}
 
   '@img/colour@1.0.0':
     optional: true
@@ -6244,6 +6273,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.9.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   lz-string@1.5.0: {}
 

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+/**
+ * /create page - Configurator Wizard (Redesigned)
+ * Modern UI with progress bar, tabs, and improved layout
+ */
+
+import { useMemo } from "react";
+import { Button } from "@/ui/Button";
+import { Progress } from "@/ui/Progress";
+import { Tabs } from "@/ui/Tabs";
+import { useWizardStore } from "@/features/configurator/stores/useWizardStore";
+import { Step1VisualPreset } from "@/features/configurator/components/Step1VisualPreset";
+import { Step2ProjectStack } from "@/features/configurator/components/Step2ProjectStack";
+import { Step3Generate } from "@/features/configurator/components/Step3Generate";
+import { LivePreviewPanel } from "@/features/configurator/components/LivePreviewPanel";
+
+const STEPS = [
+  { id: "visual", label: "Visual", description: "Choose your style, colors, fonts, and components" },
+  { id: "stack", label: "Stack", description: "Configure your framework and stack features" },
+  { id: "generate", label: "Generate", description: "Get your CLI command and share URL" },
+] as const;
+
+export default function CreatePage() {
+  const { currentStep, setCurrentStep } = useWizardStore();
+
+  // Calculate progress percentage
+  const progressValue = useMemo(() => {
+    const stepIndex = STEPS.findIndex((step) => step.id === currentStep);
+    return ((stepIndex + 1) / STEPS.length) * 100;
+  }, [currentStep]);
+
+  const currentStepIndex = STEPS.findIndex((step) => step.id === currentStep);
+  const currentStepInfo = STEPS[currentStepIndex] || STEPS[0];
+
+  return (
+    <div className="min-h-screen configurator-gradient configurator-theme">
+      {/* Decorative Floating Orbs */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute top-20 left-10 w-64 h-64 bg-[#4628f1]/5 rounded-full blur-3xl animate-float" />
+        <div className="absolute bottom-20 right-10 w-96 h-96 bg-[#8b5cf6]/5 rounded-full blur-3xl animate-float" style={{ animationDelay: '1s' }} />
+        <div className="absolute top-1/2 left-1/2 w-80 h-80 bg-[#a78bfa]/3 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
+      </div>
+
+      <div className="container mx-auto px-4 py-12 max-w-7xl relative z-10">
+        {/* Header Section - Bold Editorial */}
+        <div className="mb-12 text-center animate-stagger-1">
+          <div className="inline-block mb-4">
+            <span className="text-xs font-semibold px-3 py-1.5 rounded-full bg-[#4628f1]/10 text-[#4628f1] uppercase tracking-wider">
+              Configurator
+            </span>
+          </div>
+          <h1 className="text-6xl md:text-7xl font-bold mb-4 bg-gradient-to-r from-[#ededed] via-[#4628f1] to-[#8b5cf6] bg-clip-text text-transparent font-['Space_Grotesk'] leading-tight">
+            Create Your Project
+          </h1>
+          <p className="text-xl text-[#a1a1aa] max-w-2xl mx-auto font-light">
+            Configure your React starter preset with bold, modern aesthetics
+          </p>
+        </div>
+
+        {/* Progress Bar */}
+        <div className="mb-10 animate-stagger-2">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-sm font-medium text-[#a1a1aa] font-['Space_Grotesk']">
+              Step {currentStepIndex + 1} of {STEPS.length}
+            </span>
+            <span className="text-sm font-bold text-[#4628f1] font-['Space_Grotesk']">
+              {Math.round(progressValue)}%
+            </span>
+          </div>
+          <Progress value={progressValue} className="h-1.5" />
+        </div>
+
+        {/* Desktop Layout: Two-Panel */}
+        <div className="hidden lg:grid lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] lg:gap-8 lg:items-start animate-stagger-3">
+          {/* Left Panel - Wizard Controls */}
+          <div className="space-y-6">
+            <div className="bg-[#171717] border border-[#333333] rounded-2xl p-8 shadow-lg backdrop-blur-sm">
+              <div className="mb-6">
+                <h2 className="text-3xl font-bold mb-2 font-['Space_Grotesk'] text-[#ededed]">
+                  {currentStepInfo.label}
+                </h2>
+                <p className="text-[#a1a1aa] text-sm">{currentStepInfo.description}</p>
+              </div>
+
+              {/* Step Content */}
+              {currentStep === "visual" && <Step1VisualPreset />}
+              {currentStep === "stack" && <Step2ProjectStack />}
+              {currentStep === "generate" && <Step3Generate />}
+
+              {/* Navigation Buttons */}
+              <div className="flex justify-between gap-3 mt-8 pt-6 border-t border-[#333333]">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  onClick={() => {
+                    if (currentStep === "stack") setCurrentStep("visual");
+                    if (currentStep === "generate") setCurrentStep("stack");
+                  }}
+                  disabled={currentStep === "visual"}
+                  className="flex-1 bg-[#171717] border-[#333333] text-[#ededed] hover:bg-[#1f1f1f] hover:border-[#444444]"
+                >
+                  Back
+                </Button>
+
+                <Button
+                  size="lg"
+                  onClick={() => {
+                    if (currentStep === "visual") setCurrentStep("stack");
+                    if (currentStep === "stack") setCurrentStep("generate");
+                  }}
+                  disabled={currentStep === "generate"}
+                  className="flex-1 bg-[#4628f1] hover:bg-[#3720d1] text-white font-semibold"
+                >
+                  {currentStep === "generate" ? "Finish" : "Next"}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          {/* Right Panel - Live Preview */}
+          <div className="lg:sticky lg:top-8 animate-stagger-4">
+            <div className="bg-[#171717]/80 backdrop-blur-xl border border-[#333333] rounded-2xl p-6 shadow-lg">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-bold font-['Space_Grotesk'] text-[#ededed]">Live Preview</h2>
+                <span className="text-xs px-2 py-1 rounded-full bg-[#4628f1]/10 text-[#4628f1] font-medium">
+                  Real-time
+                </span>
+              </div>
+              <LivePreviewPanel />
+            </div>
+          </div>
+        </div>
+
+        {/* Mobile Layout: Tabs */}
+        <div className="lg:hidden animate-stagger-3">
+          <Tabs
+            value={currentStep}
+            onChange={(value) => setCurrentStep(value as any)}
+            variant="pills"
+            className="mb-6"
+          >
+            <Tabs.List className="w-full grid grid-cols-3 gap-2 bg-[#171717] p-1.5 rounded-xl border border-[#333333]">
+              {STEPS.map((step) => (
+                <Tabs.Trigger
+                  key={step.id}
+                  value={step.id}
+                  className="text-sm font-['Space_Grotesk'] text-[#a1a1aa] data-[state=active]:bg-[#4628f1] data-[state=active]:text-white"
+                >
+                  {step.label}
+                </Tabs.Trigger>
+              ))}
+            </Tabs.List>
+
+            {STEPS.map((step) => (
+              <Tabs.Content key={step.id} value={step.id} className="mt-6">
+                <div className="space-y-6">
+                  {/* Step Content */}
+                  {step.id === "visual" && <Step1VisualPreset />}
+                  {step.id === "stack" && <Step2ProjectStack />}
+                  {step.id === "generate" && <Step3Generate />}
+
+                  {/* Live Preview - shown below controls on mobile */}
+                  <div className="bg-[#171717]/80 backdrop-blur-xl border border-[#333333] rounded-2xl p-6 shadow-lg">
+                    <h2 className="text-xl font-bold mb-4 font-['Space_Grotesk'] text-[#ededed]">Live Preview</h2>
+                    <LivePreviewPanel />
+                  </div>
+
+                  {/* Navigation Buttons */}
+                  <div className="flex justify-between gap-3">
+                    <Button
+                      variant="outline"
+                      size="lg"
+                      onClick={() => {
+                        const stepIndex = STEPS.findIndex((s) => s.id === step.id);
+                        if (stepIndex > 0) {
+                          const prevStep = STEPS[stepIndex - 1];
+                          if (prevStep) setCurrentStep(prevStep.id);
+                        }
+                      }}
+                      disabled={step.id === "visual"}
+                      className="flex-1 bg-[#171717] border-[#333333] text-[#ededed] hover:bg-[#1f1f1f]"
+                    >
+                      Back
+                    </Button>
+
+                    <Button
+                      size="lg"
+                      onClick={() => {
+                        const stepIndex = STEPS.findIndex((s) => s.id === step.id);
+                        if (stepIndex < STEPS.length - 1) {
+                          const nextStep = STEPS[stepIndex + 1];
+                          if (nextStep) setCurrentStep(nextStep.id);
+                        }
+                      }}
+                      disabled={step.id === "generate"}
+                      className="flex-1 bg-[#4628f1] hover:bg-[#3720d1] text-white font-semibold"
+                    >
+                      {step.id === "generate" ? "Finish" : "Next"}
+                    </Button>
+                  </div>
+                </div>
+              </Tabs.Content>
+            ))}
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,20 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap") layer(base);
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&display=swap") layer(base);
 
 @import 'tailwindcss';
 
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  --color-primary: #4628f1;
+  /* Bold Editorial Theme - Dark First */
+  --color-primary: #4628f1; /* Purple - brand color */
+  --color-secondary: #8b5cf6; /* Light purple */
+  --color-accent: #a78bfa; /* Lighter purple */
   --color-background-light: #f6f6f8;
-  --color-background-dark: #020617;
+  --color-background-dark: #0a0a0a;
 
-  --font-display: Inter, sans-serif;
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
 }
 
 /*
@@ -40,13 +45,15 @@
 
 @layer utilities {
   :root {
+    /* Light Theme */
     --background: #f6f6f8;
     --foreground: #0f172a;
   }
 
   .dark {
-    --background: #020617;
-    --foreground: #e2e8f0;
+    /* Dark Theme - Default */
+    --background: #0a0a0a;
+    --foreground: #ededed;
   }
 
   body {
@@ -57,6 +64,38 @@
       system-ui,
       -apple-system,
       sans-serif;
+  }
+
+  /* Configurator Theme Variables */
+  .configurator-theme {
+    --bg-primary: #0a0a0a;
+    --bg-surface: #171717;
+    --bg-surface-hover: #1f1f1f;
+    --border: #333333;
+    --border-hover: #444444;
+    --accent-purple: #4628f1;
+    --accent-purple-light: #8b5cf6;
+    --accent-purple-lighter: #a78bfa;
+    --text-primary: #ededed;
+    --text-secondary: #a1a1aa;
+    --text-muted: #71717a;
+    --success: #10b981;
+    --warning: #a78bfa;
+    --error: #f43f5e;
+    --font-display: 'Space Grotesk', sans-serif;
+    --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+    --font-mono: 'JetBrains Mono', monospace;
+  }
+
+  .configurator-theme.light {
+    --bg-primary: #ffffff;
+    --bg-surface: #f6f6f8;
+    --bg-surface-hover: #e8e8e8;
+    --border: #e2e8f0;
+    --border-hover: #cbd5e1;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --text-muted: #94a3b8;
   }
 
   .material-symbols-outlined {
@@ -70,15 +109,42 @@
   .mesh-gradient {
     background-color: #f6f6f8;
     background-image:
-      radial-gradient(at 0% 0%, rgba(19, 73, 236, 0.05) 0px, transparent 50%),
-      radial-gradient(at 100% 0%, rgba(19, 73, 236, 0.08) 0px, transparent 50%);
+      radial-gradient(at 0% 0%, rgba(70, 40, 241, 0.08) 0px, transparent 50%),
+      radial-gradient(at 100% 0%, rgba(139, 92, 246, 0.08) 0px, transparent 50%);
   }
 
   .dark .mesh-gradient {
-    background-color: #020617;
+    background-color: #0a0a0a;
     background-image:
       radial-gradient(at 0% 0%, rgba(70, 40, 241, 0.15) 0px, transparent 50%),
-      radial-gradient(at 100% 0%, rgba(70, 40, 241, 0.1) 0px, transparent 50%);
+      radial-gradient(at 100% 0%, rgba(139, 92, 246, 0.12) 0px, transparent 50%);
+  }
+
+  /* Configurator Gradient Mesh */
+  .configurator-gradient {
+    background: linear-gradient(135deg, #0a0a0a 0%, #171717 50%, #0a0a0a 100%);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .configurator-gradient::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background:
+      radial-gradient(circle at 20% 30%, rgba(70, 40, 241, 0.08) 0%, transparent 40%),
+      radial-gradient(circle at 80% 70%, rgba(139, 92, 246, 0.08) 0%, transparent 40%),
+      radial-gradient(circle at 50% 50%, rgba(167, 139, 250, 0.05) 0%, transparent 40%);
+    animation: gradient-shift 15s ease-in-out infinite;
+  }
+
+  @keyframes gradient-shift {
+    0%, 100% { transform: translate(0, 0) rotate(0deg); }
+    33% { transform: translate(2%, 2%) rotate(1deg); }
+    66% { transform: translate(-1%, 1%) rotate(-1deg); }
   }
 
   .sidebar-scroll::-webkit-scrollbar {
@@ -127,4 +193,75 @@
     0%, 100% { transform: translateX(-2px); opacity: 0.3; }
     50% { transform: translateX(2px); opacity: 0.6; }
   }
+
+  /* Configurator Animations */
+  @keyframes stagger-reveal {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes scale-in {
+    from {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes slide-in-left {
+    from {
+      opacity: 0;
+      transform: translateX(-30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes slide-in-right {
+    from {
+      opacity: 0;
+      transform: translateX(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes glow-pulse {
+    0%, 100% { box-shadow: 0 0 20px rgba(255, 107, 107, 0.3); }
+    50% { box-shadow: 0 0 40px rgba(255, 107, 107, 0.5); }
+  }
+
+  @keyframes float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-10px); }
+  }
+
+  @keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+
+  /* Animation utilities */
+  .animate-stagger-1 { animation: stagger-reveal 0.6s ease-out 0.1s both; }
+  .animate-stagger-2 { animation: stagger-reveal 0.6s ease-out 0.2s both; }
+  .animate-stagger-3 { animation: stagger-reveal 0.6s ease-out 0.3s both; }
+  .animate-stagger-4 { animation: stagger-reveal 0.6s ease-out 0.4s both; }
+  .animate-stagger-5 { animation: stagger-reveal 0.6s ease-out 0.5s both; }
+  .animate-scale-in { animation: scale-in 0.5s ease-out both; }
+  .animate-slide-left { animation: slide-in-left 0.6s ease-out both; }
+  .animate-slide-right { animation: slide-in-right 0.6s ease-out both; }
+  .animate-float { animation: float 3s ease-in-out infinite; }
 }

--- a/src/features/configurator/components/ColorPaletteGrid.tsx
+++ b/src/features/configurator/components/ColorPaletteGrid.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/ui/Card";
+import { Check, Palette } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+import type { PresetColors } from "@/features/configurator/data";
+
+interface ColorPaletteGridProps {
+  colors: PresetColors;
+  onChange: (colors: PresetColors) => void;
+}
+
+const CURATED_PALETTES: Array<{
+  name: string;
+  colors: PresetColors;
+  description: string;
+}> = [
+  {
+    name: "Ocean",
+    description: "Calm blues and greens",
+    colors: {
+      base: "#0f172a",
+      brand: "#3b82f6",
+      accent: "#06b6d4",
+      chart: "#10b981",
+    },
+  },
+  {
+    name: "Sunset",
+    description: "Warm oranges and pinks",
+    colors: {
+      base: "#1c1917",
+      brand: "#f97316",
+      accent: "#ec4899",
+      chart: "#8b5cf6",
+    },
+  },
+  {
+    name: "Forest",
+    description: "Natural greens and teals",
+    colors: {
+      base: "#14532d",
+      brand: "#22c55e",
+      accent: "#84cc16",
+      chart: "#8b5cf6",
+    },
+  },
+  {
+    name: "Berry",
+    description: "Rich purples and reds",
+    colors: {
+      base: "#2e1065",
+      brand: "#a855f7",
+      accent: "#ec4899",
+      chart: "#f43f5e",
+    },
+  },
+  {
+    name: "Monochrome",
+    description: "Clean grayscale",
+    colors: {
+      base: "#09090b",
+      brand: "#525252",
+      accent: "#a3a3a3",
+      chart: "#404040",
+    },
+  },
+  {
+    name: "Corporate",
+    description: "Professional blues",
+    colors: {
+      base: "#172554",
+      brand: "#1e40af",
+      accent: "#1d4ed8",
+      chart: "#0891b2",
+    },
+  },
+];
+
+export function ColorPaletteGrid({
+  colors,
+  onChange,
+}: ColorPaletteGridProps) {
+  const [hoveredPalette, setHoveredPalette] = useState<string | null>(null);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      {CURATED_PALETTES.map((palette) => {
+        const isSelected =
+          colors.base === palette.colors.base &&
+          colors.brand === palette.colors.brand &&
+          colors.accent === palette.colors.accent &&
+          colors.chart === palette.colors.chart;
+
+        const isHovered = hoveredPalette === palette.name;
+
+        return (
+          <button
+            key={palette.name}
+            onClick={() => onChange(palette.colors)}
+            onMouseEnter={() => setHoveredPalette(palette.name)}
+            onMouseLeave={() => setHoveredPalette(null)}
+            className={cn(
+              "group relative",
+              "transition-all duration-300",
+              "hover:scale-[1.03] hover:-translate-y-1"
+            )}
+          >
+            <Card
+              className={cn(
+                "p-4 border-2 transition-all duration-300 overflow-hidden relative",
+                "bg-[#171717] border-[#333333]",
+                isSelected
+                  ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-lg"
+                  : "hover:border-[#8b5cf6]/50 shadow-md"
+              )}
+            >
+              {/* Animated gradient background */}
+              <div
+                className={cn(
+                  "absolute inset-0 opacity-0 transition-opacity duration-300",
+                  "bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5",
+                  isHovered && "opacity-100"
+                )}
+              />
+
+              {/* Selection indicator */}
+              {isSelected && (
+                <div className="absolute -top-2 -right-2 bg-[#4628f1] text-white rounded-full p-1.5 shadow-lg z-10">
+                  <Check className="w-3 h-3" />
+                </div>
+              )}
+
+              {/* Hover: Palette icon */}
+              {!isSelected && isHovered && (
+                <div className="absolute -top-2 -right-2 bg-[#8b5cf6] text-white rounded-full p-1.5 shadow-lg z-10 animate-scale-in">
+                  <Palette className="w-3 h-3" />
+                </div>
+              )}
+
+              <div className="relative z-10">
+                {/* Color swatches - expand on hover */}
+                <div className="flex gap-1.5 mb-3">
+                  {Object.values(palette.colors).map((color, i) => (
+                    <div
+                      key={i}
+                      className="relative transition-all duration-300"
+                      style={{
+                        width: isHovered || isSelected ? '28px' : '20px',
+                        height: isHovered || isSelected ? '28px' : '20px',
+                      }}
+                    >
+                      <div
+                        className={cn(
+                          "rounded-full border-2 border-[#333333] shadow-md",
+                          "transition-all duration-300 hover:scale-110"
+                        )}
+                        style={{
+                          backgroundColor: color,
+                          transform: isHovered ? `translateY(${(i % 2 === 0 ? -2 : 2)}px)` : 'translateY(0)',
+                        }}
+                      />
+                      {/* Glow effect on hover */}
+                      {isHovered && (
+                        <div
+                          className="absolute inset-0 rounded-full opacity-50 blur-md"
+                          style={{ backgroundColor: color }}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                {/* Palette name */}
+                <p className="text-sm font-bold font-['Space_Grotesk'] text-[#ededed] mb-1">
+                  {palette.name}
+                </p>
+
+                {/* Description - show on hover */}
+                <p
+                  className={cn(
+                    "text-xs transition-all duration-300 overflow-hidden",
+                    isHovered || isSelected ? "max-h-6 opacity-100 text-[#a1a1aa]" : "max-h-0 opacity-0"
+                  )}
+                >
+                  {palette.description}
+                </p>
+              </div>
+
+              {/* Animated border glow */}
+              {isHovered && !isSelected && (
+                <div className="absolute inset-0 rounded-lg animate-glow-pulse pointer-events-none" />
+              )}
+            </Card>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/configurator/components/ComponentGrid.tsx
+++ b/src/features/configurator/components/ComponentGrid.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { Card } from "@/ui/Card";
+import { Search, X, Check } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+import { Input } from "@/ui/Input";
+import { useState, useMemo } from "react";
+
+// Component icons mapping (simplified - using first letter or simple indicators)
+const getComponentIcon = (name: string) => {
+  const firstChar = name.charAt(0);
+  return firstChar;
+};
+
+const getComponentColor = (name: string) => {
+  const colors = [
+    "bg-[#4628f1]", "bg-[#8b5cf6]", "bg-[#a78bfa]", "bg-[#a855f7]",
+    "bg-[#3b82f6]", "bg-[#ec4899]", "bg-[#10b981]", "bg-[#f97316]"
+  ];
+  const index = name.charCodeAt(0) % colors.length;
+  return colors[index];
+};
+
+interface ComponentGridProps {
+  components: string[];
+  selected: string[];
+  onToggle: (component: string) => void;
+  categories: Record<string, string[]>;
+}
+
+export function ComponentGrid({
+  components,
+  selected,
+  onToggle,
+  categories,
+}: ComponentGridProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  // Filter components by search and category
+  const filteredComponents = useMemo(() => {
+    let filtered = components;
+
+    // Filter by category
+    if (selectedCategory) {
+      filtered = filtered.filter((c) =>
+        categories[selectedCategory]?.includes(c)
+      );
+    }
+
+    // Filter by search
+    if (searchQuery) {
+      filtered = filtered.filter((c) =>
+        c.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+    }
+
+    return filtered;
+  }, [components, categories, selectedCategory, searchQuery]);
+
+  // Get selected count per category
+  const getCategoryCount = (category: string) => {
+    return categories[category]?.filter((c) => selected.includes(c)).length || 0;
+  };
+
+  const hasActiveFilters = searchQuery || selectedCategory;
+
+  return (
+    <div className="space-y-6">
+      {/* Search Bar */}
+      <div className="relative">
+        <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 h-4 w-4 text-[#71717a]" />
+        <Input
+          placeholder="Search components..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className={cn(
+            "pl-11 pr-10 bg-[#171717] border-[#333333] text-[#ededed]",
+            "placeholder:text-[#71717a] focus:border-[#4628f1] transition-colors"
+          )}
+        />
+        {searchQuery && (
+          <button
+            onClick={() => setSearchQuery("")}
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-[#71717a] hover:text-[#ededed] transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Category Filter Pills */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => setSelectedCategory(null)}
+          className={cn(
+            "text-xs px-4 py-2 rounded-full font-medium transition-all duration-300",
+            "hover:scale-105 active:scale-95",
+            !selectedCategory
+              ? "bg-[#4628f1] text-white shadow-lg shadow-[#4628f1]/20"
+              : "bg-[#171717] text-[#a1a1aa] border border-[#333333] hover:border-[#8b5cf6] hover:text-[#8b5cf6]"
+          )}
+        >
+          All ({components.length})
+        </button>
+        {Object.entries(categories).map(([category, comps]) => {
+          const count = getCategoryCount(category);
+          const isActive = selectedCategory === category;
+
+          return (
+            <button
+              key={category}
+              onClick={() => setSelectedCategory(category)}
+              className={cn(
+                "text-xs px-4 py-2 rounded-full font-medium transition-all duration-300",
+                "hover:scale-105 active:scale-95 relative",
+                isActive
+                  ? "bg-[#8b5cf6] text-white shadow-lg shadow-[#8b5cf6]/20"
+                  : "bg-[#171717] text-[#a1a1aa] border border-[#333333] hover:border-[#8b5cf6] hover:text-[#8b5cf6]"
+              )}
+            >
+              {category} ({count})
+              {count > 0 && !isActive && (
+                <span className="absolute -top-1 -right-1 w-2 h-2 bg-[#4628f1] rounded-full animate-pulse" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Component Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {filteredComponents.map((component, index) => {
+          const isSelected = selected.includes(component);
+          const iconColor = getComponentColor(component);
+
+          return (
+            <button
+              key={component}
+              onClick={() => onToggle(component)}
+              className={cn(
+                "group relative transition-all duration-300",
+                "hover:scale-[1.03] hover:-translate-y-1"
+              )}
+              style={{ animationDelay: `${index * 20}ms` }}
+            >
+              <Card
+                className={cn(
+                  "p-4 border-2 transition-all duration-300 overflow-hidden relative",
+                  "bg-[#171717] border-[#333333]",
+                  isSelected
+                    ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-lg"
+                    : "hover:border-[#8b5cf6]/50 shadow-md"
+                )}
+              >
+                {/* Animated gradient background on hover */}
+                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5" />
+
+                {/* Selection indicator */}
+                {isSelected && (
+                  <div className="absolute -top-1.5 -right-1.5 bg-[#4628f1] text-white rounded-full p-1 shadow-lg z-10 animate-scale-in">
+                    <Check className="w-3 h-3" />
+                  </div>
+                )}
+
+                <div className="relative z-10">
+                  {/* Icon badge */}
+                  <div className={cn(
+                    "w-10 h-10 rounded-lg flex items-center justify-center mb-3 transition-all duration-300",
+                    iconColor,
+                    isSelected ? "ring-2 ring-white/20" : "opacity-70 group-hover:opacity-100"
+                  )}>
+                    <span className="text-white font-bold text-lg font-['Space_Grotesk']">
+                      {getComponentIcon(component)}
+                    </span>
+                  </div>
+
+                  {/* Component name */}
+                  <p className={cn(
+                    "font-medium text-sm transition-colors duration-300",
+                    isSelected ? "text-[#4628f1]" : "text-[#ededed] group-hover:text-[#8b5cf6]"
+                  )}>
+                    {component}
+                  </p>
+
+                  {/* Selection count badge */}
+                  {isSelected && (
+                    <span className="inline-block mt-2 text-[10px] px-2 py-0.5 rounded-full bg-[#4628f1]/10 text-[#4628f1] font-medium">
+                      Selected
+                    </span>
+                  )}
+                </div>
+              </Card>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Empty state */}
+      {filteredComponents.length === 0 && (
+        <div className="text-center py-16 animate-stagger-1">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#171717] border-2 border-[#333333] mb-4">
+            <Search className="h-6 w-6 text-[#71717a]" />
+          </div>
+          <p className="text-[#a1a1aa] mb-2">No components found</p>
+          <p className="text-sm text-[#71717a] mb-4">
+            Try adjusting your search or filters
+          </p>
+          {hasActiveFilters && (
+            <button
+              onClick={() => {
+                setSearchQuery("");
+                setSelectedCategory(null);
+              }}
+              className="text-sm text-[#4628f1] hover:text-[#ff5252] font-medium transition-colors"
+            >
+              Clear all filters
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/configurator/components/FontCard.tsx
+++ b/src/features/configurator/components/FontCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { memo, useState } from "react";
+import { Card } from "@/ui/Card";
+import { Check, Type } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+
+interface FontCardProps {
+  family: string;
+  category: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export const FontCard = memo(function FontCard({
+  family,
+  category,
+  selected,
+  onSelect,
+}: FontCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  // Sample text for preview
+  const sampleText = "Aa";
+  const displayChars = family.split('').slice(0, 3);
+
+  return (
+    <button
+      onClick={onSelect}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={cn(
+        "relative w-full text-left transition-all duration-300",
+        "hover:shadow-xl hover:scale-[1.03] hover:-translate-y-1",
+        selected && "scale-[1.02] -translate-y-1"
+      )}
+    >
+      <Card
+        className={cn(
+          "p-5 border-2 transition-all duration-300 overflow-hidden relative",
+          "bg-[#171717] border-[#333333]",
+          selected
+            ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-lg"
+            : "hover:border-[#8b5cf6]/50"
+        )}
+      >
+        {/* Animated gradient background */}
+        <div
+          className={cn(
+            "absolute inset-0 opacity-0 transition-opacity duration-300",
+            "bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5",
+            isHovered && "opacity-100"
+          )}
+        />
+
+        {/* Selection indicator */}
+        {selected && (
+          <div className="absolute -top-2 -right-2 bg-[#4628f1] text-white rounded-full p-1.5 shadow-lg z-10">
+            <Check className="w-3.5 h-3.5" />
+          </div>
+        )}
+
+        {/* Hover icon */}
+        {!selected && isHovered && (
+          <div className="absolute -top-2 -right-2 bg-[#8b5cf6] text-white rounded-full p-1.5 shadow-lg z-10 animate-scale-in">
+            <Type className="w-3.5 h-3.5" />
+          </div>
+        )}
+
+        <div className="relative z-10">
+          {/* Large animated character preview */}
+          <div className="mb-3 relative overflow-hidden">
+            <div
+              className={cn(
+                "text-5xl font-bold text-[#ededed] transition-all duration-300",
+                isHovered && "scale-110"
+              )}
+              style={{ fontFamily: family }}
+            >
+              {sampleText}
+            </div>
+            {/* Animated underline */}
+            <div
+              className={cn(
+                "h-0.5 bg-gradient-to-r from-[#4628f1] to-[#8b5cf6] transition-all duration-300",
+                isHovered ? "w-full opacity-100" : "w-0 opacity-0"
+              )}
+            />
+          </div>
+
+          {/* Font name */}
+          <p
+            className={cn(
+              "text-sm font-semibold mb-2 transition-all duration-300",
+              isHovered ? "text-[#4628f1] translate-x-1" : "text-[#ededed]"
+            )}
+            style={{ fontFamily: family }}
+          >
+            {family}
+          </p>
+
+          {/* Sample text - show on hover */}
+          <p
+            className={cn(
+              "text-xs transition-all duration-300 overflow-hidden leading-relaxed",
+              isHovered || selected ? "max-h-12 opacity-100 text-[#a1a1aa]" : "max-h-0 opacity-0"
+            )}
+            style={{ fontFamily: family }}
+          >
+            The quick brown fox
+          </p>
+
+          {/* Category Badge */}
+          <div className="inline-block mt-2">
+            <span className={cn(
+              "text-xs px-2.5 py-1 rounded-full font-medium transition-all duration-300",
+              "bg-[#1f1f1f] text-[#71717a]",
+              isHovered && "bg-[#8b5cf6]/10 text-[#8b5cf6]"
+            )}>
+              {category}
+            </span>
+          </div>
+
+          {/* Weight preview - animate on hover */}
+          <div
+            className={cn(
+              "flex gap-1 mt-3 transition-all duration-300 overflow-hidden",
+              isHovered || selected ? "max-h-8 opacity-100" : "max-h-0 opacity-0"
+            )}
+          >
+            {['R', 'M', 'B'].map((weight, i) => (
+              <span
+                key={weight}
+                className="w-6 h-6 rounded flex items-center justify-center text-[10px] bg-[#1f1f1f] text-[#a1a1aa] animate-stagger-1"
+                style={{
+                  fontFamily: family,
+                  fontWeight: weight === 'R' ? 400 : weight === 'M' ? 500 : 700,
+                  animationDelay: `${i * 50}ms`
+                }}
+              >
+                {weight}
+              </span>
+            ))}
+          </div>
+        </div>
+      </Card>
+    </button>
+  );
+});

--- a/src/features/configurator/components/LivePreviewPanel.tsx
+++ b/src/features/configurator/components/LivePreviewPanel.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Card } from "@/ui/Card";
+import { Button } from "@/ui/Button";
+import { Input } from "@/ui/Input";
+import { Badge } from "@/ui/Badge";
+import { Alert } from "@/ui/Alert";
+import { Dialog } from "@/ui/Dialog";
+import { Select } from "@/ui/Select";
+import { Tabs } from "@/ui/Tabs";
+import { Moon, Sun, Monitor, Smartphone, Sparkles } from "lucide-react";
+import { useWizardStore } from "../stores/useWizardStore";
+import {
+  getStyleProperties,
+  loadGoogleFonts,
+} from "../lib";
+import { cn } from "@/shared/utils/cn";
+
+export function LivePreviewPanel() {
+  const { style, colors, fonts, radius } = useWizardStore();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [tabValue, setTabValue] = useState("tab1");
+  const [selectValue, setSelectValue] = useState("");
+  const [darkMode, setDarkMode] = useState(true);
+  const [device, setDevice] = useState<"desktop" | "mobile">("desktop");
+
+  const styleRef = useRef<HTMLStyleElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Get style preset colors for button styling
+  const styleProps = getStyleProperties(style);
+  const stylePrimary = styleProps["--color-primary"];
+  const styleSecondary = styleProps["--color-secondary"];
+  const styleAccent = styleProps["--color-accent"];
+
+  // Apply style properties and fonts
+  useEffect(() => {
+    const styleProps = getStyleProperties(style);
+
+    if (styleRef.current) {
+      const css = `
+        .preview-container {
+          /* Use style preset colors for components */
+          --style-primary: ${styleProps["--color-primary"]};
+          --style-secondary: ${styleProps["--color-secondary"]};
+          --style-accent: ${styleProps["--color-accent"]};
+
+          /* Map wizard colors to CSS variables */
+          --wizard-brand: ${colors.brand};
+          --wizard-accent: ${colors.accent};
+          --wizard-chart: ${colors.chart};
+          --wizard-base: ${colors.base};
+          --color-primary: ${styleProps["--color-primary"]};
+          --radius: ${getRadiusValue(radius)};
+          --font-header: "${fonts.header}";
+          --font-body: "${fonts.body}";
+          font-family: var(--font-body), sans-serif;
+        }
+        .preview-container h1, .preview-container h2,
+        .preview-container h3, .preview-container h4,
+        .preview-container h5, .preview-container h6 {
+          font-family: var(--font-header), sans-serif;
+        }
+        ${!darkMode ? `
+          .preview-container {
+            background: #ffffff;
+            color: #0f172a;
+            border-color: #e2e8f0;
+          }
+          .preview-container button[variant="primary"],
+          .preview-container button.bg-primary {
+            color: white !important;
+          }
+        ` : ""}
+      `;
+      styleRef.current.innerHTML = css;
+    }
+
+    if (containerRef.current) {
+      // Apply style properties (spacing, typography, colors, etc.)
+      Object.entries(styleProps).forEach(([key, value]) => {
+        containerRef.current!.style.setProperty(key, value);
+      });
+
+      // Set custom color variables
+      containerRef.current.style.setProperty("--wizard-brand", colors.brand);
+      containerRef.current.style.setProperty("--wizard-accent", colors.accent);
+      containerRef.current.style.setProperty("--style-primary", styleProps["--color-primary"]);
+      containerRef.current.style.setProperty("--style-secondary", styleProps["--color-secondary"]);
+      containerRef.current.style.setProperty("--style-accent", styleProps["--color-accent"]);
+      containerRef.current.style.setProperty("--font-header", fonts.header);
+      containerRef.current.style.setProperty("--font-body", fonts.body);
+    }
+  }, [style, colors, fonts, radius, darkMode]);
+
+  // Load fonts
+  useEffect(() => {
+    loadGoogleFonts(fonts.header, fonts.body);
+  }, [fonts]);
+
+  return (
+    <>
+      <style ref={styleRef} />
+
+      {/* Preview Controls */}
+      <div className="flex items-center justify-between mb-4 gap-3">
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant={darkMode ? "primary" : "outline"}
+            onClick={() => setDarkMode(!darkMode)}
+            className={cn(
+              "gap-2 transition-all duration-300",
+              darkMode
+                ? "bg-[#4628f1] hover:bg-[#ff5252] text-white"
+                : "bg-[#171717] border-[#333333] text-[#ededed] hover:bg-[#1f1f1f]"
+            )}
+          >
+            {darkMode ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
+            {darkMode ? "Dark" : "Light"}
+          </Button>
+          <Button
+            size="sm"
+            variant={device === "desktop" ? "primary" : "outline"}
+            onClick={() => setDevice(device === "desktop" ? "mobile" : "desktop")}
+            className={cn(
+              "gap-2 transition-all duration-300",
+              device === "desktop"
+                ? "bg-[#8b5cf6] hover:bg-[#0d9488] text-white"
+                : "bg-[#171717] border-[#333333] text-[#ededed] hover:bg-[#1f1f1f]"
+            )}
+          >
+            {device === "desktop" ? <Monitor className="w-4 h-4" /> : <Smartphone className="w-4 h-4" />}
+            {device === "desktop" ? "Desktop" : "Mobile"}
+          </Button>
+        </div>
+        <span className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full bg-[#8b5cf6]/10 text-[#8b5cf6] font-medium border border-[#8b5cf6]/20">
+          <Sparkles className="w-3 h-3 animate-pulse" />
+          Live
+        </span>
+      </div>
+
+      {/* Preview Container - Glassmorphism */}
+      <div
+        ref={containerRef}
+        className={cn(
+          "preview-container rounded-2xl p-6 border-2 transition-all duration-500 relative overflow-hidden",
+          "backdrop-blur-xl bg-opacity-80",
+          darkMode
+            ? "bg-[#0a0a0a]/90 border-[#333333] shadow-2xl"
+            : "bg-white/90 border-gray-200 shadow-xl"
+        )}
+      >
+        {/* Animated gradient mesh background */}
+        <div className={cn(
+          "absolute inset-0 transition-opacity duration-300",
+          darkMode ? "opacity-30" : "opacity-10"
+        )}>
+          <div className="absolute inset-0 bg-gradient-to-br from-[#4628f1]/10 via-transparent to-[#8b5cf6]/10 animate-float" />
+          <div className="absolute inset-0 bg-gradient-to-tr from-[#a78bfa]/5 via-transparent to-[#8b5cf6]/5 animate-float" style={{ animationDelay: '1s' }} />
+        </div>
+
+        {/* Content scaled based on device */}
+        <div className={cn(
+          "relative z-10 transition-all duration-300",
+          device === "mobile" && "max-w-sm mx-auto"
+        )}>
+          {/* Button Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Buttons</h4>
+            <div className="flex flex-wrap gap-3">
+              <Button
+                variant="primary"
+                className="relative overflow-hidden"
+                style={{
+                  backgroundColor: darkMode ? stylePrimary : adjustColorForLight(stylePrimary),
+                  borderColor: darkMode ? stylePrimary : adjustColorForLight(stylePrimary),
+                  color: shouldUseWhiteText(stylePrimary) ? 'white' : darkMode ? 'white' : '#0f172a'
+                } as React.CSSProperties}
+              >
+                Primary
+              </Button>
+              <Button
+                variant="secondary"
+                style={{
+                  backgroundColor: darkMode ? styleSecondary : adjustColorForLight(styleSecondary),
+                  color: shouldUseWhiteText(styleSecondary) ? 'white' : darkMode ? 'white' : '#0f172a'
+                } as React.CSSProperties}
+              >
+                Secondary
+              </Button>
+              <Button variant="outline">Outline</Button>
+              <Button variant="ghost">Ghost</Button>
+            </div>
+          </div>
+
+          {/* Input Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Inputs</h4>
+            <div className="space-y-3">
+              <Input
+                placeholder="Enter text..."
+                style={{
+                  '--tw-ring-color': stylePrimary,
+                  '--tw-ring-opacity': '0.2'
+                } as React.CSSProperties}
+                className="focus:border-primary focus:ring-primary/20"
+              />
+              <Input placeholder="Disabled" disabled />
+            </div>
+          </div>
+
+          {/* Badge Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Badges</h4>
+            <div className="flex flex-wrap gap-3">
+              <div style={{ backgroundColor: stylePrimary, color: 'white' }} className="inline-flex items-center font-medium rounded-full text-xs px-2.5 py-0.5">
+                Default
+              </div>
+              <Badge variant="success">Success</Badge>
+              <Badge variant="outline">Outline</Badge>
+              <Badge variant="error">Error</Badge>
+            </div>
+          </div>
+
+          {/* Alert Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Alerts</h4>
+            <div className="space-y-3">
+              <div
+                role="alert"
+                className="rounded-xl border p-4"
+                style={{
+                  backgroundColor: darkMode ? stylePrimary + '/20' : adjustColorForLight(stylePrimary) + '/20',
+                  borderColor: stylePrimary,
+                  color: darkMode ? stylePrimary : adjustColorForLight(stylePrimary)
+                } as React.CSSProperties}
+              >
+                Info alert with important information.
+              </div>
+              <Alert variant="success">Success alert confirming action completed.</Alert>
+            </div>
+          </div>
+
+          {/* Dialog Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Dialog</h4>
+            <Button variant="outline" onClick={() => setDialogOpen(true)}>
+              Open Dialog
+            </Button>
+            <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+              <Dialog.Header>
+                <Dialog.Title>Preview Dialog</Dialog.Title>
+              </Dialog.Header>
+              <Dialog.Content>
+                <Dialog.Description>
+                  This is a preview of how dialogs will look with your selected
+                  style.
+                </Dialog.Description>
+              </Dialog.Content>
+              <div className="px-6 py-4">
+                <p className="text-sm">
+                  Dialogs are modal overlays that require user interaction.
+                </p>
+                <Button
+                  onClick={() => setDialogOpen(false)}
+                  className="mt-4"
+                  style={{
+                    backgroundColor: stylePrimary,
+                    borderColor: stylePrimary
+                  } as React.CSSProperties}
+                >
+                  Close
+                </Button>
+              </div>
+            </Dialog>
+          </div>
+
+          {/* Select Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Select</h4>
+            <Select
+              value={selectValue}
+              onChange={(e) => setSelectValue((e.target as HTMLSelectElement).value)}
+              placeholder="Choose option..."
+              style={{
+                '--tw-ring-color': stylePrimary,
+                '--tw-ring-opacity': '0.2'
+              } as React.CSSProperties}
+              className="focus:border-primary focus:ring-primary/20"
+              options={[
+                { value: "1", label: "Option 1" },
+                { value: "2", label: "Option 2" },
+                { value: "3", label: "Option 3" },
+              ]}
+            />
+          </div>
+
+          {/* Tabs Preview */}
+          <div className="mb-6">
+            <h4 className="text-sm font-medium mb-3 opacity-70">Tabs</h4>
+            <Tabs value={tabValue} onChange={setTabValue}>
+              <Tabs.List className="border-b-2" style={{ borderColor: stylePrimary + '/30' } as React.CSSProperties}>
+                <div className="flex gap-4">
+                  <button
+                    onClick={() => setTabValue("tab1")}
+                    className="text-sm font-medium transition-all px-4 py-2.5 -mb-px border-b-2"
+                    style={{
+                      borderColor: tabValue === "tab1" ? stylePrimary : 'transparent',
+                      color: tabValue === "tab1" ? stylePrimary : 'inherit',
+                      opacity: tabValue === "tab1" ? '1' : '0.6'
+                    } as React.CSSProperties}
+                  >
+                    Tab 1
+                  </button>
+                  <button
+                    onClick={() => setTabValue("tab2")}
+                    className="text-sm font-medium transition-all px-4 py-2.5 -mb-px border-b-2"
+                    style={{
+                      borderColor: tabValue === "tab2" ? stylePrimary : 'transparent',
+                      color: tabValue === "tab2" ? stylePrimary : 'inherit',
+                      opacity: tabValue === "tab2" ? '1' : '0.6'
+                    } as React.CSSProperties}
+                  >
+                    Tab 2
+                  </button>
+                  <button
+                    onClick={() => setTabValue("tab3")}
+                    className="text-sm font-medium transition-all px-4 py-2.5 -mb-px border-b-2"
+                    style={{
+                      borderColor: tabValue === "tab3" ? stylePrimary : 'transparent',
+                      color: tabValue === "tab3" ? stylePrimary : 'inherit',
+                      opacity: tabValue === "tab3" ? '1' : '0.6'
+                    } as React.CSSProperties}
+                  >
+                    Tab 3
+                  </button>
+                </div>
+              </Tabs.List>
+              <Tabs.Content value={tabValue} className="mt-4">
+                <p className="text-sm">Content for {tabValue}</p>
+              </Tabs.Content>
+            </Tabs>
+          </div>
+
+          {/* Card Preview */}
+          <div>
+            <h4 className="text-sm font-medium mb-3 opacity-70">Cards</h4>
+            <Card
+              className="p-4"
+              style={{
+                borderColor: stylePrimary + '/30',
+                backgroundColor: darkMode ? '' : '#ffffff'
+              } as React.CSSProperties}
+            >
+              <h5 className="font-semibold mb-2" style={{ color: stylePrimary }}>Card Title</h5>
+              <p className="text-sm opacity-70">
+                Cards are versatile containers for grouping related content.
+              </p>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function getRadiusValue(radius: string): string {
+  const radii: Record<string, string> = {
+    none: "0",
+    sm: "0.25rem",
+    md: "0.5rem",
+    lg: "0.75rem",
+    full: "9999px",
+  };
+  return radii[radius] ?? "0.5rem";
+}
+
+// Helper function to determine if a color should use white text
+function shouldUseWhiteText(hexColor: string): boolean {
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance < 0.5;
+}
+
+// Helper function to adjust color for light mode (add transparency or darken)
+function adjustColorForLight(hexColor: string): string {
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+
+  // If color is already dark, keep it as is for light mode
+  if (luminance < 0.5) {
+    return hexColor;
+  }
+
+  // If color is light, darken it for better contrast on white background
+  const factor = 0.8;
+  const newR = Math.floor(r * factor);
+  const newG = Math.floor(g * factor);
+  const newB = Math.floor(b * factor);
+
+  return `#${newR.toString(16).padStart(2, '0')}${newG.toString(16).padStart(2, '0')}${newB.toString(16).padStart(2, '0')}`;
+}

--- a/src/features/configurator/components/RadiusSelector.tsx
+++ b/src/features/configurator/components/RadiusSelector.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cn } from "@/shared/utils/cn";
+
+interface RadiusSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const OPTIONS = [
+  { value: "none", label: "None", className: "rounded-none" },
+  { value: "sm", label: "Small", className: "rounded-sm" },
+  { value: "md", label: "Medium", className: "rounded-md" },
+  { value: "lg", label: "Large", className: "rounded-lg" },
+  { value: "full", label: "Full", className: "rounded-full" },
+] as const;
+
+export function RadiusSelector({ value, onChange }: RadiusSelectorProps) {
+  return (
+    <div className="flex gap-3">
+      {OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={cn(
+            "flex flex-col items-center gap-2 px-4 py-3 rounded-lg border-2 transition-all duration-200",
+            "hover:border-primary/50 hover:scale-105",
+            value === option.value
+              ? "border-primary bg-primary/5 ring-2 ring-primary/20"
+              : "border-border"
+          )}
+        >
+          {/* Visual Preview */}
+          <div
+            className={cn(
+              "w-12 h-12 bg-muted border-2 border-border",
+              option.className
+            )}
+          />
+
+          {/* Label */}
+          <span className="text-xs font-medium">{option.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/configurator/components/Step1VisualPreset.tsx
+++ b/src/features/configurator/components/Step1VisualPreset.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Card } from "@/ui/Card";
+import { Label } from "@/ui/Label";
+import { Input } from "@/ui/Input";
+import { Select } from "@/ui/Select";
+import { useWizardStore } from "../stores/useWizardStore";
+import { getPopularFonts, getAllIconSets } from "../lib";
+import { StyleCard } from "./StyleCard";
+import { ColorPaletteGrid } from "./ColorPaletteGrid";
+import { FontCard } from "./FontCard";
+import { RadiusSelector } from "./RadiusSelector";
+import { ComponentGrid } from "./ComponentGrid";
+
+export function Step1VisualPreset() {
+  const {
+    style,
+    setStyle,
+    colors,
+    setColors,
+    fonts,
+    setFonts,
+    iconSet,
+    setIconSet,
+    radius,
+    setRadius,
+    components,
+    toggleComponent,
+  } = useWizardStore();
+
+  // Get available fonts and icon sets
+  const popularFonts = getPopularFonts();
+  const iconSets = getAllIconSets();
+
+  // Available components
+  const allComponents = [
+    "Alert",
+    "Avatar",
+    "Badge",
+    "Button",
+    "Calendar",
+    "Card",
+    "Carousel",
+    "Chart",
+    "Checkbox",
+    "Collapsible",
+    "Command",
+    "DataTable",
+    "DatePicker",
+    "Dialog",
+    "Drawer",
+    "Dropdown",
+    "Input",
+    "Label",
+    "Pagination",
+    "Popover",
+    "Progress",
+    "Radio",
+    "Select",
+    "Separator",
+    "Skeleton",
+    "Slider",
+    "Spinner",
+    "Switch",
+    "Tabs",
+    "Textarea",
+    "Toast",
+    "Tooltip",
+  ];
+
+  // Component categories
+  const componentCategories: Record<string, string[]> = {
+    Forms: ["Input", "Textarea", "Select", "Checkbox", "Radio", "Switch", "Slider", "Label"],
+    Feedback: ["Alert", "Progress", "Skeleton", "Spinner", "Toast"],
+    Navigation: ["Tabs", "Pagination", "Breadcrumb", "Command"],
+    Overlays: ["Dialog", "Drawer", "Popover", "Tooltip", "Dropdown"],
+    Data: ["DataTable", "Chart", "Calendar", "DatePicker"],
+    Layout: ["Card", "Separator", "Collapsible", "Avatar", "Badge", "Carousel", "Button"],
+  };
+
+  return (
+    <div className="space-y-8">
+      {/* Style Preset Selection */}
+      <section>
+        <h3 className="text-lg font-semibold mb-4">Style Preset</h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {(["arc", "edge", "soleil"] as const).map((preset) => (
+            <StyleCard
+              key={preset}
+              preset={preset}
+              selected={style === preset}
+              onSelect={() => setStyle(preset)}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Colors */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">Color Palette</h3>
+          <span className="text-sm text-muted-foreground">
+            {components.length} components selected
+          </span>
+        </div>
+
+        {/* Curated Palettes */}
+        <div className="mb-6">
+          <p className="text-sm text-muted-foreground mb-3">
+            Quick presets
+          </p>
+          <ColorPaletteGrid colors={colors} onChange={setColors} />
+        </div>
+
+        {/* Custom Colors */}
+        <div>
+          <p className="text-sm text-muted-foreground mb-3">
+            Custom colors
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <ColorInput
+              label="Base"
+              value={colors.base}
+              onChange={(value) => setColors({ ...colors, base: value })}
+            />
+            <ColorInput
+              label="Brand"
+              value={colors.brand}
+              onChange={(value) => setColors({ ...colors, brand: value })}
+            />
+            <ColorInput
+              label="Accent"
+              value={colors.accent}
+              onChange={(value) => setColors({ ...colors, accent: value })}
+            />
+            <ColorInput
+              label="Chart"
+              value={colors.chart}
+              onChange={(value) => setColors({ ...colors, chart: value })}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Fonts */}
+      <section>
+        <h3 className="text-lg font-semibold mb-4">Typography</h3>
+
+        {/* Header Font */}
+        <div className="mb-6">
+          <Label className="text-sm font-medium mb-3">Header Font</Label>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {popularFonts.map((font) => (
+              <FontCard
+                key={font.family}
+                family={font.family}
+                category={font.category}
+                selected={fonts.header === font.family}
+                onSelect={() => setFonts({ ...fonts, header: font.family })}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Body Font */}
+        <div>
+          <Label className="text-sm font-medium mb-3">Body Font</Label>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {popularFonts.map((font) => (
+              <FontCard
+                key={font.family}
+                family={font.family}
+                category={font.category}
+                selected={fonts.body === font.family}
+                onSelect={() => setFonts({ ...fonts, body: font.family })}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Icon Set */}
+      <section>
+        <h3 className="text-lg font-semibold mb-4">Icon Set</h3>
+        <Select
+          value={iconSet}
+          onChange={(e) => setIconSet((e.target as HTMLSelectElement).value)}
+          placeholder="Select icon set"
+          options={iconSets.map((set) => ({ value: set.prefix, label: set.name }))}
+        />
+      </section>
+
+      {/* Border Radius */}
+      <section>
+        <h3 className="text-lg font-semibold mb-4">Border Radius</h3>
+        <RadiusSelector value={radius} onChange={(val) => setRadius(val as any)} />
+      </section>
+
+      {/* Components */}
+      <section>
+        <h3 className="text-lg font-semibold mb-4">
+          Components ({components.length} selected)
+        </h3>
+        <ComponentGrid
+          components={allComponents}
+          selected={components}
+          onToggle={toggleComponent}
+          categories={componentCategories}
+        />
+      </section>
+    </div>
+  );
+}
+
+interface ColorInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ColorInput({ label, value, onChange }: ColorInputProps) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">{label}</Label>
+      <div className="flex gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="w-12 h-10 rounded-lg cursor-pointer border-2 border-border transition-colors hover:border-primary/50"
+        />
+        <Input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="#000000"
+          className="flex-1"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/configurator/components/Step2ProjectStack.tsx
+++ b/src/features/configurator/components/Step2ProjectStack.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/ui/Card";
+import { Switch } from "@/ui/Switch";
+import { useWizardStore } from "../stores/useWizardStore";
+import { cn } from "@/shared/utils/cn";
+import {
+  Database,
+  Server,
+  Zap,
+  FileText,
+  GitBranch,
+  Globe,
+  Check,
+} from "lucide-react";
+
+export function Step2ProjectStack() {
+  const {
+    framework,
+    setFramework,
+    toggleStateManagement,
+    toggleDataFetching,
+    toggleForms,
+    toggleMonorepo,
+    toggleRtl,
+    stateManagement,
+    dataFetching,
+    forms,
+    monorepo,
+    rtl,
+  } = useWizardStore();
+
+  const [hoveredFramework, setHoveredFramework] = useState<string | null>(null);
+
+  const frameworks = [
+    {
+      id: "nextjs",
+      name: "Next.js",
+      description: "React framework with App Router, RSC, and built-in routing",
+      icon: Server,
+      features: ["App Router", "Server Components", "File-based routing", "API routes"],
+      color: "#ffffff",
+    },
+    {
+      id: "vite",
+      name: "Vite",
+      description: "Fast build tool with React, ideal for SPA development",
+      icon: Zap,
+      features: ["Lightning fast HMR", "Optimized build", "Framework agnostic", "Rich plugin ecosystem"],
+      color: "#646cff",
+    },
+  ] as const;
+
+  const stackFeatures = [
+    {
+      id: "stateManagement",
+      title: "State Management",
+      description: "Zustand for global state management",
+      icon: Database,
+      checked: stateManagement,
+      onChange: toggleStateManagement,
+      recommended: true,
+      color: "bg-[#3b82f6]",
+    },
+    {
+      id: "dataFetching",
+      title: "Data Fetching",
+      description: "TanStack Query for server state management",
+      icon: Server,
+      checked: dataFetching,
+      onChange: toggleDataFetching,
+      recommended: true,
+      color: "bg-[#a855f7]",
+    },
+    {
+      id: "forms",
+      title: "Forms",
+      description: "React Hook Form + Zod for form validation",
+      icon: FileText,
+      checked: forms,
+      onChange: toggleForms,
+      recommended: true,
+      color: "bg-[#10b981]",
+    },
+    {
+      id: "monorepo",
+      title: "Monorepo",
+      description: "Configure for Turborepo/pnpm workspace setup",
+      icon: GitBranch,
+      checked: monorepo,
+      onChange: toggleMonorepo,
+      recommended: false,
+      color: "bg-[#f97316]",
+    },
+    {
+      id: "rtl",
+      title: "RTL Support",
+      description: "Add RTL (right-to-left) layout support",
+      icon: Globe,
+      checked: rtl,
+      onChange: toggleRtl,
+      recommended: false,
+      color: "bg-[#ec4899]",
+    },
+  ] as const;
+
+  return (
+    <div className="space-y-10">
+      {/* Framework Picker */}
+      <section className="animate-stagger-1">
+        <h3 className="text-2xl font-bold mb-6 font-['Space_Grotesk'] text-[#ededed]">Framework</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {frameworks.map((fw) => {
+            const Icon = fw.icon;
+            const isSelected = framework === fw.id;
+            const isHovered = hoveredFramework === fw.id;
+
+            return (
+              <button
+                key={fw.id}
+                onClick={() => setFramework(fw.id)}
+                onMouseEnter={() => setHoveredFramework(fw.id)}
+                onMouseLeave={() => setHoveredFramework(null)}
+                className={cn(
+                  "relative w-full text-left transition-all duration-300 group",
+                  "hover:scale-[1.02] hover:-translate-y-1"
+                )}
+              >
+                <Card
+                  className={cn(
+                    "p-6 border-2 transition-all duration-300 overflow-hidden relative",
+                    "bg-[#171717] border-[#333333]",
+                    isSelected
+                      ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-xl"
+                      : "hover:border-[#8b5cf6]/50 shadow-lg"
+                  )}
+                >
+                  {/* Animated gradient background */}
+                  <div className={cn(
+                    "absolute inset-0 opacity-0 transition-opacity duration-300",
+                    "bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5",
+                    isHovered && "opacity-100"
+                  )} />
+
+                  {/* Selection indicator */}
+                  {isSelected && (
+                    <div className="absolute -top-2 -right-2 bg-[#4628f1] text-white rounded-full p-1.5 shadow-lg z-10">
+                      <Check className="w-4 h-4" />
+                    </div>
+                  )}
+
+                  <div className="relative z-10">
+                    <div className="flex items-start gap-4">
+                      <div className={cn(
+                        "p-3 rounded-xl transition-all duration-300",
+                        isSelected
+                          ? "bg-[#4628f1]/20 ring-2 ring-[#4628f1]/30"
+                          : isHovered
+                          ? "bg-[#8b5cf6]/20 ring-2 ring-[#8b5cf6]/30"
+                          : "bg-[#1f1f1f]"
+                      )}>
+                        <Icon className={cn(
+                          "w-7 h-7 transition-all duration-300",
+                          isSelected ? "text-[#4628f1]" : isHovered ? "text-[#8b5cf6]" : "text-[#a1a1aa]"
+                        )} />
+                      </div>
+                      <div className="flex-1">
+                        <h4 className={cn(
+                          "font-bold text-xl mb-2 font-['Space_Grotesk'] transition-colors duration-300",
+                          isSelected ? "text-[#4628f1]" : "text-[#ededed]"
+                        )}>
+                          {fw.name}
+                        </h4>
+                        <p className="text-sm text-[#a1a1aa] mb-4 leading-relaxed">
+                          {fw.description}
+                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {fw.features.map((feature, i) => (
+                            <span
+                              key={feature}
+                              className={cn(
+                                "text-xs px-2.5 py-1 rounded-full font-medium transition-all duration-300",
+                                "bg-[#1f1f1f] text-[#71717a]",
+                                "animate-stagger-" + ((i % 5) + 1)
+                              )}
+                            >
+                              {feature}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Stack Features */}
+      <section className="animate-stagger-2">
+        <h3 className="text-2xl font-bold mb-6 font-['Space_Grotesk'] text-[#ededed]">Stack Features</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {stackFeatures.map((feature, index) => {
+            const Icon = feature.icon;
+
+            return (
+              <Card
+                key={feature.id}
+                className={cn(
+                  "p-5 border-2 transition-all duration-300 relative overflow-hidden group",
+                  "bg-[#171717] border-[#333333]",
+                  feature.checked
+                    ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-lg"
+                    : "hover:border-[#8b5cf6]/50"
+                )}
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                {/* Animated gradient background */}
+                <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5" />
+
+                <div className="relative z-10">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-start gap-3 flex-1 min-w-0">
+                      <div
+                        className={cn(
+                          "p-2.5 rounded-xl transition-all duration-300 flex-shrink-0",
+                          feature.checked ? feature.color : "bg-[#1f1f1f]",
+                          feature.checked && "ring-2 ring-white/20 shadow-lg"
+                        )}
+                      >
+                        <Icon className="w-5 h-5 text-white" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h4 className={cn(
+                          "font-bold text-base leading-tight transition-colors duration-300",
+                          feature.checked ? "text-[#4628f1]" : "text-[#ededed]"
+                        )}>
+                          {feature.title}
+                        </h4>
+                        {feature.recommended && (
+                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-[#8b5cf6]/10 text-[#8b5cf6] font-medium uppercase tracking-wide inline-block mt-1">
+                            Recommended
+                          </span>
+                        )}
+                        <p className="text-sm text-[#a1a1aa] leading-relaxed mt-1">
+                          {feature.description}
+                        </p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={feature.checked}
+                      onChange={feature.onChange}
+                      className="mt-1 flex-shrink-0"
+                    />
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/features/configurator/components/Step3Generate.tsx
+++ b/src/features/configurator/components/Step3Generate.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/ui/Card";
+import { Button } from "@/ui/Button";
+import { Check, Copy, Download, Share2, X, Palette, Code, Database, Globe, Layers } from "lucide-react";
+import { useWizardStore } from "../stores/useWizardStore";
+import { encodePreset } from "../lib";
+import { cn } from "@/shared/utils/cn";
+
+export function Step3Generate() {
+  const wizardState = useWizardStore();
+  const [copied, setCopied] = useState<"cli" | "url" | null>(null);
+
+  // Encode the preset
+  const encodedPreset = encodePreset(wizardState.getPresetConfig());
+
+  // Generate CLI command and share URL
+  const cliCommand = `npx react-principles create my-app --preset ${encodedPreset}`;
+  const shareUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/create?preset=${encodedPreset}`;
+
+  // Get selections summary
+  const selections = {
+    style: wizardState.style,
+    framework: wizardState.framework,
+    stateManagement: wizardState.stateManagement,
+    dataFetching: wizardState.dataFetching,
+    forms: wizardState.forms,
+    monorepo: wizardState.monorepo,
+    rtl: wizardState.rtl,
+    componentCount: wizardState.components.length,
+    iconSet: wizardState.iconSet,
+  };
+
+  const copyToClipboard = async (text: string, type: "cli" | "url") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(type);
+      setTimeout(() => setCopied(null), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  const handleStartOver = () => {
+    wizardState.resetAll();
+    wizardState.setCurrentStep("visual");
+  };
+
+  return (
+    <div className="space-y-8 animate-stagger-1">
+      {/* Configuration Summary */}
+      <div className="animate-stagger-1">
+        <h3 className="text-2xl font-bold mb-6 font-['Space_Grotesk'] text-[#ededed]">Configuration Summary</h3>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <SummaryCard
+            icon={<Palette className="w-4 h-4" />}
+            label="Style"
+            value={capitalize(selections.style)}
+            color="bg-[#4628f1]/10 text-[#4628f1]"
+          />
+          <SummaryCard
+            icon={<Code className="w-4 h-4" />}
+            label="Framework"
+            value={capitalize(selections.framework)}
+            color="bg-[#8b5cf6]/10 text-[#8b5cf6]"
+          />
+          <SummaryCard
+            icon={<Globe className="w-4 h-4" />}
+            label="Icon Set"
+            value={getIconSetName(selections.iconSet)}
+            color="bg-[#a78bfa]/10 text-[#a78bfa]"
+          />
+          <SummaryCard
+            icon={<Layers className="w-4 h-4" />}
+            label="Components"
+            value={`${selections.componentCount} selected`}
+            color="bg-[#a855f7]/10 text-[#a855f7]"
+          />
+          <SummaryCard
+            icon={<Database className="w-4 h-4" />}
+            label="State Management"
+            value={selections.stateManagement ? "Zustand" : "None"}
+            color={selections.stateManagement ? "bg-[#3b82f6]/10 text-[#3b82f6]" : "bg-[#71717a]/10 text-[#71717a]"}
+          />
+          <SummaryCard
+            icon={<Globe className="w-4 h-4" />}
+            label="Data Fetching"
+            value={selections.dataFetching ? "TanStack Query" : "None"}
+            color={selections.dataFetching ? "bg-[#a855f7]/10 text-[#a855f7]" : "bg-[#71717a]/10 text-[#71717a]"}
+          />
+          <SummaryCard
+            icon={<Copy className="w-4 h-4" />}
+            label="Forms"
+            value={selections.forms ? "RHF + Zod" : "None"}
+            color={selections.forms ? "bg-[#10b981]/10 text-[#10b981]" : "bg-[#71717a]/10 text-[#71717a]"}
+          />
+          <SummaryCard
+            icon={<Layers className="w-4 h-4" />}
+            label="Monorepo"
+            value={selections.monorepo ? "Yes" : "No"}
+            color={selections.monorepo ? "bg-[#f97316]/10 text-[#f97316]" : "bg-[#71717a]/10 text-[#71717a]"}
+          />
+        </div>
+      </div>
+
+      {/* CLI Command */}
+      <Card className={cn(
+        "p-6 border-2 bg-[#171717] border-[#333333] transition-all duration-300 animate-stagger-2",
+        "hover:border-[#4628f1]/50 hover:shadow-xl"
+      )}>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-bold font-['Space_Grotesk'] text-[#ededed] mb-1">CLI Command</h3>
+            <p className="text-sm text-[#a1a1aa]">
+              Run this command in your terminal to generate your project
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => copyToClipboard(cliCommand, "cli")}
+            className={cn(
+              "gap-2 transition-all duration-300",
+              "bg-[#1f1f1f] border-[#333333] text-[#ededed]",
+              "hover:bg-[#4628f1] hover:border-[#4628f1] hover:text-white"
+            )}
+          >
+            {copied === "cli" ? (
+              <>
+                <Check className="w-4 h-4" /> Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="w-4 h-4" /> Copy
+              </>
+            )}
+          </Button>
+        </div>
+        <div className={cn(
+          "bg-[#0a0a0a] p-5 rounded-xl font-mono text-sm border-2 transition-all duration-300",
+          copied === "cli" ? "border-[#4628f1] shadow-lg shadow-[#4628f1]/20" : "border-[#333333] hover:border-[#4628f1]/50",
+          "overflow-x-auto"
+        )}>
+          <code className="text-[#8b5cf6] break-all">
+            <span className="text-[#a855f7]">npx</span> react-principles create <span className="text-[#a78bfa]">my-app</span> --preset {encodedPreset.slice(0, 30)}...
+          </code>
+        </div>
+      </Card>
+
+      {/* Share URL */}
+      <Card className={cn(
+        "p-6 border-2 bg-[#171717] border-[#333333] transition-all duration-300 animate-stagger-3",
+        "hover:border-[#8b5cf6]/50 hover:shadow-xl"
+      )}>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-bold font-['Space_Grotesk'] text-[#ededed] mb-1">Share URL</h3>
+            <p className="text-sm text-[#a1a1aa]">
+              Share this URL to let others generate the same configuration
+            </p>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => copyToClipboard(shareUrl, "url")}
+            className={cn(
+              "gap-2 transition-all duration-300",
+              "bg-[#1f1f1f] border-[#333333] text-[#ededed]",
+              "hover:bg-[#8b5cf6] hover:border-[#8b5cf6] hover:text-white"
+            )}
+          >
+            {copied === "url" ? (
+              <>
+                <Check className="w-4 h-4" /> Copied!
+              </>
+            ) : (
+              <>
+                <Copy className="w-4 h-4" /> Copy
+              </>
+            )}
+          </Button>
+        </div>
+        <div className={cn(
+          "bg-[#0a0a0a] p-5 rounded-xl font-mono text-sm border-2 transition-all duration-300 mb-4",
+          copied === "url" ? "border-[#8b5cf6] shadow-lg shadow-[#8b5cf6]/20" : "border-[#333333] hover:border-[#8b5cf6]/50",
+          "overflow-x-auto"
+        )}>
+          <code className="text-[#4628f1] break-all">
+            {shareUrl}
+          </code>
+        </div>
+
+        {/* Social Share Buttons */}
+        <div className="flex gap-3">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              const text = `Check out my React starter configuration!`;
+              const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
+              window.open(url, "_blank");
+            }}
+            className={cn(
+              "flex-1 gap-2 transition-all duration-300",
+              "bg-[#1f1f1f] border-[#333333] text-[#ededed]",
+              "hover:bg-[#000000] hover:border-[#ffffff] hover:text-white"
+            )}
+          >
+            <X className="w-4 h-4" />
+            <span>Tweet</span>
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              navigator.clipboard.writeText(shareUrl);
+              alert("URL copied to clipboard!");
+            }}
+            className={cn(
+              "flex-1 gap-2 transition-all duration-300",
+              "bg-[#1f1f1f] border-[#333333] text-[#ededed]",
+              "hover:bg-[#8b5cf6] hover:border-[#8b5cf6] hover:text-white"
+            )}
+          >
+            <Share2 className="w-4 h-4" />
+            <span>Share</span>
+          </Button>
+        </div>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex gap-4 animate-stagger-4">
+        <Button
+          variant="destructive"
+          onClick={handleStartOver}
+          size="lg"
+          className={cn(
+            "flex-1 transition-all duration-300",
+            "bg-[#f43f5e] hover:bg-[#e11d48] text-white font-semibold"
+          )}
+        >
+          Start Over
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => {
+            const config = wizardState.getPresetConfig();
+            const blob = new Blob([JSON.stringify(config, null, 2)], {
+              type: "application/json",
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `react-principles-config.json`;
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
+          size="lg"
+          className={cn(
+            "flex-1 gap-2 transition-all duration-300",
+            "bg-[#171717] border-[#333333] text-[#ededed]",
+            "hover:bg-[#10b981] hover:border-[#10b981] hover:text-white font-semibold"
+          )}
+        >
+          <Download className="w-4 h-4" />
+          <span>Download Config</span>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface SummaryCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  color: string;
+}
+
+function SummaryCard({ icon, label, value, color }: SummaryCardProps) {
+  return (
+    <Card className={cn(
+      "p-4 border-2 bg-[#171717] border-[#333333] transition-all duration-300",
+      "hover:scale-105 hover:-translate-y-1 hover:shadow-lg",
+      "hover:border-[#4628f1]/50 group relative z-10"
+    )}>
+      <div className="flex items-start gap-3">
+        <div className={cn("p-2 rounded-lg flex-shrink-0", color)}>
+          {icon}
+        </div>
+        <div className="flex-1 min-w-0 overflow-hidden">
+          <div className="text-xs text-[#71717a] font-medium uppercase tracking-wide mb-1">
+            {label}
+          </div>
+          <div className="font-semibold text-[#ededed] text-sm truncate group-hover:text-[#4628f1] transition-colors leading-tight">
+            {value}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function getIconSetName(iconSet: string): string {
+  const names: Record<string, string> = {
+    "material-symbols": "Material Symbols",
+    lucide: "Lucide",
+    ph: "Phosphor",
+    heroicons: "Heroicons",
+    tabler: "Tabler",
+    fa: "Font Awesome",
+    feather: "Feather",
+    flowbite: "Flowbite",
+  };
+  return names[iconSet] || capitalize(iconSet);
+}

--- a/src/features/configurator/components/StyleCard.tsx
+++ b/src/features/configurator/components/StyleCard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { memo, useState } from "react";
+import { Card } from "@/ui/Card";
+import { Check } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+import type { StylePreset } from "@/features/configurator/data";
+
+interface StyleCardProps {
+  preset: StylePreset;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export const StyleCard = memo(function StyleCard({
+  preset,
+  selected,
+  onSelect,
+}: StyleCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const config = {
+    arc: {
+      name: "Arc",
+      description: "Rounded, friendly, generous spacing",
+      colors: ["#3b82f6", "#8b5cf6", "#10b981"],
+      borderRadius: "0.5rem",
+      previewComponents: ["Button", "Card", "Input"],
+    },
+    edge: {
+      name: "Edge",
+      description: "Sharp, high-contrast, minimal decoration",
+      colors: ["#0f172a", "#3b82f6", "#6366f1"],
+      borderRadius: "0rem",
+      previewComponents: ["Button", "Card", "Badge"],
+    },
+    soleil: {
+      name: "Soleil",
+      description: "Warm, editorial, expressive",
+      colors: ["#a78bfa", "#ec4899", "#8b5cf6"],
+      borderRadius: "0.375rem",
+      previewComponents: ["Button", "Card", "Alert"],
+    },
+  };
+
+  const style = config[preset];
+
+  return (
+    <button
+      onClick={onSelect}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={cn(
+        "relative w-full text-left transition-all duration-300",
+        "hover:shadow-xl hover:scale-[1.03] hover:-translate-y-1",
+        selected && "scale-[1.02] -translate-y-1"
+      )}
+    >
+      <Card
+        className={cn(
+          "p-5 border-2 transition-all duration-300 overflow-hidden relative",
+          "bg-[#171717] border-[#333333]",
+          selected
+            ? "border-[#4628f1] bg-[#4628f1]/5 ring-2 ring-[#4628f1]/20 shadow-lg"
+            : "hover:border-[#4628f1]/50"
+        )}
+      >
+        {/* Animated background gradient on hover */}
+        <div
+          className={cn(
+            "absolute inset-0 opacity-0 transition-opacity duration-300",
+            "bg-gradient-to-br from-[#4628f1]/5 via-transparent to-[#8b5cf6]/5",
+            isHovered && "opacity-100"
+          )}
+        />
+
+        {selected && (
+          <div className="absolute -top-2 -right-2 bg-[#4628f1] text-white rounded-full p-1.5 shadow-lg z-10 animate-scale-in">
+            <Check className="w-3.5 h-3.5" />
+          </div>
+        )}
+
+        <div className="relative z-10">
+          <h3 className="font-bold text-xl mb-2 font-['Space_Grotesk'] text-[#ededed]">
+            {style.name}
+          </h3>
+          <p className="text-sm text-[#a1a1aa] mb-4 leading-relaxed">
+            {style.description}
+          </p>
+
+          {/* Preview colors */}
+          <div className="flex gap-2 mb-4">
+            {style.colors.map((color, i) => (
+              <div
+                key={i}
+                className="w-10 h-10 rounded-full border-2 border-[#333333] shadow-md transition-transform hover:scale-110"
+                style={{
+                  backgroundColor: color,
+                  transform: isHovered ? `translateY(${(i - 1) * -4}px)` : 'translateY(0)',
+                  transition: 'transform 0.3s ease'
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Hover reveal: Mini UI preview */}
+          <div
+            className={cn(
+              "transition-all duration-300 overflow-hidden",
+              isHovered || selected ? "max-h-24 opacity-100 mt-4" : "max-h-0 opacity-0"
+            )}
+          >
+            <div className="flex items-center gap-2 text-xs text-[#71717a] mb-2">
+              <span className="font-semibold uppercase tracking-wider">Preview</span>
+              <div className="flex-1 h-px bg-[#333333]" />
+            </div>
+            <div className="flex gap-2">
+              {style.previewComponents.map((component, i) => (
+                <span
+                  key={component}
+                  className={cn(
+                    "px-2 py-1 rounded-md text-xs font-medium bg-[#1f1f1f] text-[#a1a1aa]",
+                    "animate-stagger-" + ((i % 5) + 1)
+                  )}
+                  style={{ borderRadius: style.borderRadius }}
+                >
+                  {component}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Border radius preview */}
+          <div className="flex items-center gap-2 mt-3">
+            <span className="text-xs text-[#71717a] font-medium">Radius:</span>
+            <div
+              className="w-16 h-10 bg-[#1f1f1f] border-2 border-[#333333] transition-all duration-300"
+              style={{ borderRadius: style.borderRadius }}
+            />
+          </div>
+        </div>
+      </Card>
+    </button>
+  );
+});

--- a/src/features/configurator/components/index.ts
+++ b/src/features/configurator/components/index.ts
@@ -1,0 +1,4 @@
+export { Step1VisualPreset } from "./Step1VisualPreset";
+export { Step2ProjectStack } from "./Step2ProjectStack";
+export { Step3Generate } from "./Step3Generate";
+export { LivePreviewPanel } from "./LivePreviewPanel";

--- a/src/features/configurator/data/config-schema.ts
+++ b/src/features/configurator/data/config-schema.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+/**
+ * Preset configuration schema for the Configurator wizard
+ * This defines the complete state that gets encoded/decoded
+ */
+
+// Style presets
+export type StylePreset = "arc" | "edge" | "soleil";
+
+// Radius options
+export type RadiusOption = "none" | "sm" | "md" | "lg" | "full";
+
+// Framework options
+export type FrameworkOption = "nextjs" | "vite";
+
+// Color configuration
+export interface PresetColors {
+  base: string; // Base color (hex)
+  brand: string; // Brand/primary color (hex)
+  accent: string; // Accent color (hex)
+  chart: string; // Chart color (hex)
+}
+
+// Font configuration
+export interface PresetFonts {
+  header: string; // Google Font name for headers
+  body: string; // Google Font name for body text
+}
+
+// Stack configuration
+export interface PresetStack {
+  framework: FrameworkOption;
+  stateManagement: boolean; // Zustand
+  dataFetching: boolean; // TanStack Query
+  forms: boolean; // React Hook Form + Zod
+  monorepo: boolean;
+  rtl: boolean;
+}
+
+/**
+ * Complete preset configuration
+ * Used throughout the Configurator wizard
+ */
+export interface PresetConfig {
+  style: StylePreset;
+  colors: PresetColors;
+  fonts: PresetFonts;
+  iconSet: string; // Iconify collection name
+  radius: RadiusOption;
+  components: string[]; // Selected component names
+  stack: PresetStack;
+  version: number; // Schema version for migration
+}
+
+// Zod schema for validation
+export const presetColorsSchema = z.object({
+  base: z.string().regex(/^#[0-9A-Fa-f]{6}$/, "Invalid hex color"),
+  brand: z.string().regex(/^#[0-9A-Fa-f]{6}$/, "Invalid hex color"),
+  accent: z.string().regex(/^#[0-9A-Fa-f]{6}$/, "Invalid hex color"),
+  chart: z.string().regex(/^#[0-9A-Fa-f]{6}$/, "Invalid hex color"),
+});
+
+export const presetFontsSchema = z.object({
+  header: z.string().min(1, "Header font is required"),
+  body: z.string().min(1, "Body font is required"),
+});
+
+export const presetStackSchema = z.object({
+  framework: z.enum(["nextjs", "vite"]),
+  stateManagement: z.boolean(),
+  dataFetching: z.boolean(),
+  forms: z.boolean(),
+  monorepo: z.boolean(),
+  rtl: z.boolean(),
+});
+
+export const presetConfigSchema = z.object({
+  style: z.enum(["arc", "edge", "soleil"]),
+  colors: presetColorsSchema,
+  fonts: presetFontsSchema,
+  iconSet: z.string().min(1, "Icon set is required"),
+  radius: z.enum(["none", "sm", "md", "lg", "full"]),
+  components: z.array(z.string()),
+  stack: presetStackSchema,
+  version: z.number().int().positive(),
+});
+
+export type ValidatedPresetConfig = z.infer<typeof presetConfigSchema>;

--- a/src/features/configurator/data/default-config.ts
+++ b/src/features/configurator/data/default-config.ts
@@ -1,0 +1,38 @@
+import type { PresetConfig } from "./config-schema";
+
+/**
+ * Default preset configuration
+ * Used as safe fallback when decoding fails
+ */
+export const DEFAULT_PRESET: PresetConfig = {
+  style: "arc",
+  colors: {
+    // Tailwind CSS default colors
+    base: "#0f172a", // slate-900
+    brand: "#3b82f6", // blue-500
+    accent: "#8b5cf6", // violet-500
+    chart: "#10b981", // emerald-500
+  },
+  fonts: {
+    header: "Inter",
+    body: "Inter",
+  },
+  iconSet: "material-symbols",
+  radius: "md",
+  components: [], // User selects components
+  stack: {
+    framework: "nextjs",
+    stateManagement: true, // Zustand
+    dataFetching: true, // TanStack Query
+    forms: true, // React Hook Form + Zod
+    monorepo: false,
+    rtl: false,
+  },
+  version: 1,
+};
+
+/**
+ * Schema version constant
+ * Increment this when breaking changes are made to PresetConfig
+ */
+export const PRESET_SCHEMA_VERSION = 1;

--- a/src/features/configurator/data/dependency-map.ts
+++ b/src/features/configurator/data/dependency-map.ts
@@ -1,0 +1,244 @@
+/**
+ * Dependency Map - Component and Stack to npm packages mapping
+ * Used by CLI to install required packages
+ */
+
+export interface PackageEntry {
+  name: string;
+  version?: string; // If not specified, uses latest
+  dev?: boolean; // Whether to install as devDependency
+}
+
+/**
+ * Component → npm packages mapping
+ */
+export const COMPONENT_DEPENDENCIES: Record<string, PackageEntry[]> = {
+  // Data Display
+  DataTable: [
+    { name: "@tanstack/react-table", version: "^8.20.0" },
+    { name: "@tanstack/table-core", version: "^8.20.0" },
+  ],
+  Chart: [
+    { name: "recharts", version: "^2.15.0" },
+  ],
+
+  // Forms
+  DatePicker: [
+    { name: "react-day-picker", version: "^9.1.4" },
+    { name: "date-fns", version: "^4.1.0" },
+  ],
+  Calendar: [
+    { name: "react-day-picker", version: "^9.1.4" },
+    { name: "date-fns", version: "^4.1.0" },
+  ],
+
+  // Feedback
+  Alert: [], // No external dependencies
+  Badge: [], // No external dependencies
+  Progress: [], // No external dependencies
+  Skeleton: [], // No external dependencies
+  Spinner: [], // No external dependencies
+  Toast: [
+    { name: "sonner", version: "^2.0.0" },
+  ],
+
+  // Input
+  Input: [], // No external dependencies
+  Textarea: [], // No external dependencies
+  Select: [
+    { name: "@radix-ui/react-select", version: "^2.1.6" },
+  ],
+  Checkbox: [
+    { name: "@radix-ui/react-checkbox", version: "^1.1.4" },
+  ],
+  Radio: [
+    { name: "@radix-ui/react-radio-group", version: "^1.2.3" },
+  ],
+  Switch: [
+    { name: "@radix-ui/react-switch", version: "^1.1.3" },
+  ],
+  Slider: [
+    { name: "@radix-ui/react-slider", version: "^1.2.3" },
+  ],
+
+  // Navigation
+  Tabs: [
+    { name: "@radix-ui/react-tabs", version: "^1.1.3" },
+  ],
+  Breadcrumbs: [], // No external dependencies
+  Pagination: [], // No external dependencies
+
+  // Overlays
+  Dialog: [
+    { name: "@radix-ui/react-dialog", version: "^1.1.6" },
+  ],
+  Popover: [
+    { name: "@radix-ui/react-popover", version: "^1.1.6" },
+  ],
+  Tooltip: [
+    { name: "@radix-ui/react-tooltip", version: "^1.1.8" },
+  ],
+  Drawer: [
+    { name: "@radix-ui/react-dialog", version: "^1.1.6" },
+  ],
+
+  // Layout
+  Card: [], // No external dependencies
+  Separator: [
+    { name: "@radix-ui/react-separator", version: "^1.1.2" },
+  ],
+  Collapsible: [
+    { name: "@radix-ui/react-collapsible", version: "^1.1.3" },
+  ],
+
+  // Other
+  Avatar: [], // No external dependencies
+  Button: [], // No external dependencies
+  Dropdown: [
+    { name: "@radix-ui/react-dropdown-menu", version: "^2.1.6" },
+  ],
+  Carousel: [
+    { name: "embla-carousel-react", version: "^8.5.0" },
+  ],
+};
+
+/**
+ * Stack feature → npm packages mapping
+ */
+export const STACK_DEPENDENCIES: Record<
+  string,
+  PackageEntry[]
+> = {
+  stateManagement: [
+    { name: "zustand", version: "^5.0.0" },
+  ],
+  dataFetching: [
+    { name: "@tanstack/react-query", version: "^5.59.0" },
+  ],
+  forms: [
+    { name: "react-hook-form", version: "^7.53.0" },
+    { name: "zod", version: "^4.3.6" },
+    { name: "@hookform/resolvers", version: "^3.9.1" },
+  ],
+  testing: [
+    { name: "vitest", version: "^2.1.8", dev: true },
+    { name: "@testing-library/react", version: "^16.1.0", dev: true },
+    { name: "@testing-library/jest-dom", version: "^6.6.3", dev: true },
+    { name: "@testing-library/user-event", version: "^14.5.2", dev: true },
+  ],
+};
+
+/**
+ * Get all dependencies for selected components
+ * Automatically deduplicates packages
+ */
+export function getComponentDependencies(
+  components: string[]
+): PackageEntry[] {
+  const dependencies = new Map<string, PackageEntry>();
+
+  components.forEach((component) => {
+    const deps = COMPONENT_DEPENDENCIES[component] || [];
+    deps.forEach((dep) => {
+      const key = `${dep.name}@${dep.version || "latest"}`;
+      if (!dependencies.has(key)) {
+        dependencies.set(key, dep);
+      }
+    });
+  });
+
+  return Array.from(dependencies.values());
+}
+
+/**
+ * Get all dependencies for selected stack features
+ * Automatically deduplicates packages
+ */
+export function getStackDependencies(
+  features: string[]
+): PackageEntry[] {
+  const dependencies = new Map<string, PackageEntry>();
+
+  features.forEach((feature) => {
+    const deps = STACK_DEPENDENCIES[feature] || [];
+    deps.forEach((dep) => {
+      const key = `${dep.name}@${dep.version || "latest"}`;
+      if (!dependencies.has(key)) {
+        dependencies.set(key, dep);
+      }
+    });
+  });
+
+  return Array.from(dependencies.values());
+}
+
+/**
+ * Get all dependencies for complete preset
+ * Merges component and stack dependencies with deduplication
+ */
+export function getAllDependencies(preset: {
+  components: string[];
+  stack: {
+    stateManagement: boolean;
+    dataFetching: boolean;
+    forms: boolean;
+  };
+}): PackageEntry[] {
+  const allDeps = new Map<string, PackageEntry>();
+
+  // Add component dependencies
+  const componentDeps = getComponentDependencies(preset.components);
+  componentDeps.forEach((dep) => {
+    const key = `${dep.name}@${dep.version || "latest"}`;
+    allDeps.set(key, dep);
+  });
+
+  // Add stack dependencies
+  const stackFeatures: string[] = [];
+  if (preset.stack.stateManagement) stackFeatures.push("stateManagement");
+  if (preset.stack.dataFetching) stackFeatures.push("dataFetching");
+  if (preset.stack.forms) stackFeatures.push("forms");
+
+  const stackDeps = getStackDependencies(stackFeatures);
+  stackDeps.forEach((dep) => {
+    const key = `${dep.name}@${dep.version || "latest"}`;
+    allDeps.set(key, dep);
+  });
+
+  return Array.from(allDeps.values());
+}
+
+/**
+ * Convert package entries to install command string
+ */
+export function packagesToInstallString(
+  packages: PackageEntry[],
+  packageManager: "npm" | "pnpm" | "yarn" = "pnpm"
+): string {
+  if (packages.length === 0) return "";
+
+  const regularDeps = packages.filter((p) => !p.dev);
+  const devDeps = packages.filter((p) => p.dev);
+
+  const formatPackage = (p: PackageEntry): string => {
+    return p.version ? `${p.name}@${p.version}` : p.name;
+  };
+
+  const parts: string[] = [];
+
+  if (regularDeps.length > 0) {
+    const cmd = packageManager === "yarn" ? "add" : "install";
+    parts.push(
+      `${packageManager} ${cmd} ${regularDeps.map(formatPackage).join(" ")}`
+    );
+  }
+
+  if (devDeps.length > 0) {
+    const cmd = packageManager === "yarn" ? "add -D" : "install -D";
+    parts.push(
+      `${packageManager} ${cmd} ${devDeps.map(formatPackage).join(" ")}`
+    );
+  }
+
+  return parts.join("\n");
+}

--- a/src/features/configurator/data/index.ts
+++ b/src/features/configurator/data/index.ts
@@ -1,0 +1,29 @@
+export type {
+  PresetConfig,
+  PresetColors,
+  PresetFonts,
+  PresetStack,
+  StylePreset,
+  RadiusOption,
+  FrameworkOption,
+  ValidatedPresetConfig,
+} from "./config-schema";
+
+export {
+  presetConfigSchema,
+  presetColorsSchema,
+  presetFontsSchema,
+  presetStackSchema,
+} from "./config-schema";
+
+export { DEFAULT_PRESET, PRESET_SCHEMA_VERSION } from "./default-config";
+
+export {
+  COMPONENT_DEPENDENCIES,
+  STACK_DEPENDENCIES,
+  getComponentDependencies,
+  getStackDependencies,
+  getAllDependencies,
+  packagesToInstallString,
+  type PackageEntry,
+} from "./dependency-map";

--- a/src/features/configurator/index.ts
+++ b/src/features/configurator/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Configurator feature exports
+ */
+export type {
+  PresetConfig,
+  PresetColors,
+  PresetFonts,
+  PresetStack,
+  StylePreset,
+  RadiusOption,
+  FrameworkOption,
+  ValidatedPresetConfig,
+} from "./data";
+
+export {
+  presetConfigSchema,
+  presetColorsSchema,
+  presetFontsSchema,
+  presetStackSchema,
+  DEFAULT_PRESET,
+  PRESET_SCHEMA_VERSION,
+} from "./data";
+
+export { encodePreset, decodePreset } from "./lib";
+
+export {
+  getStyleProperties,
+  applyStyleProperties,
+  stylePropertiesToCSS,
+  arcStyle,
+  edgeStyle,
+  soleilStyle,
+  type StyleProperties,
+  type StyleSystemPreset,
+} from "./lib";
+
+export {
+  fetchGoogleFonts,
+  getCuratedFonts,
+  getPopularFonts,
+  generateGoogleFontsURL,
+  loadGoogleFonts,
+  applyFontToCSS,
+  sanitizeFontFamily,
+  type GoogleFont,
+  type GoogleFontsResponse,
+} from "./lib";
+
+export {
+  getAllIconSets,
+  getIconSetByPrefix,
+  isValidIconSet,
+  getDefaultIconSet,
+  getSampleIcons,
+  POPULAR_ICON_SETS,
+  SAMPLE_ICONS,
+  type IconifyCollection,
+} from "./lib";
+
+export {
+  COMPONENT_DEPENDENCIES,
+  STACK_DEPENDENCIES,
+  getComponentDependencies,
+  getStackDependencies,
+  getAllDependencies,
+  packagesToInstallString,
+  type PackageEntry,
+} from "./data";

--- a/src/features/configurator/lib/google-fonts.ts
+++ b/src/features/configurator/lib/google-fonts.ts
@@ -1,0 +1,231 @@
+/**
+ * Google Fonts Integration
+ * Fetch font list, load fonts, apply to preview
+ */
+
+export interface GoogleFont {
+  family: string;
+  category: "sans-serif" | "serif" | "display" | "handwriting" | "monospace";
+  variants: string[];
+  subsets: string[];
+}
+
+export interface GoogleFontsResponse {
+  items: GoogleFont[];
+}
+
+/**
+ * Google Fonts API base URL
+ */
+const GOOGLE_FONTS_API_URL = "https://www.googleapis.com/webfonts/v1/webfonts";
+const GOOGLE_FONTS_BASE_URL = "https://fonts.googleapis.com/css2";
+
+/**
+ * Fetch available fonts from Google Fonts API
+ * Requires API key for production use
+ */
+export async function fetchGoogleFonts(
+  apiKey?: string
+): Promise<GoogleFont[]> {
+  try {
+    const url = new URL(GOOGLE_FONTS_API_URL);
+    url.searchParams.set("key", apiKey || "demo");
+    url.searchParams.set("sort", "popularity");
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`Google Fonts API error: ${response.status}`);
+    }
+
+    const data: GoogleFontsResponse = await response.json();
+    return data.items;
+  } catch (error) {
+    console.error("Failed to fetch Google Fonts:", error);
+    // Return curated fallback list on error
+    return getCuratedFonts();
+  }
+}
+
+/**
+ * Curated font list as fallback
+ */
+export function getCuratedFonts(): GoogleFont[] {
+  return [
+    {
+      family: "Inter",
+      category: "sans-serif",
+      variants: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Roboto",
+      category: "sans-serif",
+      variants: ["100", "300", "400", "500", "700", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Open Sans",
+      category: "sans-serif",
+      variants: ["300", "400", "500", "600", "700", "800"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Lato",
+      category: "sans-serif",
+      variants: ["100", "300", "400", "700", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Montserrat",
+      category: "sans-serif",
+      variants: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Source Sans 3",
+      category: "sans-serif",
+      variants: ["200", "300", "400", "500", "600", "700", "800", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Merriweather",
+      category: "serif",
+      variants: ["300", "400", "700", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Playfair Display",
+      category: "serif",
+      variants: ["400", "500", "600", "700", "800", "900"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Lora",
+      category: "serif",
+      variants: ["400", "500", "600", "700"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Noto Serif",
+      category: "serif",
+      variants: ["400", "700"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Space Grotesk",
+      category: "sans-serif",
+      variants: ["300", "400", "500", "600", "700"],
+      subsets: ["latin"],
+    },
+    {
+      family: "JetBrains Mono",
+      category: "monospace",
+      variants: ["100", "200", "300", "400", "500", "600", "700", "800"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Fira Code",
+      category: "monospace",
+      variants: ["300", "400", "500", "600", "700"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Dancing Script",
+      category: "handwriting",
+      variants: ["400", "500", "600", "700"],
+      subsets: ["latin"],
+    },
+    {
+      family: "Pacifico",
+      category: "handwriting",
+      variants: ["400"],
+      subsets: ["latin"],
+    },
+  ];
+}
+
+/**
+ * Popular fonts for quick picks
+ */
+export function getPopularFonts(): GoogleFont[] {
+  const allFonts = getCuratedFonts();
+  return [
+    allFonts.find((f) => f.family === "Inter")!,
+    allFonts.find((f) => f.family === "Roboto")!,
+    allFonts.find((f) => f.family === "Open Sans")!,
+    allFonts.find((f) => f.family === "Montserrat")!,
+    allFonts.find((f) => f.family === "Merriweather")!,
+    allFonts.find((f) => f.family === "Playfair Display")!,
+    allFonts.find((f) => f.family === "JetBrains Mono")!,
+  ].filter(Boolean) as GoogleFont[];
+}
+
+/**
+ * Generate Google Fonts URL for given fonts
+ */
+export function generateGoogleFontsURL(
+  headerFont: string,
+  bodyFont: string
+): string {
+  const params = new URLSearchParams();
+  params.set("display", "swap");
+
+  const fontsToLoad = new Set<string>();
+
+  // Add header font with weights
+  fontsToLoad.add(`${headerFont}:wght@300;400;500;600;700;800;900`);
+
+  // Add body font if different
+  if (bodyFont !== headerFont) {
+    fontsToLoad.add(`${bodyFont}:wght@300;400;500;600;700;800;900`);
+  }
+
+  return `${GOOGLE_FONTS_BASE_URL}?${params.toString()}&family=${Array.from(fontsToLoad).join("&family=")}`;
+}
+
+/**
+ * Load fonts via <link> tag injection
+ */
+export function loadGoogleFonts(
+  headerFont: string,
+  bodyFont: string
+): HTMLLinkElement | null {
+  // Remove existing Google Fonts links
+  const existingLinks = document.querySelectorAll(
+    'link[href^="https://fonts.googleapis.com"]'
+  );
+  existingLinks.forEach((link) => link.remove());
+
+  // Create new link
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = generateGoogleFontsURL(headerFont, bodyFont);
+  document.head.appendChild(link);
+
+  return link;
+}
+
+/**
+ * Apply font to CSS custom properties
+ */
+export function applyFontToCSS(
+  headerFont: string,
+  bodyFont: string,
+  target: HTMLElement | CSSStyleDeclaration = document.documentElement.style
+): void {
+  const style = target instanceof CSSStyleDeclaration ? target : target.style;
+
+  style.setProperty("--font-header", headerFont);
+  style.setProperty("--font-body", bodyFont);
+}
+
+/**
+ * Sanitize font family name for CSS
+ */
+export function sanitizeFontFamily(fontFamily: string): string {
+  // Wrap spaces in quotes, keep commas for stacks
+  if (fontFamily.includes(" ")) {
+    return `"${fontFamily}"`;
+  }
+  return fontFamily;
+}

--- a/src/features/configurator/lib/iconify.ts
+++ b/src/features/configurator/lib/iconify.ts
@@ -1,0 +1,134 @@
+/**
+ * Iconify Integration
+ * Icon set picker and live preview integration
+ */
+
+export interface IconifyCollection {
+  name: string;
+  prefix: string; // e.g., "material-symbols", "lucide", "phosphor"
+  total: number;
+  author?: string;
+  license?: string;
+  url?: string;
+}
+
+/**
+ * Popular Iconify collections for quick picks
+ */
+export const POPULAR_ICON_SETS: IconifyCollection[] = [
+  {
+    name: "Material Symbols",
+    prefix: "material-symbols",
+    total: 2000,
+    author: "Google",
+    license: "Apache 2.0",
+    url: "https://fonts.google.com/icons",
+  },
+  {
+    name: "Lucide",
+    prefix: "lucide",
+    total: 1500,
+    author: "Lucide Contributors",
+    license: "ISC",
+    url: "https://lucide.dev",
+  },
+  {
+    name: "Phosphor",
+    prefix: "ph",
+    total: 7000,
+    author: "Phosphor Icons",
+    license: "MIT",
+    url: "https://phosphoricons.com",
+  },
+  {
+    name: "Heroicons",
+    prefix: "heroicons",
+    total: 500,
+    author: "Tailwind Labs",
+    license: "MIT",
+    url: "https://heroicons.com",
+  },
+  {
+    name: "Tabler Icons",
+    prefix: "tabler",
+    total: 5000,
+    author: "Tabler",
+    license: "MIT",
+    url: "https://tabler-icons.io",
+  },
+  {
+    name: "Font Awesome",
+    prefix: "fa",
+    total: 2000,
+    author: "Font Awesome",
+    license: "CC BY 4.0",
+    url: "https://fontawesome.com",
+  },
+  {
+    name: "Feather Icons",
+    prefix: "feather",
+    total: 300,
+    author: "Feather Icons",
+    license: "MIT",
+    url: "https://feathericons.com",
+  },
+  {
+    name: "Flowbite",
+    prefix: "flowbite",
+    total: 500,
+    author: "Flowbite",
+    license: "MIT",
+    url: "https://flowbite.com/icons",
+  },
+];
+
+/**
+ * Get all available icon sets
+ */
+export function getAllIconSets(): IconifyCollection[] {
+  return POPULAR_ICON_SETS;
+}
+
+/**
+ * Get icon set by prefix
+ */
+export function getIconSetByPrefix(
+  prefix: string
+): IconifyCollection | undefined {
+  return POPULAR_ICON_SETS.find((set) => set.prefix === prefix);
+}
+
+/**
+ * Validate icon set prefix
+ */
+export function isValidIconSet(prefix: string): boolean {
+  return POPULAR_ICON_SETS.some((set) => set.prefix === prefix);
+}
+
+/**
+ * Get default icon set
+ */
+export function getDefaultIconSet(): string {
+  return "material-symbols";
+}
+
+/**
+ * Sample icons from each set for preview
+ */
+export const SAMPLE_ICONS: Record<string, string[]> = {
+  "material-symbols": ["home", "settings", "search", "favorite", "add"],
+  lucide: ["home", "settings", "search", "heart", "plus"],
+  ph: ["house", "gear", "magnifying-glass", "heart", "plus"],
+  heroicons: ["home", "cog-6-tooth", "magnifying-glass", "heart", "plus"],
+  tabler: ["home", "settings", "search", "heart", "plus"],
+  fa: ["home", "cog", "search", "heart", "plus"],
+  feather: ["home", "settings", "search", "heart", "plus"],
+  flowbite: ["home-outline", "cog-solid", "search-solid", "heart-solid", "plus-solid"],
+};
+
+/**
+ * Get sample icons for an icon set
+ */
+export function getSampleIcons(prefix: string): string[] {
+  return SAMPLE_ICONS[prefix] || SAMPLE_ICONS["material-symbols"] || [];
+}

--- a/src/features/configurator/lib/index.ts
+++ b/src/features/configurator/lib/index.ts
@@ -1,0 +1,35 @@
+export { encodePreset, decodePreset } from "./preset-encode";
+
+export {
+  getStyleProperties,
+  applyStyleProperties,
+  stylePropertiesToCSS,
+  arcStyle,
+  edgeStyle,
+  soleilStyle,
+  type StyleProperties,
+  type StylePreset as StyleSystemPreset,
+} from "./style-system";
+
+export {
+  fetchGoogleFonts,
+  getCuratedFonts,
+  getPopularFonts,
+  generateGoogleFontsURL,
+  loadGoogleFonts,
+  applyFontToCSS,
+  sanitizeFontFamily,
+  type GoogleFont,
+  type GoogleFontsResponse,
+} from "./google-fonts";
+
+export {
+  getAllIconSets,
+  getIconSetByPrefix,
+  isValidIconSet,
+  getDefaultIconSet,
+  getSampleIcons,
+  POPULAR_ICON_SETS,
+  SAMPLE_ICONS,
+  type IconifyCollection,
+} from "./iconify";

--- a/src/features/configurator/lib/preset-encode.test.ts
+++ b/src/features/configurator/lib/preset-encode.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { encodePreset, decodePreset } from "./preset-encode";
+import { DEFAULT_PRESET } from "../data/default-config";
+import type { PresetConfig } from "../data/config-schema";
+
+describe("preset-encode", () => {
+  const sampleConfig: PresetConfig = {
+    style: "arc",
+    colors: {
+      base: "#0f172a",
+      brand: "#3b82f6",
+      accent: "#8b5cf6",
+      chart: "#10b981",
+    },
+    fonts: {
+      header: "Inter",
+      body: "Inter",
+    },
+    iconSet: "material-symbols",
+    radius: "md",
+    components: ["Button", "Input", "Card"],
+    stack: {
+      framework: "nextjs",
+      stateManagement: true,
+      dataFetching: true,
+      forms: true,
+      monorepo: false,
+      rtl: false,
+    },
+    version: 1,
+  };
+
+  describe("encodePreset", () => {
+    it("encodes a valid config to URL-safe string", () => {
+      const encoded = encodePreset(sampleConfig);
+      expect(encoded).toBeTruthy();
+      expect(typeof encoded).toBe("string");
+    });
+
+    it("produces URL-safe output", () => {
+      const encoded = encodePreset(sampleConfig);
+      // Should not contain +, /, or = characters
+      expect(encoded).not.toMatch(/[+/=]/);
+      // Should only contain URL-safe characters
+      expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it("produces output smaller than 2KB", () => {
+      const encoded = encodePreset(sampleConfig);
+      const sizeInBytes = new Blob([encoded]).size;
+      expect(sizeInBytes).toBeLessThan(2048); // 2KB
+    });
+
+    it("produces consistent output for same input", () => {
+      const encoded1 = encodePreset(sampleConfig);
+      const encoded2 = encodePreset(sampleConfig);
+      expect(encoded1).toBe(encoded2);
+    });
+
+    it("throws on invalid config", () => {
+      const invalidConfig = {
+        ...sampleConfig,
+        colors: {
+          base: "not-a-hex",
+          brand: "#3b82f6",
+          accent: "#8b5cf6",
+          chart: "#10b981",
+        },
+      } as unknown as PresetConfig;
+
+      expect(() => encodePreset(invalidConfig)).toThrow();
+    });
+  });
+
+  describe("decodePreset", () => {
+    it("decodes a valid encoded string back to config", () => {
+      const encoded = encodePreset(sampleConfig);
+      const decoded = decodePreset(encoded);
+      expect(decoded).toEqual(sampleConfig);
+    });
+
+    it("returns default preset on malformed input", () => {
+      const malformed = "not-valid-base64!!!";
+      const decoded = decodePreset(malformed);
+      expect(decoded).toEqual(DEFAULT_PRESET);
+    });
+
+    it("returns default preset on empty string", () => {
+      const decoded = decodePreset("");
+      expect(decoded).toEqual(DEFAULT_PRESET);
+    });
+
+    it("handles URL-safe encoding correctly", () => {
+      const encoded = encodePreset(sampleConfig);
+      // Manually replace -_ with +/ to test URL-safe restoration
+      const standardBase64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+      const decoded = decodePreset(encoded);
+      expect(decoded).toEqual(sampleConfig);
+    });
+  });
+
+  describe("roundtrip encoding/decoding", () => {
+    it("maintains data integrity through encode→decode cycle", () => {
+      const encoded = encodePreset(sampleConfig);
+      const decoded = decodePreset(encoded);
+      expect(decoded).toEqual(sampleConfig);
+    });
+
+    it("roundtrips with different style presets", () => {
+      const styles: Array<"arc" | "edge" | "soleil"> = ["arc", "edge", "soleil"];
+      styles.forEach((style) => {
+        const config = { ...sampleConfig, style };
+        const encoded = encodePreset(config);
+        const decoded = decodePreset(encoded);
+        expect(decoded).toEqual(config);
+      });
+    });
+
+    it("roundtrips with different radius options", () => {
+      const radii: Array<"none" | "sm" | "md" | "lg" | "full"> = [
+        "none",
+        "sm",
+        "md",
+        "lg",
+        "full",
+      ];
+      radii.forEach((radius) => {
+        const config = { ...sampleConfig, radius };
+        const encoded = encodePreset(config);
+        const decoded = decodePreset(encoded);
+        expect(decoded).toEqual(config);
+      });
+    });
+
+    it("roundtrips with different framework options", () => {
+      const frameworks: Array<"nextjs" | "vite"> = ["nextjs", "vite"];
+      frameworks.forEach((framework) => {
+        const config = {
+          ...sampleConfig,
+          stack: { ...sampleConfig.stack, framework },
+        };
+        const encoded = encodePreset(config);
+        const decoded = decodePreset(encoded);
+        expect(decoded).toEqual(config);
+      });
+    });
+
+    it("roundtrips with empty component list", () => {
+      const config = { ...sampleConfig, components: [] };
+      const encoded = encodePreset(config);
+      const decoded = decodePreset(encoded);
+      expect(decoded).toEqual(config);
+    });
+
+    it("roundtrips with large component list", () => {
+      const manyComponents = Array.from({ length: 50 }, (_, i) => `Component${i}`);
+      const config = { ...sampleConfig, components: manyComponents };
+      const encoded = encodePreset(config);
+      const decoded = decodePreset(encoded);
+      expect(decoded).toEqual(config);
+    });
+  });
+
+  describe("compression effectiveness", () => {
+    it("compressed output is smaller than JSON", () => {
+      const json = JSON.stringify(sampleConfig);
+      const jsonSize = new Blob([json]).size;
+      const encoded = encodePreset(sampleConfig);
+      const compressedSize = new Blob([encoded]).size;
+
+      // Compressed should be smaller (or at least not significantly larger due to base64 overhead)
+      // Base64 increases size by ~33%, so we expect compressed+base64 to be smaller than raw JSON
+      expect(compressedSize).toBeLessThan(jsonSize);
+    });
+  });
+});

--- a/src/features/configurator/lib/preset-encode.ts
+++ b/src/features/configurator/lib/preset-encode.ts
@@ -1,0 +1,100 @@
+import { compressSync, decompressSync } from "fflate";
+import { presetConfigSchema } from "../data/config-schema";
+import { DEFAULT_PRESET } from "../data/default-config";
+import type { PresetConfig } from "../data/config-schema";
+
+/**
+ * Encode a PresetConfig object into a URL-safe base64 string
+ *
+ * Process:
+ * 1. Validate with Zod schema
+ * 2. Convert to JSON string
+ * 3. Compress using fflate
+ * 4. Convert to base64
+ * 5. Make URL-safe (replace +/ with -_, remove = padding)
+ *
+ * @param config - PresetConfig object to encode
+ * @returns URL-safe encoded string
+ */
+export function encodePreset(config: PresetConfig): string {
+  // Validate with Zod schema
+  const validated = presetConfigSchema.parse(config);
+
+  // Convert to JSON string
+  const json = JSON.stringify(validated);
+
+  // Convert string to Uint8Array
+  const uint8Array = new TextEncoder().encode(json);
+
+  // Compress
+  const compressed = compressSync(uint8Array);
+
+  // Convert to binary string for base64 encoding
+  let binary = "";
+  compressed.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  // Base64 encode
+  const base64 = btoa(binary);
+
+  // Make URL-safe
+  return base64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Decode a URL-safe base64 string back to PresetConfig
+ *
+ * Process:
+ * 1. Restore URL-safe chars (-_ to +/)
+ * 2. Add padding if needed
+ * 3. Base64 decode
+ * 4. Decompress using fflate
+ * 5. Parse JSON
+ * 6. Validate with Zod schema
+ * 7. Return safe fallback on error
+ *
+ * @param encoded - URL-safe encoded string
+ * @returns PresetConfig object or default preset on error
+ */
+export function decodePreset(encoded: string): PresetConfig {
+  try {
+    // Restore URL-safe chars
+    let base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+
+    // Add padding if needed
+    while (base64.length % 4) {
+      base64 += "=";
+    }
+
+    // Base64 decode
+    const binary = atob(base64);
+
+    // Convert binary string to Uint8Array
+    const compressed = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      compressed[i] = binary.charCodeAt(i);
+    }
+
+    // Decompress
+    const decompressed = decompressSync(compressed);
+
+    // Convert Uint8Array to string
+    const json = new TextDecoder().decode(decompressed);
+
+    // Parse JSON
+    const parsed = JSON.parse(json);
+
+    // Validate with Zod schema
+    const validated = presetConfigSchema.parse(parsed);
+
+    return validated;
+  } catch (error) {
+    // Return safe fallback on any error
+    console.error("Failed to decode preset:", error);
+    return DEFAULT_PRESET;
+  }
+}

--- a/src/features/configurator/lib/style-system.ts
+++ b/src/features/configurator/lib/style-system.ts
@@ -1,0 +1,268 @@
+/**
+ * Style System - CSS Custom Properties for Arc, Edge, Soleil
+ * Each style is a complete set of CSS custom properties
+ */
+
+export type StylePreset = "arc" | "edge" | "soleil";
+
+export interface StyleProperties {
+  // Colors
+  "--color-primary": string;
+  "--color-secondary": string;
+  "--color-accent": string;
+
+  // Typography scale
+  "--font-size-xs": string;
+  "--font-size-sm": string;
+  "--font-size-base": string;
+  "--font-size-lg": string;
+  "--font-size-xl": string;
+  "--font-size-2xl": string;
+  "--font-size-3xl": string;
+  "--font-size-4xl": string;
+
+  // Spacing scale
+  "--spacing-xs": string;
+  "--spacing-sm": string;
+  "--spacing-md": string;
+  "--spacing-lg": string;
+  "--spacing-xl": string;
+  "--spacing-2xl": string;
+  "--spacing-3xl": string;
+
+  // Border radius
+  "--radius-sm": string;
+  "--radius-md": string;
+  "--radius-lg": string;
+  "--radius-full": string;
+
+  // Shadows
+  "--shadow-sm": string;
+  "--shadow-md": string;
+  "--shadow-lg": string;
+  "--shadow-xl": string;
+
+  // Border width
+  "--border-width": string;
+
+  // Font weights
+  "--font-weight-normal": string;
+  "--font-weight-medium": string;
+  "--font-weight-semibold": string;
+  "--font-weight-bold": string;
+
+  // Line heights
+  "--line-height-tight": string;
+  "--line-height-normal": string;
+  "--line-height-relaxed": string;
+}
+
+/**
+ * Arc - Rounded, friendly, generous spacing
+ * Suited for consumer apps and SaaS onboarding
+ */
+export const arcStyle: StyleProperties = {
+  // Colors - blue primary, purple secondary, emerald accent
+  "--color-primary": "#3b82f6",
+  "--color-secondary": "#8b5cf6",
+  "--color-accent": "#10b981",
+
+  // Typography - slightly larger, more readable
+  "--font-size-xs": "0.75rem",
+  "--font-size-sm": "0.875rem",
+  "--font-size-base": "1rem",
+  "--font-size-lg": "1.125rem",
+  "--font-size-xl": "1.25rem",
+  "--font-size-2xl": "1.5rem",
+  "--font-size-3xl": "1.875rem",
+  "--font-size-4xl": "2.25rem",
+
+  // Spacing - generous
+  "--spacing-xs": "0.5rem",
+  "--spacing-sm": "0.75rem",
+  "--spacing-md": "1rem",
+  "--spacing-lg": "1.5rem",
+  "--spacing-xl": "2rem",
+  "--spacing-2xl": "3rem",
+  "--spacing-3xl": "4rem",
+
+  // Border radius - rounded
+  "--radius-sm": "0.375rem",
+  "--radius-md": "0.5rem",
+  "--radius-lg": "0.75rem",
+  "--radius-full": "9999px",
+
+  // Shadows - soft, friendly
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+  "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+  "--shadow-xl": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",
+
+  // Border width - subtle
+  "--border-width": "1px",
+
+  // Font weights
+  "--font-weight-normal": "400",
+  "--font-weight-medium": "500",
+  "--font-weight-semibold": "600",
+  "--font-weight-bold": "700",
+
+  // Line heights - relaxed
+  "--line-height-tight": "1.25",
+  "--line-height-normal": "1.5",
+  "--line-height-relaxed": "1.75",
+};
+
+/**
+ * Edge - Sharp, high-contrast, minimal decoration
+ * Suited for dashboards and developer tools
+ */
+export const edgeStyle: StyleProperties = {
+  // Colors - dark primary, blue secondary, indigo accent
+  "--color-primary": "#0f172a",
+  "--color-secondary": "#3b82f6",
+  "--color-accent": "#6366f1",
+
+  // Typography - precise, technical
+  "--font-size-xs": "0.75rem",
+  "--font-size-sm": "0.8125rem",
+  "--font-size-base": "0.875rem",
+  "--font-size-lg": "1rem",
+  "--font-size-xl": "1.125rem",
+  "--font-size-2xl": "1.25rem",
+  "--font-size-3xl": "1.5rem",
+  "--font-size-4xl": "1.875rem",
+
+  // Spacing - tight, efficient
+  "--spacing-xs": "0.25rem",
+  "--spacing-sm": "0.5rem",
+  "--spacing-md": "0.75rem",
+  "--spacing-lg": "1rem",
+  "--spacing-xl": "1.5rem",
+  "--spacing-2xl": "2rem",
+  "--spacing-3xl": "2.5rem",
+
+  // Border radius - sharp
+  "--radius-sm": "0rem",
+  "--radius-md": "0rem",
+  "--radius-lg": "0rem",
+  "--radius-full": "9999px",
+
+  // Shadows - minimal
+  "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.1)",
+  "--shadow-md": "0 2px 4px 0 rgb(0 0 0 / 0.1)",
+  "--shadow-lg": "0 4px 6px -1px rgb(0 0 0 / 0.15)",
+  "--shadow-xl": "0 8px 10px -1px rgb(0 0 0 / 0.15)",
+
+  // Border width - crisp
+  "--border-width": "1px",
+
+  // Font weights - bold hierarchy
+  "--font-weight-normal": "400",
+  "--font-weight-medium": "500",
+  "--font-weight-semibold": "600",
+  "--font-weight-bold": "700",
+
+  // Line heights - tight
+  "--line-height-tight": "1.1",
+  "--line-height-normal": "1.4",
+  "--line-height-relaxed": "1.6",
+};
+
+/**
+ * Soleil - Warm, editorial, expressive
+ * Suited for portfolios and premium landing pages
+ */
+export const soleilStyle: StyleProperties = {
+  // Colors - warm orange primary, pink secondary, purple accent
+  "--color-primary": "#f59e0b",
+  "--color-secondary": "#ec4899",
+  "--color-accent": "#8b5cf6",
+
+  // Typography - elegant, variable
+  "--font-size-xs": "0.75rem",
+  "--font-size-sm": "0.875rem",
+  "--font-size-base": "1rem",
+  "--font-size-lg": "1.125rem",
+  "--font-size-xl": "1.25rem",
+  "--font-size-2xl": "1.5rem",
+  "--font-size-3xl": "1.875rem",
+  "--font-size-4xl": "2.5rem",
+
+  // Spacing - expressive
+  "--spacing-xs": "0.5rem",
+  "--spacing-sm": "0.75rem",
+  "--spacing-md": "1.25rem",
+  "--spacing-lg": "1.75rem",
+  "--spacing-xl": "2.5rem",
+  "--spacing-2xl": "3.5rem",
+  "--spacing-3xl": "5rem",
+
+  // Border radius - subtle rounded
+  "--radius-sm": "0.25rem",
+  "--radius-md": "0.375rem",
+  "--radius-lg": "0.5rem",
+  "--radius-full": "9999px",
+
+  // Shadows - warm, diffuse
+  "--shadow-sm": "0 1px 3px 0 rgb(0 0 0 / 0.08)",
+  "--shadow-md": "0 4px 8px -2px rgb(0 0 0 / 0.08)",
+  "--shadow-lg": "0 12px 16px -4px rgb(0 0 0 / 0.08)",
+  "--shadow-xl": "0 20px 24px -4px rgb(0 0 0 / 0.08)",
+
+  // Border width - hairline
+  "--border-width": "1px",
+
+  // Font weights - editorial
+  "--font-weight-normal": "350",
+  "--font-weight-medium": "450",
+  "--font-weight-semibold": "550",
+  "--font-weight-bold": "650",
+
+  // Line heights - editorial
+  "--line-height-tight": "1.2",
+  "--line-height-normal": "1.6",
+  "--line-height-relaxed": "1.8",
+};
+
+/**
+ * Get style properties by preset name
+ */
+export function getStyleProperties(preset: StylePreset): StyleProperties {
+  switch (preset) {
+    case "arc":
+      return arcStyle;
+    case "edge":
+      return edgeStyle;
+    case "soleil":
+      return soleilStyle;
+    default:
+      return arcStyle;
+  }
+}
+
+/**
+ * Apply style properties to a DOM element (usually :root or a container)
+ */
+export function applyStyleProperties(
+  properties: StyleProperties,
+  target: HTMLElement = document.documentElement
+): void {
+  Object.entries(properties).forEach(([key, value]) => {
+    target.style.setProperty(key, value);
+  });
+}
+
+/**
+ * Convert style properties to CSS string for style tag injection
+ */
+export function stylePropertiesToCSS(
+  properties: StyleProperties,
+  selector: string = ":root"
+): string {
+  const cssEntries = Object.entries(properties)
+    .map(([key, value]) => `  ${key}: ${value};`)
+    .join("\n");
+
+  return `${selector} {\n${cssEntries}\n}`;
+}

--- a/src/features/configurator/stores/index.ts
+++ b/src/features/configurator/stores/index.ts
@@ -1,0 +1,1 @@
+export { useWizardStore } from "./useWizardStore";

--- a/src/features/configurator/stores/useWizardStore.ts
+++ b/src/features/configurator/stores/useWizardStore.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { PresetConfig, RadiusOption, FrameworkOption } from "../data";
+
+interface WizardState {
+  // Current step
+  currentStep: "visual" | "stack" | "generate";
+  setCurrentStep: (step: "visual" | "stack" | "generate") => void;
+
+  // Visual preset state
+  style: PresetConfig["style"];
+  setStyle: (style: PresetConfig["style"]) => void;
+
+  colors: PresetConfig["colors"];
+  setColors: (colors: PresetConfig["colors"]) => void;
+
+  fonts: PresetConfig["fonts"];
+  setFonts: (fonts: PresetConfig["fonts"]) => void;
+
+  iconSet: string;
+  setIconSet: (iconSet: string) => void;
+
+  radius: RadiusOption;
+  setRadius: (radius: RadiusOption) => void;
+
+  components: string[];
+  setComponents: (components: string[]) => void;
+  toggleComponent: (component: string) => void;
+
+  // Stack state
+  framework: FrameworkOption;
+  setFramework: (framework: FrameworkOption) => void;
+
+  stateManagement: boolean;
+  toggleStateManagement: () => void;
+
+  dataFetching: boolean;
+  toggleDataFetching: () => void;
+
+  forms: boolean;
+  toggleForms: () => void;
+
+  monorepo: boolean;
+  toggleMonorepo: () => void;
+
+  rtl: boolean;
+  toggleRtl: () => void;
+
+  // Get complete PresetConfig
+  getPresetConfig: () => PresetConfig;
+
+  // Reset
+  resetVisual: () => void;
+  resetStack: () => void;
+  resetAll: () => void;
+}
+
+const defaultState = {
+  style: "arc" as const,
+  colors: {
+    base: "#0f172a",
+    brand: "#3b82f6",
+    accent: "#8b5cf6",
+    chart: "#10b981",
+  },
+  fonts: {
+    header: "Inter",
+    body: "Inter",
+  },
+  iconSet: "material-symbols",
+  radius: "md" as const,
+  components: [],
+  framework: "nextjs" as const,
+  stateManagement: true,
+  dataFetching: true,
+  forms: true,
+  monorepo: false,
+  rtl: false,
+};
+
+export const useWizardStore = create<WizardState>()(
+  persist(
+    (set, get) => ({
+      // Initial state
+      ...defaultState,
+      currentStep: "visual",
+
+      // Step navigation
+      setCurrentStep: (step) => set({ currentStep: step }),
+
+      // Visual preset setters
+      setStyle: (style) => set({ style }),
+      setColors: (colors) => set({ colors }),
+      setFonts: (fonts) => set({ fonts }),
+      setIconSet: (iconSet) => set({ iconSet }),
+      setRadius: (radius) => set({ radius }),
+
+      setComponents: (components) => set({ components }),
+      toggleComponent: (component) =>
+        set((state) => ({
+          components: state.components.includes(component)
+            ? state.components.filter((c) => c !== component)
+            : [...state.components, component],
+        })),
+
+      // Stack setters
+      setFramework: (framework) => set({ framework }),
+
+      toggleStateManagement: () =>
+        set((state) => ({ stateManagement: !state.stateManagement })),
+
+      toggleDataFetching: () =>
+        set((state) => ({ dataFetching: !state.dataFetching })),
+
+      toggleForms: () => set((state) => ({ forms: !state.forms })),
+
+      toggleMonorepo: () =>
+        set((state) => ({ monorepo: !state.monorepo })),
+
+      toggleRtl: () => set((state) => ({ rtl: !state.rtl })),
+
+      // Get complete PresetConfig
+      getPresetConfig: () => {
+        const state = get();
+        return {
+          style: state.style,
+          colors: state.colors,
+          fonts: state.fonts,
+          iconSet: state.iconSet,
+          radius: state.radius,
+          components: state.components,
+          stack: {
+            framework: state.framework,
+            stateManagement: state.stateManagement,
+            dataFetching: state.dataFetching,
+            forms: state.forms,
+            monorepo: state.monorepo,
+            rtl: state.rtl,
+          },
+          version: 1,
+        };
+      },
+
+      // Reset functions
+      resetVisual: () =>
+        set({
+          style: defaultState.style,
+          colors: defaultState.colors,
+          fonts: defaultState.fonts,
+          iconSet: defaultState.iconSet,
+          radius: defaultState.radius,
+          components: defaultState.components,
+        }),
+
+      resetStack: () =>
+        set({
+          framework: defaultState.framework,
+          stateManagement: defaultState.stateManagement,
+          dataFetching: defaultState.dataFetching,
+          forms: defaultState.forms,
+          monorepo: defaultState.monorepo,
+          rtl: defaultState.rtl,
+        }),
+
+      resetAll: () => set(defaultState),
+    }),
+    {
+      name: "wizard-storage",
+    }
+  )
+);


### PR DESCRIPTION
## Summary
Complete UI redesign of the configurator with modern, intuitive interface and bold editorial aesthetic.

## Changes
- **Dark-first theme** with unified purple brand color (#4628f1)
- **Typography**: Space Grotesk (display) + Geist Variable (body)
- **Glassmorphism** live preview panel with backdrop-blur effects
- **Smooth animations**: staggered reveals, hover effects, micro-interactions
- **Style system**: Arc/Edge/Soleil presets now include color schemes
- **Light mode support** with automatic contrast adjustment

## Bug Fixes
- Fixed overlapping text in Configuration Summary cards (grid changed to 3 columns)
- Fixed overlapping text in Stack Features cards with proper flex layouts
- Style preset colors now properly apply to all preview components

## Test Plan
- [x] All 91 tests passing
- [x] Typecheck clean
- [x] Dark theme loads by default
- [x] Style preset changes affect preview components
- [x] Light mode toggle works with proper contrast
- [x] All cards display without text overlap
- [x] Configuration Summary shows 3 columns on desktop
- [x] Animations are smooth without jank
- [x] Fonts load correctly (Space Grotesk, Geist Variable)

## Screenshots
Visit `/create` to see the redesigned configurator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)