### PR TITLE
chore: on-page SEO optimization for react principles keyword

### DIFF
--- a/src/app/(examples)/layout.tsx
+++ b/src/app/(examples)/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ExamplesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,13 +19,17 @@ export const metadata: Metadata = {
   },
   description: DESCRIPTION,
   keywords: [
+    "React principles",
     "React",
+    "React patterns",
+    "React best practices",
+    "React design patterns",
+    "React architecture",
+    "React cookbook",
     "Next.js",
     "TanStack Query",
     "Zustand",
     "TypeScript",
-    "React patterns",
-    "React cookbook",
     "React Hook Form",
     "Tailwind CSS",
   ],
@@ -91,17 +95,35 @@ export default function RootLayout({
 }) {
   const structuredData = {
     "@context": "https://schema.org",
-    "@type": "WebSite",
-    name: TITLE,
-    url: BASE_URL,
-    description: DESCRIPTION,
-    inLanguage: "en-US",
-    publisher: {
-      "@type": "Organization",
-      name: TITLE,
-      url: BASE_URL,
-      logo: `${BASE_URL}/android-chrome-512x512.png`,
-    },
+    "@graph": [
+      {
+        "@type": "WebSite",
+        name: TITLE,
+        url: BASE_URL,
+        description: DESCRIPTION,
+        inLanguage: "en-US",
+        publisher: {
+          "@type": "Organization",
+          name: TITLE,
+          url: BASE_URL,
+          logo: `${BASE_URL}/android-chrome-512x512.png`,
+        },
+      },
+      {
+        "@type": "SoftwareApplication",
+        name: TITLE,
+        url: BASE_URL,
+        description: DESCRIPTION,
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Web",
+        inLanguage: "en-US",
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+      },
+    ],
   };
 
   return (

--- a/src/app/nextjs/cookbook/[slug]/page.tsx
+++ b/src/app/nextjs/cookbook/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import { use } from "react";
 import Link from "next/link";
+import Script from "next/script";
 import type { Metadata } from "next";
 import { DocsPageLayout } from "@/features/docs/components";
 import { CookbookDetailPage } from "@/features/cookbook/components/CookbookDetailPage";
 import { getRecipeDetail } from "@/features/cookbook/data";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 
 export async function generateMetadata({
   params,
@@ -81,5 +84,62 @@ export default function NextjsCookbookDetailPage({
     );
   }
 
-  return <CookbookDetailPage detail={detail} framework="nextjs" />;
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        headline: detail.title,
+        description: detail.description,
+        dateModified: detail.lastUpdated,
+        author: {
+          "@type": "Person",
+          name: detail.contributor.name,
+          jobTitle: detail.contributor.role,
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "React Principles",
+          url: BASE_URL,
+          logo: `${BASE_URL}/android-chrome-512x512.png`,
+        },
+        inLanguage: "en-US",
+        url: `${BASE_URL}/nextjs/cookbook/${detail.slug}`,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: BASE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Cookbook",
+            item: `${BASE_URL}/nextjs/cookbook`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: detail.title,
+            item: `${BASE_URL}/nextjs/cookbook/${detail.slug}`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <Script
+        id={`structured-data-${detail.slug}`}
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <CookbookDetailPage detail={detail} framework="nextjs" />
+    </>
+  );
 }

--- a/src/app/nextjs/cookbook/foundation/page.tsx
+++ b/src/app/nextjs/cookbook/foundation/page.tsx
@@ -1,10 +1,93 @@
+import Script from "next/script";
+import type { Metadata } from "next";
 import { CookbookFoundationPage } from "@/features/cookbook/components/CookbookFoundationPage";
 
-export const metadata = {
-  title: "Foundation — Cookbook · Next.js",
-  description: "Understand the principles, patterns, and conventions behind this cookbook before diving into recipes.",
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+export const metadata: Metadata = {
+  title: "React Principles Foundation — Core Concepts & Conventions",
+  description:
+    "Learn the React principles behind this cookbook: SOLID principles, design patterns, folder structure, and coding conventions for scalable React apps.",
+  keywords: [
+    "react principles",
+    "react design principles",
+    "react patterns",
+    "SOLID principles React",
+    "react conventions",
+    "react folder structure",
+    "react architecture",
+    "react best practices",
+  ],
+  alternates: {
+    canonical: "/nextjs/cookbook/foundation",
+  },
+  openGraph: {
+    title: "React Principles Foundation — Core Concepts & Conventions",
+    description:
+      "Learn the React principles behind this cookbook: SOLID principles, design patterns, folder structure, and coding conventions for scalable React apps.",
+    type: "article",
+    url: "/nextjs/cookbook/foundation",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "React Principles Foundation — Core Concepts & Conventions",
+    description:
+      "Learn the React principles behind this cookbook: SOLID principles, design patterns, folder structure, and coding conventions for scalable React apps.",
+  },
 };
 
 export default function NextjsCookbookFoundationPage() {
-  return <CookbookFoundationPage framework="nextjs" />;
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        headline: "React Principles Foundation",
+        description:
+          "Learn the React principles behind this cookbook: SOLID principles, design patterns, folder structure, and coding conventions for scalable React apps.",
+        url: `${BASE_URL}/nextjs/cookbook/foundation`,
+        publisher: {
+          "@type": "Organization",
+          name: "React Principles",
+          url: BASE_URL,
+          logo: `${BASE_URL}/android-chrome-512x512.png`,
+        },
+        inLanguage: "en-US",
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: BASE_URL,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "Cookbook",
+            item: `${BASE_URL}/nextjs/cookbook`,
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: "Foundation",
+            item: `${BASE_URL}/nextjs/cookbook/foundation`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <Script
+        id="foundation-structured-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <CookbookFoundationPage framework="nextjs" />
+    </>
+  );
 }

--- a/src/app/nextjs/cookbook/page.tsx
+++ b/src/app/nextjs/cookbook/page.tsx
@@ -4,7 +4,7 @@ import { CookbookListPage } from "@/features/cookbook/components/CookbookListPag
 export const metadata: Metadata = {
   title: "Cookbook",
   description: "Production-ready Next.js App Router patterns and reference architectures.",
-  keywords: ["Next.js", "React patterns", "App Router", "TanStack Query", "Zustand", "TypeScript"],
+  keywords: ["React principles", "React patterns", "React cookbook", "Next.js", "App Router", "TanStack Query", "Zustand", "TypeScript"],
   openGraph: {
     title: "React Principles — Cookbook",
     description: "Production-ready Next.js App Router patterns and reference architectures.",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,14 +15,27 @@ import {
 export const metadata: Metadata = {
   title: "React Principles — A Living Cookbook of React Patterns",
   description:
-    "Production-grade React patterns with real implementations using Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
+    "Master React principles with production-grade patterns and real implementations. Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
+  keywords: [
+    "react principles",
+    "react patterns",
+    "react best practices",
+    "react cookbook",
+    "react design patterns",
+    "react architecture",
+    "Next.js patterns",
+    "TypeScript React",
+    "TanStack Query",
+    "Zustand",
+    "React Hook Form",
+  ],
   alternates: {
     canonical: "/",
   },
   openGraph: {
     title: "React Principles — A Living Cookbook of React Patterns",
     description:
-      "Production-grade React patterns with real implementations using Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
+      "Master React principles with production-grade patterns and real implementations. Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
     url: "/",
     images: [
       {
@@ -37,7 +50,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "React Principles — A Living Cookbook of React Patterns",
     description:
-      "Production-grade React patterns with real implementations using Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
+      "Master React principles with production-grade patterns and real implementations. Next.js, Vite, TanStack Query, Zustand, React Hook Form, and TypeScript.",
     images: ["/opengraph-image"],
   },
 };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,6 +22,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.9,
     },
+    {
+      url: `${BASE_URL}/nextjs/cookbook/foundation`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.85,
+    },
   ];
 
   // Docs pages (only published — skip "soon" items)

--- a/src/app/vitejs/cookbook/foundation/page.tsx
+++ b/src/app/vitejs/cookbook/foundation/page.tsx
@@ -1,8 +1,17 @@
+import type { Metadata } from "next";
 import { CookbookFoundationPage } from "@/features/cookbook/components/CookbookFoundationPage";
 
-export const metadata = {
-  title: "Foundation — Cookbook · Vite",
-  description: "Understand the principles, patterns, and conventions behind this cookbook before diving into recipes.",
+export const metadata: Metadata = {
+  title: "React Principles Foundation — Core Concepts & Conventions",
+  description:
+    "Learn the React principles behind this cookbook: SOLID principles, design patterns, folder structure, and coding conventions for scalable React apps.",
+  alternates: {
+    canonical: "/nextjs/cookbook/foundation",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function VitejsCookbookFoundationPage() {

--- a/src/features/cookbook/components/CookbookFoundationPage.tsx
+++ b/src/features/cookbook/components/CookbookFoundationPage.tsx
@@ -113,7 +113,7 @@ export function CookbookFoundationPage({ framework }: CookbookFoundationPageProp
             </span>
           </div>
           <h1 className="text-4xl font-extrabold tracking-tight text-slate-900 dark:text-white lg:text-5xl mb-4">
-            Foundation
+            React Principles Foundation
           </h1>
           <p className="max-w-2xl text-lg leading-relaxed text-slate-600 dark:text-slate-400">
             Before diving into recipes, here's everything you need to know about how this cookbook

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -174,8 +174,9 @@ export function HeroSection() {
         </Badge>
 
         <h1 className="mb-8 text-5xl font-black leading-[1.1] tracking-tight text-slate-900 md:text-7xl dark:text-white">
-          The Living Cookbook <br />
-          <span className="text-primary">for Modern React</span>
+          <span className="text-primary">React Principles</span>
+          <br />
+          The Living Cookbook for Modern React
         </h1>
 
         <p className="mx-auto mb-10 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">


### PR DESCRIPTION
## Summary

- Upgrade root JSON-LD from single `WebSite` to `@graph` combining `WebSite` + `SoftwareApplication` (applicationCategory: DeveloperApplication)
- Add `TechArticle` + `BreadcrumbList` JSON-LD on all cookbook recipe pages and the foundation page for rich snippet eligibility
- Update homepage H1 to lead with brand keyword "React Principles"
- Expand global keywords and homepage metadata description to naturally include target terms
- Fully optimize `/nextjs/cookbook/foundation` — the most "React principles as concept" page on the site: metadata, canonical, OG, keywords, H1, sitemap entry
- Set vitejs foundation to `noindex` with canonical pointing to nextjs version (consistent with existing vitejs pattern)
- Add `noindex` to all `(examples)` demo pages via a single route group layout to prevent thin content from being indexed

## Files changed

| File | Change |
|---|---|
| `src/app/layout.tsx` | Keywords + `@graph` structured data |
| `src/app/page.tsx` | Description + keywords |
| `src/features/landing/components/HeroSection.tsx` | H1 now leads with "React Principles" |
| `src/app/nextjs/cookbook/page.tsx` | Keywords |
| `src/app/nextjs/cookbook/[slug]/page.tsx` | TechArticle + BreadcrumbList JSON-LD |
| `src/app/nextjs/cookbook/foundation/page.tsx` | Full metadata overhaul + JSON-LD |
| `src/app/vitejs/cookbook/foundation/page.tsx` | Canonical + noindex |
| `src/app/sitemap.ts` | Foundation page added |
| `src/app/(examples)/layout.tsx` | New — noindex for all demo pages |
| `src/features/cookbook/components/CookbookFoundationPage.tsx` | H1 update |