### PR TITLE
fix(ci): switch release-please to use pat instead of default token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Replace \`GITHUB_TOKEN\` with \`RELEASE_TOKEN\` (PAT) in release-please workflow
- \`GITHUB_TOKEN\` cannot trigger other GitHub Actions workflows by design — switching to PAT allows the \`release: published\` event to trigger \`publish.yml\` automatically

## Related

> **Note:** This fix does not touch \`packages/cli/\` — no version bump will be triggered.