### PR TITLE
fix(ci): add workflow_dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish CLI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Add \`workflow_dispatch\` trigger to \`publish.yml\` so the workflow can be triggered manually from GitHub Actions UI
- Needed to publish \`react-principles@0.1.1\` to npm, which was skipped when \`publish.yml\` failed to trigger due to \`GITHUB_TOKEN\` limitation

## Related

> **Note:** This PR does not touch \`packages/cli/\` — no version bump will be triggered.