### PR TITLE
docs(cli): add create command documentation to README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,6 +77,69 @@ npx react-principles init --template next
 
 ---
 
+### `create`
+
+Scaffold a full React project from a preset string generated at [reactprinciples.dev/create](https://reactprinciples.dev/create).
+
+```bash
+npx react-principles create my-app
+npx react-principles create my-app --preset <encoded>
+npx react-principles create my-app --preset <encoded> --dry-run
+```
+
+**Arguments**
+
+| Argument | Description |
+|----------|-------------|
+| `[app-name]` | Name of the project directory to create. Prompted if not provided. |
+
+**Options**
+
+| Flag | Description |
+|------|-------------|
+| `--preset <encoded>` | Encoded preset string from `reactprinciples.dev/create`. Falls back to default (Arc style, Next.js) if omitted. |
+| `--dry-run` | Print the dependency list and project summary without writing any files. |
+
+**What it does**
+
+1. Decodes the preset string to read your chosen style, framework, components, and stack
+2. Creates the project directory with a feature-sliced structure: `src/ui/`, `src/shared/`, `src/app/`
+3. Generates `package.json`, `tsconfig.json`, framework config, and `globals.css` with your style's CSS custom properties
+4. Copies your selected UI components into `src/ui/`
+5. Auto-detects your package manager (npm / pnpm / yarn / bun) and runs install
+
+**Example output**
+
+```
+✦ react-principles create
+
+  Framework : Next.js
+  Style     : arc (#3b82f6)
+  Radius    : md
+  Components: Button, Input, Card, Dialog, Toast
+  Packages  : 2 deps, 0 devDeps
+  PM        : pnpm
+
+→ Creating project structure
+  ✓ Base files
+  ✓ Next.js config + app directory
+  ✓ package.json
+  ✓ components.json
+
+→ Copying components
+  ✓ Copied: Button, Input, Card, Dialog, Toast
+
+→ Installing dependencies with pnpm
+  ✓ Dependencies installed
+
+✓ Done! Created my-app/
+
+  cd my-app
+  pnpm run dev
+```
+
+---
+
 ### `add`
 
 Add one or more components to your project.


### PR DESCRIPTION
Includes create command usage, options, and example output in packages/cli/README.md.