### PR TITLE
feat(cli): add create command with preset scaffolding (v0.1.0)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## [0.1.0] - 2026-05-02
+
+### Added
+
+- `react-principles create <app-name>` command — scaffolds a full React project from a preset
+  - Supports Next.js and Vite frameworks
+  - Decodes preset string from `reactprinciples.dev/create`
+  - Auto-detects package manager (npm / pnpm / yarn / bun)
+  - Scaffolds feature-sliced structure: `src/ui/`, `src/shared/`, `src/app/`
+  - Generates `package.json`, `tsconfig.json`, framework config, and CSS with style vars
+  - Copies selected UI components into `src/ui/`
+  - Runs install automatically after scaffold
+  - `--dry-run` flag to preview without writing files
+- Preset decoder (`utils/preset.ts`) — decodes base64+deflate preset strings using Node.js built-in `zlib`
+- Dependency resolver (`utils/deps.ts`) — maps component and stack selections to deduplicated npm package lists
+
+## [0.0.4] - 2025-10-01
+
+### Changed
+
+- Internal registry sync improvements
+
+## [0.0.1] - 2025-09-01
+
+### Added
+
+- Initial release
+- `react-principles init` — initialize `components.json` config
+- `react-principles add [components...]` — add UI components to existing project
+- `react-principles list` — list all available components
+- 33 UI components available

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-principles",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "CLI to add react-principles UI components to your project",
   "author": "Singgih Budi Purnadi",
   "license": "MIT",

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -52,7 +52,7 @@ const RADIUS_VALUES: Record<string, string> = {
 // ── File generators ───────────────────────────────────────────────────────
 
 function buildCssVars(preset: CliPreset): string {
-  const vars: Record<string, string> = STYLE_VARS[preset.style] ?? STYLE_VARS.arc;
+  const vars: Record<string, string> = STYLE_VARS[preset.style] ?? STYLE_VARS["arc"] ?? {};
   const radius = RADIUS_VALUES[preset.radius] ?? "0.5rem";
 
   const entries = [

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -52,7 +52,7 @@ const RADIUS_VALUES: Record<string, string> = {
 // ── File generators ───────────────────────────────────────────────────────
 
 function buildCssVars(preset: CliPreset): string {
-  const vars = STYLE_VARS[preset.style] ?? STYLE_VARS.arc;
+  const vars: Record<string, string> = STYLE_VARS[preset.style] ?? STYLE_VARS.arc;
   const radius = RADIUS_VALUES[preset.radius] ?? "0.5rem";
 
   const entries = [

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,492 @@
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+import pc from "picocolors";
+import prompts from "prompts";
+import { decodePreset, type CliPreset } from "../utils/preset";
+import { resolvePresetDependencies, installPresetDependencies } from "../utils/deps";
+import { detectPackageManager } from "../utils/pm";
+import { getEntry, getTemplate } from "../registry";
+
+// ── Style system CSS vars ─────────────────────────────────────────────────
+
+const STYLE_VARS: Record<string, Record<string, string>> = {
+  arc: {
+    "--radius-sm": "0.375rem", "--radius-md": "0.5rem", "--radius-lg": "0.75rem", "--radius-full": "9999px",
+    "--font-size-xs": "0.75rem", "--font-size-sm": "0.875rem", "--font-size-base": "1rem",
+    "--font-size-lg": "1.125rem", "--font-size-xl": "1.25rem", "--font-size-2xl": "1.5rem",
+    "--font-size-3xl": "1.875rem",
+    "--font-weight-normal": "400", "--font-weight-medium": "500",
+    "--font-weight-semibold": "600", "--font-weight-bold": "700",
+    "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+    "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+    "--line-height-tight": "1.25", "--line-height-normal": "1.5", "--line-height-relaxed": "1.75",
+  },
+  edge: {
+    "--radius-sm": "0rem", "--radius-md": "0.125rem", "--radius-lg": "0.25rem", "--radius-full": "0.25rem",
+    "--font-size-xs": "0.6875rem", "--font-size-sm": "0.8125rem", "--font-size-base": "0.875rem",
+    "--font-size-lg": "1rem", "--font-size-xl": "1.125rem", "--font-size-2xl": "1.375rem",
+    "--font-size-3xl": "1.75rem",
+    "--font-weight-normal": "400", "--font-weight-medium": "500",
+    "--font-weight-semibold": "700", "--font-weight-bold": "800",
+    "--shadow-sm": "none", "--shadow-md": "0 1px 3px 0 rgb(0 0 0 / 0.15)",
+    "--line-height-tight": "1.2", "--line-height-normal": "1.45", "--line-height-relaxed": "1.65",
+  },
+  soleil: {
+    "--radius-sm": "0.25rem", "--radius-md": "0.375rem", "--radius-lg": "0.625rem", "--radius-full": "9999px",
+    "--font-size-xs": "0.75rem", "--font-size-sm": "0.875rem", "--font-size-base": "1rem",
+    "--font-size-lg": "1.125rem", "--font-size-xl": "1.25rem", "--font-size-2xl": "1.5rem",
+    "--font-size-3xl": "1.875rem",
+    "--font-weight-normal": "400", "--font-weight-medium": "500",
+    "--font-weight-semibold": "600", "--font-weight-bold": "700",
+    "--shadow-sm": "0 1px 3px 0 rgb(0 0 0 / 0.08)",
+    "--shadow-md": "0 4px 8px -2px rgb(0 0 0 / 0.12), 0 2px 4px -2px rgb(0 0 0 / 0.08)",
+    "--line-height-tight": "1.3", "--line-height-normal": "1.6", "--line-height-relaxed": "1.8",
+  },
+};
+
+const RADIUS_VALUES: Record<string, string> = {
+  none: "0px", sm: "0.25rem", md: "0.5rem", lg: "0.75rem",
+};
+
+// ── File generators ───────────────────────────────────────────────────────
+
+function buildCssVars(preset: CliPreset): string {
+  const vars = STYLE_VARS[preset.style] ?? STYLE_VARS.arc;
+  const radius = RADIUS_VALUES[preset.radius] ?? "0.5rem";
+
+  const entries = [
+    `  --radius: ${radius};`,
+    `  --color-brand: ${preset.colors.brand};`,
+    `  --color-accent: ${preset.colors.accent};`,
+    `  --color-chart: ${preset.colors.chart};`,
+    `  --color-base: ${preset.colors.base};`,
+    `  --font-header: "${preset.fonts.header}";`,
+    `  --font-body: "${preset.fonts.body}";`,
+    ...Object.entries(vars).map(([k, v]) => `  ${k}: ${v};`),
+  ];
+
+  return entries.join("\n");
+}
+
+function buildGlobalCss(preset: CliPreset): string {
+  return `@import "tailwindcss";
+
+:root {
+${buildCssVars(preset)}
+}
+
+body {
+  font-family: var(--font-body), sans-serif;
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-header), sans-serif;
+  line-height: var(--line-height-tight);
+}
+`;
+}
+
+function buildNextPackageJson(appName: string, preset: CliPreset, extraDeps: string[]): string {
+  const deps: Record<string, string> = {
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4",
+  };
+
+  for (const dep of extraDeps) {
+    const [name, version] = dep.split("@").length > 1
+      ? [dep.slice(0, dep.lastIndexOf("@")), dep.slice(dep.lastIndexOf("@") + 1)]
+      : [dep, "latest"];
+    deps[name] = version;
+  }
+
+  const pkg = {
+    name: appName,
+    version: "0.1.0",
+    private: true,
+    scripts: { dev: "next dev", build: "next build", start: "next start", lint: "next lint" },
+    dependencies: deps,
+    devDependencies: {
+      typescript: "^5.0.0",
+      "@types/node": "^22.0.0",
+      "@types/react": "^19.0.0",
+      "@types/react-dom": "^19.0.0",
+    },
+  };
+
+  return JSON.stringify(pkg, null, 2);
+}
+
+function buildVitePackageJson(appName: string, preset: CliPreset, extraDeps: string[]): string {
+  const deps: Record<string, string> = {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.4",
+  };
+
+  for (const dep of extraDeps) {
+    const at = dep.lastIndexOf("@");
+    const name = at > 0 ? dep.slice(0, at) : dep;
+    const version = at > 0 ? dep.slice(at + 1) : "latest";
+    deps[name] = version;
+  }
+
+  const pkg = {
+    name: appName,
+    version: "0.1.0",
+    private: true,
+    scripts: { dev: "vite", build: "tsc -b && vite build", preview: "vite preview" },
+    dependencies: deps,
+    devDependencies: {
+      typescript: "^5.0.0",
+      "@types/react": "^19.0.0",
+      "@types/react-dom": "^19.0.0",
+      "@vitejs/plugin-react": "^4.0.0",
+      "vite": "^6.0.0",
+      "tailwindcss": "^4.0.0",
+      "@tailwindcss/vite": "^4.0.0",
+    },
+  };
+
+  return JSON.stringify(pkg, null, 2);
+}
+
+const NEXT_CONFIG = `import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;
+`;
+
+const VITE_CONFIG = `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});
+`;
+
+const TSCONFIG_NEXT = JSON.stringify({
+  compilerOptions: {
+    target: "ES2017", lib: ["dom", "dom.iterable", "esnext"],
+    allowJs: true, skipLibCheck: true, strict: true,
+    noEmit: true, esModuleInterop: true, module: "esnext",
+    moduleResolution: "bundler", resolveJsonModule: true,
+    isolatedModules: true, jsx: "preserve", incremental: true,
+    plugins: [{ name: "next" }],
+    paths: { "@/*": ["./src/*"] },
+  },
+  include: ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  exclude: ["node_modules"],
+}, null, 2);
+
+const TSCONFIG_VITE = JSON.stringify({
+  compilerOptions: {
+    target: "ES2020", lib: ["ES2020", "DOM", "DOM.Iterable"],
+    module: "ESNext", skipLibCheck: true,
+    moduleResolution: "bundler", allowImportingTsExtensions: true,
+    isolatedModules: true, moduleDetection: "force",
+    noEmit: true, jsx: "react-jsx", strict: true,
+    paths: { "@/*": ["./src/*"] },
+  },
+  include: ["src"],
+}, null, 2);
+
+const INDEX_HTML = (appName: string) => `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${appName}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`;
+
+const MAIN_TSX = `import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+`;
+
+const APP_TSX_VITE = `export default function App() {
+  return (
+    <main className="min-h-screen bg-white p-8">
+      <h1 className="text-3xl font-bold">Welcome</h1>
+      <p className="mt-2 text-slate-500">Scaffolded with react-principles</p>
+    </main>
+  );
+}
+`;
+
+const NEXT_LAYOUT = (appName: string) => `import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "${appName}",
+  description: "Scaffolded with react-principles",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`;
+
+const NEXT_PAGE = `export default function Page() {
+  return (
+    <main className="min-h-screen bg-white p-8">
+      <h1 className="text-3xl font-bold">Welcome</h1>
+      <p className="mt-2 text-slate-500">Scaffolded with react-principles</p>
+    </main>
+  );
+}
+`;
+
+const GITIGNORE = `# dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# build output
+dist/
+.next/
+out/
+
+# env
+.env
+.env.local
+.env.*.local
+
+# misc
+.DS_Store
+*.pem
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+`;
+
+const CN_UTIL = `import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+`;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function write(dir: string, file: string, content: string): void {
+  const fullPath = join(dir, file);
+  mkdirSync(join(dir, file, ".."), { recursive: true });
+  writeFileSync(fullPath, content, "utf8");
+}
+
+function step(msg: string) {
+  console.log(`\n${pc.bold(pc.cyan("→"))} ${msg}`);
+}
+
+function ok(msg: string) {
+  console.log(`  ${pc.green("✓")} ${msg}`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+export async function create(
+  appNameArg: string | undefined,
+  opts: { preset?: string; dryRun?: boolean },
+): Promise<void> {
+  console.log(pc.bold("\n✦ react-principles create\n"));
+
+  // 1. App name
+  let appName = appNameArg;
+  if (!appName) {
+    const res = await prompts({
+      type: "text",
+      name: "name",
+      message: "Project name",
+      initial: "my-app",
+      validate: (v: string) => /^[a-z0-9-_]+$/i.test(v) || "Use letters, numbers, hyphens only",
+    });
+    if (!res.name) process.exit(0);
+    appName = res.name as string;
+  }
+
+  const cwd = process.cwd();
+  const projectDir = join(cwd, appName);
+
+  if (existsSync(projectDir)) {
+    console.log(pc.red(`\n✖ Directory "${appName}" already exists.`));
+    process.exit(1);
+  }
+
+  // 2. Preset
+  let preset: CliPreset | null = null;
+
+  if (opts.preset) {
+    preset = decodePreset(opts.preset);
+    if (!preset) {
+      console.log(pc.yellow("⚠ Could not decode preset — using defaults (Next.js, Arc style)."));
+    }
+  }
+
+  if (!preset) {
+    preset = {
+      style: "arc",
+      colors: { base: "#0f172a", brand: "#3b82f6", accent: "#8b5cf6", chart: "#10b981" },
+      fonts: { header: "Inter", body: "Inter" },
+      iconSet: "material-symbols",
+      radius: "md",
+      components: ["Button", "Input", "Card", "Badge"],
+      stack: { framework: "nextjs", stateManagement: false, dataFetching: false, forms: false, monorepo: false, rtl: false },
+      version: 1,
+    };
+  }
+
+  const isNext = preset.stack.framework === "nextjs";
+  const pm = detectPackageManager(cwd);
+
+  // 3. Dependency resolution (#141)
+  const resolved = resolvePresetDependencies(preset);
+
+  // 4. Summary
+  console.log(pc.gray(`  Framework : ${isNext ? "Next.js" : "Vite"}`));
+  console.log(pc.gray(`  Style     : ${preset.style} (${preset.colors.brand})`));
+  console.log(pc.gray(`  Radius    : ${preset.radius}`));
+  console.log(pc.gray(`  Components: ${preset.components.join(", ") || "none"}`));
+  console.log(pc.gray(`  Packages  : ${resolved.deps.length} deps, ${resolved.devDeps.length} devDeps`));
+  console.log(pc.gray(`  PM        : ${pm}`));
+
+  if (opts.dryRun) {
+    console.log(pc.yellow("\n[dry-run] Dependencies that would be installed:"));
+    if (resolved.deps.length > 0) console.log(pc.gray("  deps:"), resolved.deps.join(" "));
+    if (resolved.devDeps.length > 0) console.log(pc.gray("  devDeps:"), resolved.devDeps.join(" "));
+    console.log(pc.yellow("\n[dry-run] No files written.\n"));
+    return;
+  }
+
+  const confirm = await prompts({
+    type: "confirm",
+    name: "ok",
+    message: `Create "${appName}"?`,
+    initial: true,
+  });
+  if (!confirm.ok) process.exit(0);
+
+  // 5. Scaffold
+  step("Creating project structure");
+  mkdirSync(projectDir, { recursive: true });
+
+  // Common
+  write(projectDir, ".gitignore", GITIGNORE);
+  write(projectDir, "tsconfig.json", isNext ? TSCONFIG_NEXT : TSCONFIG_VITE);
+  write(projectDir, "src/shared/utils/cn.ts", CN_UTIL);
+  ok("Base files");
+
+  // Framework config + entry files
+  if (isNext) {
+    write(projectDir, "next.config.mjs", NEXT_CONFIG);
+    write(projectDir, "postcss.config.mjs", `export default { plugins: { "@tailwindcss/postcss": {} } };\n`);
+    write(projectDir, "src/app/globals.css", buildGlobalCss(preset));
+    write(projectDir, "src/app/layout.tsx", NEXT_LAYOUT(appName));
+    write(projectDir, "src/app/page.tsx", NEXT_PAGE);
+    ok("Next.js config + app directory");
+  } else {
+    write(projectDir, "vite.config.ts", VITE_CONFIG);
+    write(projectDir, "index.html", INDEX_HTML(appName));
+    write(projectDir, "src/index.css", buildGlobalCss(preset));
+    write(projectDir, "src/main.tsx", MAIN_TSX);
+    write(projectDir, "src/App.tsx", APP_TSX_VITE);
+    ok("Vite config + entry files");
+  }
+
+  // package.json
+  const pkgJson = isNext
+    ? buildNextPackageJson(appName, preset, resolved.deps)
+    : buildVitePackageJson(appName, preset, resolved.deps);
+  write(projectDir, "package.json", pkgJson);
+  ok("package.json");
+
+  // components.json
+  const componentsJson = {
+    framework: isNext ? "next" : "vite",
+    rsc: isNext,
+    tsx: true,
+    componentsDir: "src/ui",
+    hooksDir: "src/shared/hooks",
+    libDir: "src/shared/utils",
+    aliases: { components: "@/ui", hooks: "@/shared/hooks", lib: "@/shared/utils" },
+  };
+  write(projectDir, "components.json", JSON.stringify(componentsJson, null, 2));
+  ok("components.json");
+
+  // 6. Copy selected UI components
+  step("Copying components");
+  const copied: string[] = [];
+  const skipped: string[] = [];
+
+  for (const compName of preset.components) {
+    const entryName = compName.toLowerCase();
+    const entry = getEntry(entryName);
+    if (!entry) { skipped.push(compName); continue; }
+
+    const template = getTemplate(entry.templateKey);
+    if (!template) { skipped.push(compName); continue; }
+
+    write(projectDir, `src/ui/${entry.outputFile}`, template);
+    copied.push(compName);
+  }
+
+  // Always include utils (cn) via registry for correct @/lib/utils import
+  const utilsEntry = getEntry("utils");
+  if (utilsEntry) {
+    const utilsTemplate = getTemplate(utilsEntry.templateKey);
+    if (utilsTemplate) {
+      write(projectDir, "src/shared/utils/cn.ts", utilsTemplate);
+    }
+  }
+
+  if (copied.length > 0) ok(`Copied: ${copied.join(", ")}`);
+  if (skipped.length > 0) console.log(pc.yellow(`  ⚠ Not found in registry: ${skipped.join(", ")}`));
+
+  // 7. Install
+  step(`Installing dependencies with ${pm}`);
+  try {
+    const installCmd = pm === "yarn" ? "yarn" : `${pm} install`;
+    execSync(installCmd, { cwd: projectDir, stdio: "inherit" });
+
+    // Extra preset deps (component + stack)
+    installPresetDependencies(resolved, projectDir);
+
+    ok("Dependencies installed");
+  } catch {
+    console.log(pc.yellow("\n  ⚠ Install failed. Run manually:"));
+    console.log(pc.gray(`    cd ${appName} && ${pm} install`));
+  }
+
+  // 8. Done
+  console.log(`\n${pc.bold(pc.green("✓ Done!"))} ${pc.gray(`Created ${appName}/`)}\n`);
+  console.log(pc.gray(`  cd ${appName}`));
+  console.log(pc.gray(`  ${pm} run dev\n`));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import pc from "picocolors";
 import { init } from "./commands/init";
 import { add } from "./commands/add";
+import { create } from "./commands/create";
 import { getAll } from "./registry";
 
 const program = new Command();
@@ -26,6 +27,15 @@ program
   .option("--all", "Install all available components")
   .action(async (components: string[], opts: { all?: boolean }) => {
     await add(opts.all ? ["--all"] : components, process.cwd());
+  });
+
+program
+  .command("create [app-name]")
+  .description("Scaffold a new React project from a preset")
+  .option("--preset <encoded>", "Encoded preset string from reactprinciples.dev/create")
+  .option("--dry-run", "Print dependencies without installing or writing files")
+  .action(async (appName: string | undefined, opts: { preset?: string; dryRun?: boolean }) => {
+    await create(appName, opts);
   });
 
 program

--- a/packages/cli/src/registry/templates.ts
+++ b/packages/cli/src/registry/templates.ts
@@ -581,11 +581,11 @@ Avatar.Image = function AvatarImage({ className, onError, alt, ...props }: ImgHT
   );
 }
 
-Avatar.Fallback = function AvatarFallback({ className, children }: { className?: string; children: ReactNode }) {
+Avatar.Fallback = function AvatarFallback({ className, style, children }: { className?: string; style?: React.CSSProperties; children: ReactNode }) {
   const { hasImageError } = useAvatarContext();
   if (!hasImageError) return null;
 
-  return <span className={cn("font-semibold uppercase", className)}>{children}</span>;
+  return <span className={cn("font-semibold uppercase", className)} style={style}>{children}</span>;
 }`,
   "Badge": `import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
@@ -1967,12 +1967,7 @@ Carousel.Next = function CarouselNext({
 };`,
   "Chart": `"use client";
 
-import {
-  createContext,
-  useContext,
-  type CSSProperties,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import {
   ResponsiveContainer,
@@ -1982,8 +1977,7 @@ import {
   LineChart,
   AreaChart,
   PieChart,
-  type TooltipProps,
-  type LegendProps,
+  type TooltipContentProps,
 } from "recharts";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -2029,7 +2023,7 @@ export function ChartContainer({
 }: ChartContainerProps) {
   return (
     <ChartContext.Provider value={config}>
-      <div className={cn("w-full", className)}>
+      <div className={cn("h-full w-full", className)}>
         <ResponsiveContainer width="100%" height="100%">
           {children}
         </ResponsiveContainer>
@@ -2044,9 +2038,10 @@ export function ChartTooltipContent({
   active,
   payload,
   label,
-}: TooltipProps<number, string>) {
-  if (!active || !payload?.length) return null;
+}: TooltipContentProps) {
   const config = useChartConfig();
+
+  if (!active || !payload?.length) return null;
 
   return (
     <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-lg dark:border-[#1f2937] dark:bg-[#0d1117]">
@@ -2054,7 +2049,7 @@ export function ChartTooltipContent({
         {label}
       </p>
       {payload.map((entry, i) => {
-        const key = entry.dataKey as string;
+        const key = String(entry.dataKey ?? i);
         const item = config[key];
         const color = item?.color ?? CHART_COLORS[i % CHART_COLORS.length];
         const entryLabel = item?.label ?? key;
@@ -2073,7 +2068,7 @@ export function ChartTooltipContent({
             <span className="text-xs font-semibold text-slate-900 dark:text-white">
               {typeof entry.value === "number"
                 ? entry.value.toLocaleString()
-                : String(entry.value)}
+                : String(entry.value ?? "")}
             </span>
           </div>
         );
@@ -2082,21 +2077,21 @@ export function ChartTooltipContent({
   );
 }
 
-export function ChartTooltip(props?: Partial<TooltipProps<number, string>>) {
-  return (
-    <RechartsTooltip
-      content={<ChartTooltipContent />}
-      cursor={false}
-      {...props}
-    />
-  );
+export function ChartTooltip() {
+  return <RechartsTooltip content={ChartTooltipContent} cursor={false} />;
 }
 
 // ─── ChartLegend ───────────────────────────────────────────────────────────────
 
 export function ChartLegendContent({
   payload,
-}: LegendProps) {
+}: {
+  payload?: ReadonlyArray<{
+    value?: string;
+    color?: string;
+    dataKey?: unknown;
+  }>;
+}) {
   const config = useChartConfig();
 
   if (!payload?.length) return null;
@@ -2104,10 +2099,10 @@ export function ChartLegendContent({
   return (
     <div className="flex flex-wrap items-center justify-center gap-4 pt-2">
       {payload.map((entry, i) => {
-        const key = entry.value as string;
+        const key = String(entry.value ?? i);
         const item = config[key];
         const color = item?.color ?? entry.color ?? CHART_COLORS[i % CHART_COLORS.length];
-        const entryLabel = item?.label ?? entry.value;
+        const entryLabel = item?.label ?? entry.value ?? key;
 
         return (
           <div key={key} className="flex items-center gap-1.5">
@@ -2125,13 +2120,8 @@ export function ChartLegendContent({
   );
 }
 
-export function ChartLegend(props?: Partial<LegendProps>) {
-  return (
-    <RechartsLegend
-      content={<ChartLegendContent />}
-      {...props}
-    />
-  );
+export function ChartLegend() {
+  return <RechartsLegend content={<ChartLegendContent />} />;
 }
 
 // ─── Re-exports ────────────────────────────────────────────────────────────────

--- a/packages/cli/src/utils/deps.ts
+++ b/packages/cli/src/utils/deps.ts
@@ -61,9 +61,9 @@ export function resolvePresetDependencies(preset: CliPreset): ResolvedDeps {
   }
 
   // Stack deps
-  if (preset.stack.stateManagement) STACK_DEPS.stateManagement.forEach(add);
-  if (preset.stack.dataFetching) STACK_DEPS.dataFetching.forEach(add);
-  if (preset.stack.forms) STACK_DEPS.forms.forEach(add);
+  if (preset.stack.stateManagement) STACK_DEPS["stateManagement"]?.forEach(add);
+  if (preset.stack.dataFetching) STACK_DEPS["dataFetching"]?.forEach(add);
+  if (preset.stack.forms) STACK_DEPS["forms"]?.forEach(add);
 
   const all = Array.from(seen.values());
   const fmt = (p: PackageEntry) => p.version ? `${p.name}@${p.version}` : p.name;

--- a/packages/cli/src/utils/deps.ts
+++ b/packages/cli/src/utils/deps.ts
@@ -1,0 +1,103 @@
+import { execSync } from "child_process";
+import type { CliPreset } from "./preset";
+import { detectPackageManager } from "./pm";
+
+interface PackageEntry {
+  name: string;
+  version?: string;
+  dev?: boolean;
+}
+
+const COMPONENT_DEPS: Record<string, PackageEntry[]> = {
+  DataTable:   [{ name: "@tanstack/react-table", version: "^8.20.0" }],
+  Chart:       [{ name: "recharts", version: "^2.15.0" }],
+  DatePicker:  [{ name: "react-day-picker", version: "^9.1.4" }, { name: "date-fns", version: "^4.1.0" }],
+  Calendar:    [{ name: "react-day-picker", version: "^9.1.4" }, { name: "date-fns", version: "^4.1.0" }],
+  Toast:       [{ name: "sonner", version: "^2.0.0" }],
+  Select:      [{ name: "@radix-ui/react-select", version: "^2.1.6" }],
+  Checkbox:    [{ name: "@radix-ui/react-checkbox", version: "^1.1.4" }],
+  Radio:       [{ name: "@radix-ui/react-radio-group", version: "^1.2.3" }],
+  Switch:      [{ name: "@radix-ui/react-switch", version: "^1.1.3" }],
+  Slider:      [{ name: "@radix-ui/react-slider", version: "^1.2.3" }],
+  Tabs:        [{ name: "@radix-ui/react-tabs", version: "^1.1.3" }],
+  Dialog:      [{ name: "@radix-ui/react-dialog", version: "^1.1.6" }],
+  Popover:     [{ name: "@radix-ui/react-popover", version: "^1.1.6" }],
+  Tooltip:     [{ name: "@radix-ui/react-tooltip", version: "^1.1.8" }],
+  Drawer:      [{ name: "@radix-ui/react-dialog", version: "^1.1.6" }],
+  Separator:   [{ name: "@radix-ui/react-separator", version: "^1.1.2" }],
+  Collapsible: [{ name: "@radix-ui/react-collapsible", version: "^1.1.3" }],
+  Dropdown:    [{ name: "@radix-ui/react-dropdown-menu", version: "^2.1.6" }],
+  Carousel:    [{ name: "embla-carousel-react", version: "^8.5.0" }],
+};
+
+const STACK_DEPS: Record<string, PackageEntry[]> = {
+  stateManagement: [{ name: "zustand", version: "^5.0.0" }],
+  dataFetching:    [{ name: "@tanstack/react-query", version: "^5.59.0" }],
+  forms:           [
+    { name: "react-hook-form", version: "^7.53.0" },
+    { name: "zod", version: "^4.3.6" },
+    { name: "@hookform/resolvers", version: "^3.9.1" },
+  ],
+};
+
+export interface ResolvedDeps {
+  deps: string[];
+  devDeps: string[];
+}
+
+export function resolvePresetDependencies(preset: CliPreset): ResolvedDeps {
+  const seen = new Map<string, PackageEntry>();
+
+  const add = (entry: PackageEntry) => {
+    const key = entry.name;
+    if (!seen.has(key)) seen.set(key, entry);
+  };
+
+  // Component deps
+  for (const comp of preset.components) {
+    for (const dep of COMPONENT_DEPS[comp] ?? []) {
+      add(dep);
+    }
+  }
+
+  // Stack deps
+  if (preset.stack.stateManagement) STACK_DEPS.stateManagement.forEach(add);
+  if (preset.stack.dataFetching) STACK_DEPS.dataFetching.forEach(add);
+  if (preset.stack.forms) STACK_DEPS.forms.forEach(add);
+
+  const all = Array.from(seen.values());
+  const fmt = (p: PackageEntry) => p.version ? `${p.name}@${p.version}` : p.name;
+
+  return {
+    deps: all.filter((p) => !p.dev).map(fmt),
+    devDeps: all.filter((p) => p.dev).map(fmt),
+  };
+}
+
+export function installPresetDependencies(
+  resolved: ResolvedDeps,
+  cwd: string,
+  options: { dryRun?: boolean } = {},
+): void {
+  const pm = detectPackageManager(cwd);
+  const addCmd = pm === "yarn" ? "yarn add" : `${pm} install`;
+  const addDevCmd = pm === "yarn" ? "yarn add -D" : `${pm} install -D`;
+
+  if (resolved.deps.length > 0) {
+    const cmd = `${addCmd} ${resolved.deps.join(" ")}`;
+    if (options.dryRun) {
+      console.log(`  ${cmd}`);
+    } else {
+      execSync(cmd, { cwd, stdio: "inherit" });
+    }
+  }
+
+  if (resolved.devDeps.length > 0) {
+    const cmd = `${addDevCmd} ${resolved.devDeps.join(" ")}`;
+    if (options.dryRun) {
+      console.log(`  ${cmd}`);
+    } else {
+      execSync(cmd, { cwd, stdio: "inherit" });
+    }
+  }
+}

--- a/packages/cli/src/utils/preset.ts
+++ b/packages/cli/src/utils/preset.ts
@@ -1,0 +1,37 @@
+import { inflateRawSync } from "zlib";
+
+export interface CliPreset {
+  style: "arc" | "edge" | "soleil";
+  colors: { base: string; brand: string; accent: string; chart: string };
+  fonts: { header: string; body: string };
+  iconSet: string;
+  radius: "none" | "sm" | "md" | "lg";
+  components: string[];
+  stack: {
+    framework: "nextjs" | "vite";
+    stateManagement: boolean;
+    dataFetching: boolean;
+    forms: boolean;
+    monorepo: boolean;
+    rtl: boolean;
+  };
+  version: number;
+}
+
+/**
+ * Decodes a URL-safe base64+deflate preset string produced by encodePreset()
+ * in the web app. Uses Node.js built-in zlib (raw deflate) — no extra deps.
+ */
+export function decodePreset(encoded: string): CliPreset | null {
+  try {
+    let base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    while (base64.length % 4) base64 += "=";
+
+    const compressed = Buffer.from(base64, "base64");
+    const decompressed = inflateRawSync(compressed);
+    const json = decompressed.toString("utf8");
+    return JSON.parse(json) as CliPreset;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/api/og/create/route.tsx
+++ b/src/app/api/og/create/route.tsx
@@ -1,0 +1,250 @@
+import { ImageResponse } from "next/og";
+import type { NextRequest } from "next/server";
+import { decodePreset } from "@/features/configurator/lib";
+
+export const runtime = "edge";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+export function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const preset = searchParams.get("preset");
+
+  if (!preset) return fallbackImage();
+
+  const config = decodePreset(preset);
+  if (!config) return fallbackImage();
+
+  const frameworkLabel = config.stack.framework === "nextjs" ? "Next.js" : "Vite";
+  const styleLabel = config.style.charAt(0).toUpperCase() + config.style.slice(1);
+  const topComponents = config.components.slice(0, 6);
+  const moreCount = config.components.length - topComponents.length;
+
+  const stackFeatures: string[] = [];
+  if (config.stack.stateManagement) stackFeatures.push("Zustand");
+  if (config.stack.dataFetching) stackFeatures.push("TanStack Query");
+  if (config.stack.forms) stackFeatures.push("RHF + Zod");
+  if (config.stack.monorepo) stackFeatures.push("Monorepo");
+
+  const brandColor = config.colors.brand;
+  const accentColor = config.colors.accent;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: WIDTH,
+          height: HEIGHT,
+          background: "#0b0e14",
+          display: "flex",
+          flexDirection: "column",
+          fontFamily: "sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Brand color top bar */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 4,
+            background: `linear-gradient(90deg, ${brandColor}, ${accentColor})`,
+            display: "flex",
+          }}
+        />
+
+        {/* Background glow */}
+        <div
+          style={{
+            position: "absolute",
+            top: -120,
+            left: -80,
+            width: 480,
+            height: 480,
+            borderRadius: "50%",
+            background: `radial-gradient(circle, ${brandColor}18 0%, transparent 70%)`,
+            display: "flex",
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            padding: "56px 64px",
+            flex: 1,
+            gap: 0,
+          }}
+        >
+          {/* Header row */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 48 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <div
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  background: brandColor,
+                  display: "flex",
+                }}
+              />
+              <span style={{ color: "#94a3b8", fontSize: 16, fontWeight: 600, letterSpacing: 2, textTransform: "uppercase" }}>
+                React Principles
+              </span>
+            </div>
+            {/* Framework badge */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "6px 16px",
+                borderRadius: 24,
+                border: `1px solid ${brandColor}40`,
+                background: `${brandColor}15`,
+              }}
+            >
+              <span style={{ color: brandColor, fontSize: 15, fontWeight: 700 }}>{frameworkLabel}</span>
+            </div>
+          </div>
+
+          {/* Main title */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 40 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              {/* Color swatch */}
+              <div
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 12,
+                  background: `linear-gradient(135deg, ${brandColor}, ${accentColor})`,
+                  display: "flex",
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ color: "#ffffff", fontSize: 52, fontWeight: 800, lineHeight: 1.1, letterSpacing: -1 }}>
+                {styleLabel} preset
+              </span>
+            </div>
+            <span style={{ color: "#64748b", fontSize: 22, fontWeight: 400, paddingLeft: 62 }}>
+              {frameworkLabel} starter configured via react-principles
+            </span>
+          </div>
+
+          {/* Components row */}
+          {topComponents.length > 0 && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginBottom: 40 }}>
+              {topComponents.map((comp) => (
+                <div
+                  key={comp}
+                  style={{
+                    display: "flex",
+                    padding: "6px 14px",
+                    borderRadius: 8,
+                    background: "#161b22",
+                    border: "1px solid #1f2937",
+                    color: "#94a3b8",
+                    fontSize: 14,
+                    fontWeight: 600,
+                  }}
+                >
+                  {comp}
+                </div>
+              ))}
+              {moreCount > 0 && (
+                <div
+                  style={{
+                    display: "flex",
+                    padding: "6px 14px",
+                    borderRadius: 8,
+                    background: "#161b22",
+                    border: "1px solid #1f2937",
+                    color: "#475569",
+                    fontSize: 14,
+                    fontWeight: 600,
+                  }}
+                >
+                  +{moreCount} more
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Stack features row */}
+          {stackFeatures.length > 0 && (
+            <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+              <span style={{ color: "#475569", fontSize: 14, fontWeight: 600 }}>Stack:</span>
+              {stackFeatures.map((f) => (
+                <div
+                  key={f}
+                  style={{
+                    display: "flex",
+                    padding: "4px 12px",
+                    borderRadius: 6,
+                    background: `${accentColor}15`,
+                    border: `1px solid ${accentColor}30`,
+                    color: accentColor,
+                    fontSize: 13,
+                    fontWeight: 600,
+                  }}
+                >
+                  {f}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "20px 64px",
+            borderTop: "1px solid #1f2937",
+          }}
+        >
+          <span style={{ color: "#475569", fontSize: 15 }}>reactprinciples.dev/create</span>
+          <span style={{ color: "#334155", fontSize: 14 }}>Share this preset →</span>
+        </div>
+      </div>
+    ),
+    { width: WIDTH, height: HEIGHT },
+  );
+}
+
+function fallbackImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: WIDTH,
+          height: HEIGHT,
+          background: "#0b0e14",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          gap: 16,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{ width: 12, height: 12, borderRadius: "50%", background: "#3b82f6", display: "flex" }} />
+          <span style={{ color: "#94a3b8", fontSize: 18, fontWeight: 600, letterSpacing: 2, textTransform: "uppercase" }}>
+            React Principles
+          </span>
+        </div>
+        <span style={{ color: "#ffffff", fontSize: 56, fontWeight: 800, letterSpacing: -1 }}>Create Project</span>
+        <span style={{ color: "#475569", fontSize: 22 }}>Configure and scaffold your React stack</span>
+        <span style={{ color: "#334155", fontSize: 16, marginTop: 8 }}>reactprinciples.dev/create</span>
+      </div>
+    ),
+    { width: WIDTH, height: HEIGHT },
+  );
+}

--- a/src/app/create/_CreatePageContent.tsx
+++ b/src/app/create/_CreatePageContent.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryState } from "nuqs";
+import { DocsHeader } from "@/features/docs/components/DocsHeader";
+import { ConfiguratorSidebar } from "@/features/configurator/components/ConfiguratorSidebar";
+import { CreateProjectModal } from "@/features/configurator/components/CreateProjectModal";
+import { LivePreviewPanel } from "@/features/configurator/components/LivePreviewPanel";
+import { decodePreset, encodePreset } from "@/features/configurator/lib";
+import { useWizardStore } from "@/features/configurator/stores/useWizardStore";
+import { useDebounce } from "@/shared/hooks/useDebounce";
+import { Button } from "@/ui/Button";
+import { Drawer } from "@/ui/Drawer";
+
+export function CreatePageContent() {
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [presetParam, setPresetParam] = useQueryState("preset", {
+    history: "replace",
+    shallow: true,
+  });
+
+  const { hydrateFromPreset, getPresetConfig } = useWizardStore();
+  const [ready, setReady] = useState(!presetParam);
+
+  const didHydrateFromUrlRef = useRef(false);
+  const skipNextUrlWriteRef = useRef(false);
+
+  useEffect(() => {
+    if (didHydrateFromUrlRef.current) return;
+
+    if (presetParam) {
+      const preset = decodePreset(presetParam);
+      hydrateFromPreset(preset);
+      skipNextUrlWriteRef.current = true;
+    }
+
+    didHydrateFromUrlRef.current = true;
+    setReady(true);
+  }, [hydrateFromPreset, presetParam]);
+
+  const encodedPreset = encodePreset(getPresetConfig());
+  const debouncedPreset = useDebounce(encodedPreset, 250);
+
+  useEffect(() => {
+    if (!didHydrateFromUrlRef.current) return;
+
+    if (skipNextUrlWriteRef.current) {
+      skipNextUrlWriteRef.current = false;
+      return;
+    }
+
+    if (debouncedPreset !== presetParam) {
+      void setPresetParam(debouncedPreset);
+    }
+  }, [debouncedPreset, presetParam, setPresetParam]);
+
+  const openCreateModal = () => {
+    setCreateModalOpen(true);
+    setMobileSidebarOpen(false);
+  };
+
+  if (!ready) return <CreatePageFallback />;
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900 dark:bg-[#0b0e14] dark:text-white">
+      <DocsHeader />
+
+      <main className="min-h-[calc(100vh-3.5rem)] lg:flex">
+        <div className="hidden lg:block lg:w-[320px] lg:shrink-0">
+          <ConfiguratorSidebar onOpenCreateModal={openCreateModal} className="lg:sticky lg:top-14 lg:h-[calc(100vh-3.5rem)]" />
+        </div>
+
+        <section className="flex-1 border-slate-200 bg-slate-50/80 dark:border-[#1f2937] dark:bg-[#0d1117]">
+          <div className="flex items-center justify-between gap-4 border-b border-slate-200 bg-white/80 px-4 py-3 backdrop-blur-md dark:border-[#1f2937] dark:bg-[#0b0e14]/80 lg:hidden">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-wider text-primary">Configurator</p>
+              <h1 className="text-base font-semibold text-slate-900 dark:text-white">Create Project</h1>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => setMobileSidebarOpen(true)} className="gap-2">
+              <span className="material-symbols-outlined text-[18px]">tune</span>
+              Configure
+            </Button>
+          </div>
+
+          <div className="p-4 sm:p-6">
+            <LivePreviewPanel />
+          </div>
+        </section>
+      </main>
+
+      <Drawer open={mobileSidebarOpen} onClose={() => setMobileSidebarOpen(false)} side="left" size="full">
+        <ConfiguratorSidebar onOpenCreateModal={openCreateModal} />
+      </Drawer>
+
+      <CreateProjectModal open={createModalOpen} onClose={() => setCreateModalOpen(false)} />
+    </div>
+  );
+}
+
+export function CreatePageFallback() {
+  return (
+    <div className="min-h-screen bg-white text-slate-900 dark:bg-[#0b0e14] dark:text-white">
+      <DocsHeader />
+      <main className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center bg-slate-50/80 dark:bg-[#0d1117]">
+        <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-500 dark:border-[#1f2937] dark:bg-[#161b22] dark:text-slate-400">
+          Loading configurator...
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,122 +1,79 @@
-"use client";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { decodePreset } from "@/features/configurator/lib";
+import { CreatePageContent, CreatePageFallback } from "./_CreatePageContent";
 
-import { Suspense, useEffect, useRef, useState } from "react";
-import { useQueryState } from "nuqs";
-import { DocsHeader } from "@/features/docs/components/DocsHeader";
-import { ConfiguratorSidebar } from "@/features/configurator/components/ConfiguratorSidebar";
-import { CreateProjectModal } from "@/features/configurator/components/CreateProjectModal";
-import { LivePreviewPanel } from "@/features/configurator/components/LivePreviewPanel";
-import { decodePreset, encodePreset } from "@/features/configurator/lib";
-import { useWizardStore } from "@/features/configurator/stores/useWizardStore";
-import { useDebounce } from "@/shared/hooks/useDebounce";
-import { Button } from "@/ui/Button";
-import { Drawer } from "@/ui/Drawer";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3001";
+
+const DEFAULT_METADATA: Metadata = {
+  title: "Create Project — React Principles",
+  description:
+    "Configure and scaffold a React project with your preferred stack, components, and visual style.",
+  openGraph: {
+    title: "Create Project — React Principles",
+    description:
+      "Configure and scaffold a React project with your preferred stack, components, and visual style.",
+    images: [`${SITE_URL}/api/og/create`],
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
+};
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ preset?: string }>;
+}): Promise<Metadata> {
+  const { preset } = await searchParams;
+
+  if (!preset) return DEFAULT_METADATA;
+
+  const config = decodePreset(preset);
+
+  const frameworkLabel = config.stack.framework === "nextjs" ? "Next.js" : "Vite";
+  const styleLabel = config.style.charAt(0).toUpperCase() + config.style.slice(1);
+
+  const topComponents = config.components.slice(0, 4).join(", ");
+  const more = config.components.length > 4 ? ` +${config.components.length - 4} more` : "";
+
+  const stackFeatures: string[] = [];
+  if (config.stack.stateManagement) stackFeatures.push("Zustand");
+  if (config.stack.dataFetching) stackFeatures.push("TanStack Query");
+  if (config.stack.forms) stackFeatures.push("React Hook Form");
+
+  const title = topComponents
+    ? `${frameworkLabel} · ${topComponents}${more} · ${styleLabel} — React Principles`
+    : `${frameworkLabel} · ${styleLabel} style — React Principles`;
+
+  const description =
+    stackFeatures.length > 0
+      ? `React project with ${stackFeatures.join(", ")} — configured via react-principles`
+      : `${frameworkLabel} project with ${styleLabel} style — configured via react-principles`;
+
+  const ogImage = `${SITE_URL}/api/og/create?preset=${preset}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [ogImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
 
 export default function CreatePage() {
   return (
     <Suspense fallback={<CreatePageFallback />}>
       <CreatePageContent />
     </Suspense>
-  );
-}
-
-function CreatePageContent() {
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  const [createModalOpen, setCreateModalOpen] = useState(false);
-  const [presetParam, setPresetParam] = useQueryState("preset", {
-    history: "replace",
-    shallow: true,
-  });
-
-  const { hydrateFromPreset, getPresetConfig } = useWizardStore();
-  // Delay render until URL preset is hydrated to prevent flash of stale localStorage state.
-  // If there's no preset in the URL, we're immediately ready.
-  const [ready, setReady] = useState(!presetParam);
-
-  const didHydrateFromUrlRef = useRef(false);
-  const skipNextUrlWriteRef = useRef(false);
-
-  useEffect(() => {
-    if (didHydrateFromUrlRef.current) return;
-
-    if (presetParam) {
-      const preset = decodePreset(presetParam);
-      hydrateFromPreset(preset);
-      skipNextUrlWriteRef.current = true;
-    }
-
-    didHydrateFromUrlRef.current = true;
-    setReady(true);
-  }, [hydrateFromPreset, presetParam]);
-
-  const encodedPreset = encodePreset(getPresetConfig());
-  const debouncedPreset = useDebounce(encodedPreset, 250);
-
-  useEffect(() => {
-    if (!didHydrateFromUrlRef.current) return;
-
-    if (skipNextUrlWriteRef.current) {
-      skipNextUrlWriteRef.current = false;
-      return;
-    }
-
-    if (debouncedPreset !== presetParam) {
-      void setPresetParam(debouncedPreset);
-    }
-  }, [debouncedPreset, presetParam, setPresetParam]);
-
-  const openCreateModal = () => {
-    setCreateModalOpen(true);
-    setMobileSidebarOpen(false);
-  };
-
-  if (!ready) return <CreatePageFallback />;
-
-  return (
-    <div className="min-h-screen bg-white text-slate-900 dark:bg-[#0b0e14] dark:text-white">
-      <DocsHeader />
-
-      <main className="min-h-[calc(100vh-3.5rem)] lg:flex">
-        <div className="hidden lg:block lg:w-[320px] lg:shrink-0">
-          <ConfiguratorSidebar onOpenCreateModal={openCreateModal} className="lg:sticky lg:top-14 lg:h-[calc(100vh-3.5rem)]" />
-        </div>
-
-        <section className="flex-1 border-slate-200 bg-slate-50/80 dark:border-[#1f2937] dark:bg-[#0d1117]">
-          <div className="flex items-center justify-between gap-4 border-b border-slate-200 bg-white/80 px-4 py-3 backdrop-blur-md dark:border-[#1f2937] dark:bg-[#0b0e14]/80 lg:hidden">
-            <div>
-              <p className="text-xs font-bold uppercase tracking-wider text-primary">Configurator</p>
-              <h1 className="text-base font-semibold text-slate-900 dark:text-white">Create Project</h1>
-            </div>
-            <Button variant="outline" size="sm" onClick={() => setMobileSidebarOpen(true)} className="gap-2">
-              <span className="material-symbols-outlined text-[18px]">tune</span>
-              Configure
-            </Button>
-          </div>
-
-          <div className="p-4 sm:p-6">
-            <LivePreviewPanel />
-          </div>
-        </section>
-      </main>
-
-      <Drawer open={mobileSidebarOpen} onClose={() => setMobileSidebarOpen(false)} side="left" size="full">
-        <ConfiguratorSidebar onOpenCreateModal={openCreateModal} />
-      </Drawer>
-
-      <CreateProjectModal open={createModalOpen} onClose={() => setCreateModalOpen(false)} />
-    </div>
-  );
-}
-
-function CreatePageFallback() {
-  return (
-    <div className="min-h-screen bg-white text-slate-900 dark:bg-[#0b0e14] dark:text-white">
-      <DocsHeader />
-      <main className="flex min-h-[calc(100vh-3.5rem)] items-center justify-center bg-slate-50/80 dark:bg-[#0d1117]">
-        <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-500 dark:border-[#1f2937] dark:bg-[#161b22] dark:text-slate-400">
-          Loading configurator...
-        </div>
-      </main>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add `react-principles create <app-name> --preset <encoded>` command that scaffolds a full React project from a preset string generated at `reactprinciples.dev/create`
- Add preset decoder using Node.js built-in `zlib` — no new dependencies required
- Add dependency resolver that maps component and stack selections to deduplicated npm package lists
- Bump CLI version to `0.1.0` and add `CHANGELOG.md`

## What's included

**`packages/cli/src/commands/create.ts`**
- Prompts for app name if not provided
- Decodes preset (falls back to default Arc/Next.js if missing)
- Scaffolds feature-sliced structure: `src/ui/`, `src/shared/`, `src/app/`
- Generates `package.json`, `tsconfig.json`, framework config, `globals.css` with style vars
- Copies selected UI components from registry into `src/ui/`
- Runs install automatically (npm / pnpm / yarn / bun auto-detected)
- `--dry-run` flag prints packages without writing files

**`packages/cli/src/utils/preset.ts`**
- Decodes URL-safe base64 + raw DEFLATE preset strings
- Uses `zlib.inflateRawSync` — compatible with `fflate.compressSync` output from the web app

**`packages/cli/src/utils/deps.ts`**
- `resolvePresetDependencies(preset)` — returns `{ deps, devDeps }` deduplicated
- `installPresetDependencies(resolved, cwd, { dryRun? })` — runs correct install command per PM

## Test plan

- [x] `node packages/cli/dist/index.js create test-app --dry-run` — prints summary, no files written
- [x] `node packages/cli/dist/index.js create test-app` — scaffolds project, installs 49 packages
- [x] Scaffolded structure verified: `src/ui/`, `src/shared/`, `src/app/`, all config files present
- [x] Typecheck passes — `pnpm --filter react-principles typecheck`
- [x] Build passes — `pnpm build:cli`

## Closes

Closes #140, #141, #144