### PR TITLE
feat(examples): implement server state, client state, and form validation recipes (#64, #65, #66)

### DIFF
--- a/src/app/(examples)/layout.tsx
+++ b/src/app/(examples)/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ExamplesShell } from "@/features/examples/components/ExamplesShell";
 
 export const metadata: Metadata = {
   robots: {
@@ -12,5 +13,5 @@ export default function ExamplesLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return <ExamplesShell>{children}</ExamplesShell>;
 }

--- a/src/app/(examples)/react-query/page.tsx
+++ b/src/app/(examples)/react-query/page.tsx
@@ -1,6 +1,16 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/get-query-client";
+import { queryKeys } from "@/lib/query-keys";
+import { usersService } from "@/lib/services/users";
 import { UserList } from "@/features/examples/components/UserList";
 
-export default function ReactQueryPage() {
+export default async function ReactQueryPage() {
+  const qc = getQueryClient();
+  await qc.prefetchQuery({
+    queryKey: queryKeys.users.list({}),
+    queryFn: () => usersService.getAll({}),
+  });
+
   return (
     <main className="mx-auto max-w-4xl px-6 py-12">
       <h1 className="text-3xl font-bold tracking-tight">React Query Example</h1>
@@ -8,7 +18,9 @@ export default function ReactQueryPage() {
         Fetching and displaying users with TanStack React Query.
       </p>
       <div className="mt-8">
-        <UserList />
+        <HydrationBoundary state={dehydrate(qc)}>
+          <UserList />
+        </HydrationBoundary>
       </div>
     </main>
   );

--- a/src/app/(examples)/state/page.tsx
+++ b/src/app/(examples)/state/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useShallow } from "zustand/shallow";
 import { useAppStore } from "@/shared/stores/useAppStore";
-import { useFilterStore } from "@/shared/stores/useFilterStore";
+import { UserFilters } from "@/features/examples/components/UserFilters";
 
 export default function StatePage() {
-  const { theme, sidebarOpen, toggleTheme, toggleSidebar } = useAppStore();
-  const { search, role, status, setSearch, setRole, setStatus, reset } =
-    useFilterStore();
+  const { theme, sidebarOpen, toggleTheme, toggleSidebar } = useAppStore(
+    useShallow((s) => ({
+      theme: s.theme,
+      sidebarOpen: s.sidebarOpen,
+      toggleTheme: s.toggleTheme,
+      toggleSidebar: s.toggleSidebar,
+    })),
+  );
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-12">
@@ -40,12 +46,14 @@ export default function StatePage() {
             </div>
             <div className="flex gap-2 pt-2">
               <button
+                type="button"
                 onClick={toggleTheme}
                 className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-300"
               >
                 Toggle Theme
               </button>
               <button
+                type="button"
                 onClick={toggleSidebar}
                 className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
               >
@@ -58,62 +66,8 @@ export default function StatePage() {
         {/* Filter Store */}
         <section className="rounded-xl border border-gray-200 p-6 dark:border-gray-800">
           <h2 className="text-xl font-semibold">Filter Store</h2>
-          <div className="mt-4 space-y-3">
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Search
-              </label>
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search users..."
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              />
-            </div>
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Role
-              </label>
-              <select
-                value={role ?? ""}
-                onChange={(e) =>
-                  setRole(
-                    (e.target.value || null) as "admin" | "editor" | "viewer" | null,
-                  )
-                }
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              >
-                <option value="">All roles</option>
-                <option value="admin">Admin</option>
-                <option value="editor">Editor</option>
-                <option value="viewer">Viewer</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Status
-              </label>
-              <select
-                value={status ?? ""}
-                onChange={(e) =>
-                  setStatus(
-                    (e.target.value || null) as "active" | "inactive" | null,
-                  )
-                }
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              >
-                <option value="">All statuses</option>
-                <option value="active">Active</option>
-                <option value="inactive">Inactive</option>
-              </select>
-            </div>
-            <button
-              onClick={reset}
-              className="mt-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-            >
-              Reset Filters
-            </button>
+          <div className="mt-4">
+            <UserFilters />
           </div>
         </section>
       </div>

--- a/src/app/(examples)/users/[id]/edit/page.tsx
+++ b/src/app/(examples)/users/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { use } from "react";
+import { UserEditForm } from "@/features/examples/components/UserEditForm";
+
+export default function EditUserPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">Edit User</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">
+        Update user details with pre-populated form fields.
+      </p>
+      <div className="mt-8">
+        <UserEditForm id={id} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(examples)/users/new/page.tsx
+++ b/src/app/(examples)/users/new/page.tsx
@@ -1,0 +1,15 @@
+import { UserForm } from "@/features/examples/components/UserForm";
+
+export default function NewUserPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">New User</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">
+        Create a user with React Hook Form and Zod validation.
+      </p>
+      <div className="mt-8">
+        <UserForm />
+      </div>
+    </main>
+  );
+}

--- a/src/features/cookbook/data/recipes/client-state.ts
+++ b/src/features/cookbook/data/recipes/client-state.ts
@@ -5,21 +5,26 @@ export const clientState: RecipeDetail = {
   title: "Client State with Zustand",
   breadcrumbCategory: "Patterns",
   description:
-    "Manage global UI state across multiple Zustand stores. Covers store slices, selectors, actions, and a computed filter store with reset.",
+    "Manage global UI state across multiple Zustand stores. Covers selectors, actions, computed selectors, reset, and the 'use client' boundary in Next.js.",
   principle: {
     text: "Client state — UI toggles, filter state, user preferences — belongs in Zustand, not React Query. Each store owns one domain. Components read a slice of state via selectors and call actions. No prop drilling, no context boilerplate.",
     tip: "One store per feature domain. Never put server state (API data) in Zustand — if it comes from an endpoint, it belongs in React Query.",
   },
   rules: [
-    { title: "One store per domain", description: "useAppStore for app-wide settings, useFilterStore for filters. Never mix concerns in a single store." },
+    { title: "One store per domain", description: "useAppStore for app-wide settings, useFilterStore for filters, useSearchStore for search UI. Never mix concerns in a single store." },
     { title: "Actions inside the store", description: "Mutations happen in store actions, not in component event handlers. Keeps logic close to state." },
-    { title: "Selectors over full-state", description: "Pass selector functions: useAppStore(s => s.theme) not useAppStore(). Prevents unnecessary re-renders." },
+    { title: "Selectors over full-state", description: "Pass selector functions: useAppStore(s => s.theme) not useAppStore(). For multiple values, use useShallow from zustand/shallow." },
     { title: "Reset is first-class", description: "Always define a reset() action for stores that can be cleared. Useful for logout, navigation, and testing." },
+    { title: "'use client' on the store file", description: "Zustand hooks call React internals (useState, useSyncExternalStore). Put 'use client' on the store file itself — never on barrel exports — so Server Components can still import types." },
   ],
   pattern: {
-    filename: "stores/useFilterStore.ts",
-    code: `import { create } from 'zustand';
-import type { UserRole, UserStatus } from '@/types';
+    filename: "stores/useFilterStore.ts · useAppStore.ts · useSearchStore.ts",
+    code: `'use client';
+
+import { create } from 'zustand';
+import type { UserRole, UserStatus } from '@/shared/types/common';
+
+// ─── useFilterStore (feature-scoped filters) ─────────────────────────────────
 
 interface FilterState {
   search: string;
@@ -31,71 +36,161 @@ interface FilterState {
   reset: () => void;
 }
 
-const initialState = { search: '', role: null, status: null };
+const initialFilterState = {
+  search: '',
+  role: null as UserRole | null,
+  status: null as UserStatus | null,
+};
 
 export const useFilterStore = create<FilterState>((set) => ({
-  ...initialState,
+  ...initialFilterState,
   setSearch: (search) => set({ search }),
   setRole: (role) => set({ role }),
   setStatus: (status) => set({ status }),
-  reset: () => set(initialState),
+  reset: () => set(initialFilterState),
 }));
 
-// Computed selector — avoids inline logic in components
 export const useHasActiveFilters = () =>
-  useFilterStore((s) => s.search !== '' || s.role !== null || s.status !== null);`,
+  useFilterStore(
+    (s) => s.search !== '' || s.role !== null || s.status !== null,
+  );
+
+// ─── useAppStore (app-wide settings) ─────────────────────────────────────────
+
+type Theme = 'light' | 'dark';
+
+interface AppState {
+  theme: Theme;
+  sidebarOpen: boolean;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  setSidebarOpen: (open: boolean) => void;
+  toggleSidebar: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  theme: 'dark',
+  sidebarOpen: true,
+  setTheme: (theme) => set({ theme }),
+  toggleTheme: () =>
+    set((state) => ({ theme: state.theme === 'light' ? 'dark' : 'light' })),
+  setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
+  toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+}));
+
+// ─── useSearchStore (search dialog UI) ───────────────────────────────────────
+
+interface SearchState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+export const useSearchStore = create<SearchState>()((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((s) => ({ open: !s.open })),
+}));`,
   },
   implementation: {
     nextjs: {
       description:
-        "Zustand stores are client-side only. In Next.js, use them inside Client Components marked with 'use client'. No HydrationBoundary needed — client state is not serialized.",
+        "Zustand stores are client-side only. In Next.js, use them inside Client Components marked with 'use client'. No HydrationBoundary needed — client state is not serialized. Use useShallow when reading multiple values to avoid unnecessary re-renders.",
       filename: "components/UserFilters.tsx",
       code: `'use client';
 
-import { useFilterStore, useHasActiveFilters } from '@/stores/useFilterStore';
+import { useShallow } from 'zustand/shallow';
+import { useFilterStore, useHasActiveFilters } from '@/shared/stores/useFilterStore';
+import { Input } from '@/ui/Input';
+import { NativeSelect } from '@/ui/NativeSelect';
+import type { UserRole } from '@/shared/types/common';
 
 export function UserFilters() {
-  const { search, role, setSearch, setRole, reset } = useFilterStore();
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
   const hasFilters = useHasActiveFilters();
 
   return (
-    <div className="flex gap-3">
-      <input value={search} onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search..." />
-      <select value={role ?? ''} onChange={(e) => setRole(e.target.value || null)}>
+    <div className="flex items-end gap-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+      />
+      <NativeSelect
+        value={role ?? ''}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+      >
         <option value="">All roles</option>
         <option value="admin">Admin</option>
-      </select>
-      {hasFilters && <button onClick={reset}>Reset</button>}
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button onClick={reset}>Reset</button>
+      )}
     </div>
   );
 }`,
     },
     vite: {
       description:
-        "In Vite, Zustand works identically — no special setup required. Import the store hook directly in any component.",
+        "In Vite, Zustand works identically — no special setup required. Import the store hook directly in any component. useShallow is still recommended for multi-value subscriptions.",
       filename: "components/UserFilters.tsx",
-      code: `import { useFilterStore, useHasActiveFilters } from '@/stores/useFilterStore';
+      code: `import { useShallow } from 'zustand/shallow';
+import { useFilterStore, useHasActiveFilters } from '@/shared/stores/useFilterStore';
+import { Input } from '@/ui/Input';
+import { NativeSelect } from '@/ui/NativeSelect';
+import type { UserRole } from '@/shared/types/common';
 
 export function UserFilters() {
-  const { search, role, setSearch, setRole, reset } = useFilterStore();
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
   const hasFilters = useHasActiveFilters();
 
   return (
-    <div className="flex gap-3">
-      <input value={search} onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search..." />
-      <select value={role ?? ''} onChange={(e) => setRole(e.target.value || null)}>
+    <div className="flex items-end gap-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+      />
+      <NativeSelect
+        value={role ?? ''}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+      >
         <option value="">All roles</option>
         <option value="admin">Admin</option>
-      </select>
-      {hasFilters && <button onClick={reset}>Reset</button>}
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button onClick={reset}>Reset</button>
+      )}
     </div>
   );
 }`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 11, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
   demoKey: "zustand",
 };

--- a/src/features/cookbook/data/recipes/form-validation.ts
+++ b/src/features/cookbook/data/recipes/form-validation.ts
@@ -18,23 +18,24 @@ export const formValidation: RecipeDetail = {
     { title: "Share schemas between create and edit", description: "Define a base schema, then derive create and edit variants with .omit() or .partial(). Single source of truth for all validation rules." },
   ],
   pattern: {
-    filename: "lib/schemas/user.ts",
+    filename: "shared/utils/validators.ts",
     code: `import { z } from 'zod';
 
-// Base schema matching DummyJSON user payload
-const baseUserSchema = z.object({
-  firstName: z.string().min(1, 'First name is required'),
-  lastName:  z.string().min(1, 'Last name is required'),
+// Base schema matching the User interface
+const userSchema = z.object({
+  id:        z.string().min(1, 'ID is required'),
+  name:      z.string().min(1, 'Name is required'),
   email:     z.string().email('Enter a valid email address'),
   role:      z.enum(['viewer', 'editor', 'admin']),
-  age:       z.number().int().min(18, 'Must be at least 18').max(120),
+  status:    z.enum(['active', 'inactive']),
+  createdAt: z.string().datetime({ message: 'Invalid ISO date string' }),
 });
 
-// Create: user provides all fields, no id/createdAt
-export const createUserSchema = baseUserSchema;
+// Create: omit server-generated fields
+export const createUserSchema = userSchema.omit({ id: true, createdAt: true });
 
-// Edit: all fields optional — partial of base
-export const editUserSchema = baseUserSchema.partial();
+// Edit: partial of create schema — all fields optional
+export const editUserSchema = createUserSchema.partial();
 
 export type CreateUserValues = z.infer<typeof createUserSchema>;
 export type EditUserValues   = z.infer<typeof editUserSchema>;`,
@@ -43,38 +44,50 @@ export type EditUserValues   = z.infer<typeof editUserSchema>;`,
     nextjs: {
       description:
         "In Next.js App Router, pair the form with a React Query mutation. The form is a Client Component ('use client'). On success, invalidate the users list so the table refreshes automatically. Reset the form to clear dirty state.",
-      filename: "features/examples/components/UserCreateForm.tsx",
+      filename: "features/examples/components/UserForm.tsx",
       code: `'use client';
 
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { type z } from 'zod';
+import { userSchema } from '@/shared/utils/validators';
 import { useCreateUser } from '@/features/examples/hooks/useCreateUser';
-import { createUserSchema, type CreateUserValues } from '@/lib/schemas/user';
 
-export function UserCreateForm() {
+const createUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+type CreateUserFormValues = z.infer<typeof createUserFormSchema>;
+
+export function UserForm() {
   const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
-    resolver: zodResolver(createUserSchema),
-    defaultValues: { firstName: '', lastName: '', email: '', role: 'viewer', age: 18 },
+    formState: { errors, isSubmitting } } = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserFormSchema),
+    defaultValues: { name: '', email: '', role: 'viewer', status: 'active' },
   });
 
   const createMutation = useCreateUser();
 
-  const onSubmit = async (data: CreateUserValues) => {
+  const onSubmit = async (data: CreateUserFormValues) => {
     await createMutation.mutateAsync(data);
     reset();
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('firstName')} placeholder="First name" />
-      {errors.firstName && <p>{errors.firstName.message}</p>}
-
-      <input {...register('lastName')} placeholder="Last name" />
-      {errors.lastName && <p>{errors.lastName.message}</p>}
+      <input {...register('name')} placeholder="Full name" />
+      {errors.name && <p>{errors.name.message}</p>}
 
       <input {...register('email')} placeholder="Email" />
       {errors.email && <p>{errors.email.message}</p>}
+
+      <select {...register('role')}>
+        <option value="viewer">Viewer</option>
+        <option value="editor">Editor</option>
+        <option value="admin">Admin</option>
+      </select>
+
+      <select {...register('status')}>
+        <option value="active">Active</option>
+        <option value="inactive">Inactive</option>
+      </select>
 
       <button type="submit" disabled={isSubmitting}>Create User</button>
     </form>
@@ -90,32 +103,36 @@ export function UserCreateForm() {
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { type z } from 'zod';
+import { userSchema } from '@/shared/utils/validators';
 import { useUser } from '@/features/examples/hooks/useUser';
 import { useUpdateUser } from '@/features/examples/hooks/useUpdateUser';
-import { editUserSchema, type EditUserValues } from '@/lib/schemas/user';
+
+const editUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+type EditUserFormValues = z.infer<typeof editUserFormSchema>;
 
 export function UserEditForm({ id }: { id: string }) {
   const { data: user } = useUser(id);
   const updateMutation = useUpdateUser(id);
 
   const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<EditUserValues>({
-    resolver: zodResolver(editUserSchema),
+    formState: { errors, isSubmitting } } = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserFormSchema),
   });
 
   // Pre-populate form when user data loads
   useEffect(() => {
     if (user) {
       reset({
-        firstName: user.name.split(' ')[0],
-        lastName:  user.name.split(' ')[1] ?? '',
-        email:     user.email,
-        role:      user.role,
+        name:   user.name,
+        email:  user.email,
+        role:   user.role,
+        status: user.status,
       });
     }
   }, [user, reset]);
 
-  const onSubmit = async (data: EditUserValues) => {
+  const onSubmit = async (data: EditUserFormValues) => {
     await updateMutation.mutateAsync(data);
   };
 
@@ -123,8 +140,22 @@ export function UserEditForm({ id }: { id: string }) {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('firstName')} placeholder="First name" />
-      {errors.firstName && <p>{errors.firstName.message}</p>}
+      <input {...register('name')} placeholder="Full name" />
+      {errors.name && <p>{errors.name.message}</p>}
+
+      <input {...register('email')} placeholder="Email" />
+      {errors.email && <p>{errors.email.message}</p>}
+
+      <select {...register('role')}>
+        <option value="viewer">Viewer</option>
+        <option value="editor">Editor</option>
+        <option value="admin">Admin</option>
+      </select>
+
+      <select {...register('status')}>
+        <option value="active">Active</option>
+        <option value="inactive">Inactive</option>
+      </select>
 
       <button type="submit" disabled={isSubmitting}>Save Changes</button>
     </form>

--- a/src/features/cookbook/data/recipes/form-validation.ts
+++ b/src/features/cookbook/data/recipes/form-validation.ts
@@ -15,72 +15,124 @@ export const formValidation: RecipeDetail = {
     { title: "Omit server-generated fields", description: "Use .omit({ id: true, createdAt: true }) for create forms. The schema reflects what the user provides." },
     { title: "handleSubmit owns errors", description: "Wrap mutation calls in handleSubmit. Validation errors surface automatically without try/catch in the component." },
     { title: "Reset after success", description: "Call reset() after a successful mutation to clear all field values and dirty state." },
+    { title: "Share schemas between create and edit", description: "Define a base schema, then derive create and edit variants with .omit() or .partial(). Single source of truth for all validation rules." },
   ],
   pattern: {
-    filename: "components/UserForm.tsx",
-    code: `import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+    filename: "lib/schemas/user.ts",
+    code: `import { z } from 'zod';
 
-const createUserSchema = z.object({
-  name:   z.string().min(1, 'Name is required'),
-  email:  z.string().email('Enter a valid email address'),
-  role:   z.enum(['viewer', 'editor', 'admin']),
-  status: z.enum(['active', 'inactive']),
+// Base schema matching DummyJSON user payload
+const baseUserSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName:  z.string().min(1, 'Last name is required'),
+  email:     z.string().email('Enter a valid email address'),
+  role:      z.enum(['viewer', 'editor', 'admin']),
+  age:       z.number().int().min(18, 'Must be at least 18').max(120),
 });
 
-type CreateUserValues = z.infer<typeof createUserSchema>;
+// Create: user provides all fields, no id/createdAt
+export const createUserSchema = baseUserSchema;
 
-export function UserForm() {
-  const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
-    resolver: zodResolver(createUserSchema),
-    defaultValues: { name: '', email: '', role: 'viewer', status: 'active' },
-  });
+// Edit: all fields optional — partial of base
+export const editUserSchema = baseUserSchema.partial();
 
-  const onSubmit = async (data: CreateUserValues) => {
-    await createUser(data);
-    reset();
-  };
-
-  return <form onSubmit={handleSubmit(onSubmit)}>{/* fields */}</form>;
-}`,
+export type CreateUserValues = z.infer<typeof createUserSchema>;
+export type EditUserValues   = z.infer<typeof editUserSchema>;`,
   },
   implementation: {
     nextjs: {
       description:
-        "In Next.js App Router, pair the form with a Server Action for zero-client-bundle mutations. Validate with the same Zod schema on the server to prevent bypassing client validation.",
-      filename: "app/users/actions.ts",
-      code: `'use server';
+        "In Next.js App Router, pair the form with a React Query mutation. The form is a Client Component ('use client'). On success, invalidate the users list so the table refreshes automatically. Reset the form to clear dirty state.",
+      filename: "features/examples/components/UserCreateForm.tsx",
+      code: `'use client';
 
-import { createUserSchema } from '@/lib/schemas';
-import { db } from '@/lib/db';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCreateUser } from '@/features/examples/hooks/useCreateUser';
+import { createUserSchema, type CreateUserValues } from '@/lib/schemas/user';
 
-export async function createUserAction(values: unknown) {
-  const data = createUserSchema.parse(values); // validates server-side too
-  await db.user.create({ data });
+export function UserCreateForm() {
+  const { register, handleSubmit, reset,
+    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: { firstName: '', lastName: '', email: '', role: 'viewer', age: 18 },
+  });
+
+  const createMutation = useCreateUser();
+
+  const onSubmit = async (data: CreateUserValues) => {
+    await createMutation.mutateAsync(data);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('firstName')} placeholder="First name" />
+      {errors.firstName && <p>{errors.firstName.message}</p>}
+
+      <input {...register('lastName')} placeholder="Last name" />
+      {errors.lastName && <p>{errors.lastName.message}</p>}
+
+      <input {...register('email')} placeholder="Email" />
+      {errors.email && <p>{errors.email.message}</p>}
+
+      <button type="submit" disabled={isSubmitting}>Create User</button>
+    </form>
+  );
 }`,
     },
     vite: {
       description:
-        "In Vite, pair the form with a React Query mutation. On success, invalidate the users list so the table refreshes automatically.",
-      filename: "hooks/mutations/useCreateUser.ts",
-      code: `import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createUser } from '@/services/users';
-import { queryKeys } from '@/lib/query-keys';
+        "In Vite, the pattern is identical — React Query mutation with cache invalidation. The only difference is routing: use react-router instead of Next.js file-based routing.",
+      filename: "features/examples/components/UserEditForm.tsx",
+      code: `'use client';
 
-export function useCreateUser() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: createUser,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.users.lists() });
-    },
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useUser } from '@/features/examples/hooks/useUser';
+import { useUpdateUser } from '@/features/examples/hooks/useUpdateUser';
+import { editUserSchema, type EditUserValues } from '@/lib/schemas/user';
+
+export function UserEditForm({ id }: { id: string }) {
+  const { data: user } = useUser(id);
+  const updateMutation = useUpdateUser(id);
+
+  const { register, handleSubmit, reset,
+    formState: { errors, isSubmitting } } = useForm<EditUserValues>({
+    resolver: zodResolver(editUserSchema),
   });
+
+  // Pre-populate form when user data loads
+  useEffect(() => {
+    if (user) {
+      reset({
+        firstName: user.name.split(' ')[0],
+        lastName:  user.name.split(' ')[1] ?? '',
+        email:     user.email,
+        role:      user.role,
+      });
+    }
+  }, [user, reset]);
+
+  const onSubmit = async (data: EditUserValues) => {
+    await updateMutation.mutateAsync(data);
+  };
+
+  if (!user) return <p>Loading...</p>;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('firstName')} placeholder="First name" />
+      {errors.firstName && <p>{errors.firstName.message}</p>}
+
+      <button type="submit" disabled={isSubmitting}>Save Changes</button>
+    </form>
+  );
 }`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 11, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
   demoKey: "forms",
 };

--- a/src/features/cookbook/data/recipes/server-state.ts
+++ b/src/features/cookbook/data/recipes/server-state.ts
@@ -20,12 +20,12 @@ export const serverState: RecipeDetail = {
     filename: "hooks/queries/useUsers.ts",
     code: `import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
-import { getUsers, type GetUsersParams } from '@/services/users';
+import { usersService, type GetUsersParams } from '@/lib/services/users';
 
 export function useUsers(params: GetUsersParams = {}) {
   return useQuery({
     queryKey: queryKeys.users.list(params),
-    queryFn: () => getUsers(params),
+    queryFn: () => usersService.getAll(params),
     staleTime: 1000 * 60 * 5,       // 5 minutes
     placeholderData: (prev) => prev, // no layout shift on page change
   });
@@ -39,13 +39,13 @@ export function useUsers(params: GetUsersParams = {}) {
       code: `import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { getQueryClient } from '@/lib/get-query-client';
 import { queryKeys } from '@/lib/query-keys';
-import { getUsers } from '@/services/users';
+import { usersService } from '@/lib/services/users';
 
 export default async function UsersPage() {
   const qc = getQueryClient();
   await qc.prefetchQuery({
     queryKey: queryKeys.users.list({}),
-    queryFn: () => getUsers({}),
+    queryFn: () => usersService.getAll({}),
   });
   return (
     <HydrationBoundary state={dehydrate(qc)}>
@@ -62,12 +62,12 @@ export default async function UsersPage() {
 import { LoadingState } from '@/components/common/LoadingState';
 
 export function UsersPage() {
-  const { data, isLoading, isError } = useUsers({ page: 1, limit: 10 });
+  const { data, isLoading, isError } = useUsers({ limit: 10, skip: 0 });
 
   if (isLoading) return <LoadingState rows={5} />;
   if (isError) return <p>Failed to load users.</p>;
 
-  return <UserList users={data.data} meta={data.meta} />;
+  return <UserList users={data.users} total={data.total} skip={data.skip} limit={data.limit} />;
 }`,
     },
   },

--- a/src/features/examples/components/ExamplesNavbar.tsx
+++ b/src/features/examples/components/ExamplesNavbar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { ThemeToggle } from "@/features/landing/components/ThemeToggle";
+import { useAppStore } from "@/shared/stores/useAppStore";
+
+const NAV_LINKS = [
+  { href: "/state", label: "State" },
+  { href: "/react-query", label: "React Query" },
+  { href: "/forms", label: "Forms" },
+  { href: "/table", label: "Table" },
+  { href: "/users", label: "Users" },
+] as const;
+
+export function ExamplesNavbar() {
+  const toggleSidebar = useAppStore((s) => s.toggleSidebar);
+
+  return (
+    <header className="sticky top-0 z-40 w-full border-b border-slate-200 bg-white/80 backdrop-blur-md dark:border-[#1f2937] dark:bg-[#0b0e14]/80">
+      <div className="mx-auto flex h-14 max-w-[1440px] items-center justify-between gap-3 px-4 sm:px-6">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            aria-label="Toggle sidebar"
+            className="flex items-center justify-center rounded-lg p-2 text-slate-500 transition-colors hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+          >
+            <span className="material-symbols-outlined text-xl">menu</span>
+          </button>
+          <Link
+            href="/state"
+            className="text-sm font-bold tracking-tight text-slate-900 dark:text-white"
+          >
+            Examples
+          </Link>
+          <nav className="hidden items-center gap-4 md:flex">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-xs font-medium text-slate-500 transition-colors hover:text-primary dark:text-slate-400"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/features/examples/components/ExamplesShell.tsx
+++ b/src/features/examples/components/ExamplesShell.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useAppStore } from "@/shared/stores/useAppStore";
+import { ExamplesNavbar } from "@/features/examples/components/ExamplesNavbar";
+import { ExamplesSidebar } from "@/features/examples/components/ExamplesSidebar";
+import { cn } from "@/shared/utils/cn";
+
+export function ExamplesShell({ children }: { children: React.ReactNode }) {
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen);
+
+  return (
+    <div className="min-h-screen">
+      <ExamplesNavbar />
+      <div className="flex">
+        <ExamplesSidebar />
+        <main
+          className={cn(
+            "flex-1 transition-all duration-200",
+            sidebarOpen ? "ml-56" : "ml-0",
+          )}
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/features/examples/components/ExamplesSidebar.tsx
+++ b/src/features/examples/components/ExamplesSidebar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAppStore } from "@/shared/stores/useAppStore";
+import { cn } from "@/shared/utils/cn";
+
+const SIDEBAR_LINKS = [
+  { href: "/state", label: "State", icon: "toggle_on" },
+  { href: "/react-query", label: "React Query", icon: "cloud_sync" },
+  { href: "/forms", label: "Forms", icon: "edit_note" },
+  { href: "/table", label: "Table", icon: "table" },
+  { href: "/users", label: "Users", icon: "group" },
+] as const;
+
+export function ExamplesSidebar() {
+  const pathname = usePathname();
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen);
+
+  return (
+    <aside
+      className={cn(
+        "fixed left-0 top-14 z-30 h-[calc(100vh-3.5rem)] w-56 border-r border-slate-200 bg-white transition-transform duration-200 dark:border-[#1f2937] dark:bg-[#0b0e14]",
+        sidebarOpen ? "translate-x-0" : "-translate-x-full",
+      )}
+    >
+      <nav className="flex flex-col gap-1 p-3">
+        {SIDEBAR_LINKS.map((link) => {
+          const isActive = pathname === link.href;
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary/10 text-primary"
+                  : "text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800",
+              )}
+            >
+              <span className="material-symbols-outlined text-lg">
+                {link.icon}
+              </span>
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/features/examples/components/UserEditForm.tsx
+++ b/src/features/examples/components/UserEditForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type z } from "zod";
+import { userSchema } from "@/shared/utils/validators";
+import { useUser } from "@/features/examples/hooks/useUser";
+import { useUpdateUser } from "@/features/examples/hooks/useUpdateUser";
+
+const editUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+
+type EditUserFormValues = z.infer<typeof editUserFormSchema>;
+
+export function UserEditForm({ id }: { id: string }) {
+  const { data: user, isLoading } = useUser(id);
+  const updateUser = useUpdateUser(id);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserFormSchema),
+  });
+
+  useEffect(() => {
+    if (user) {
+      reset({
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        status: user.status,
+      });
+    }
+  }, [user, reset]);
+
+  const onSubmit = async (data: EditUserFormValues) => {
+    try {
+      await updateUser.mutateAsync(data);
+    } catch {
+      // Error is available via updateUser.error
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading user data...</p>;
+  }
+
+  if (!user) {
+    return <p className="text-sm text-red-600">User not found.</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div>
+        <label
+          htmlFor="edit-name"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Name
+        </label>
+        <input
+          id="edit-name"
+          type="text"
+          {...register("name")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+          placeholder="John Doe"
+        />
+        {errors.name && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-email"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Email
+        </label>
+        <input
+          id="edit-email"
+          type="email"
+          {...register("email")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+          placeholder="john@example.com"
+        />
+        {errors.email && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-role"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Role
+        </label>
+        <select
+          id="edit-role"
+          {...register("role")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <option value="viewer">Viewer</option>
+          <option value="editor">Editor</option>
+          <option value="admin">Admin</option>
+        </select>
+        {errors.role && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.role.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-status"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Status
+        </label>
+        <select
+          id="edit-status"
+          {...register("status")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+        {errors.status && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.status.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? "Saving..." : "Save Changes"}
+        </button>
+        {updateUser.isSuccess && (
+          <p className="text-sm text-green-600 dark:text-green-400">
+            User updated successfully!
+          </p>
+        )}
+        {updateUser.isError && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {updateUser.error.message}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/features/examples/components/UserFilters.tsx
+++ b/src/features/examples/components/UserFilters.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useShallow } from "zustand/shallow";
+import { useFilterStore, useHasActiveFilters } from "@/shared/stores/useFilterStore";
+import { Input } from "@/ui/Input";
+import { NativeSelect } from "@/ui/NativeSelect";
+import type { UserRole } from "@/shared/types/common";
+
+export function UserFilters() {
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
+  const hasFilters = useHasActiveFilters();
+
+  return (
+    <div className="space-y-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+        label="Search"
+      />
+      <NativeSelect
+        value={role ?? ""}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+        label="Role"
+      >
+        <option value="">All roles</option>
+        <option value="admin">Admin</option>
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+        >
+          Reset Filters
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/examples/components/UserList.tsx
+++ b/src/features/examples/components/UserList.tsx
@@ -2,19 +2,28 @@
 
 import { useState } from "react";
 import { useUsers } from "@/features/examples/hooks/useUsers";
+import { useSearchUsers } from "@/features/examples/hooks/useSearchUsers";
 import { LoadingState } from "@/shared/components/LoadingState";
 import { EmptyState } from "@/shared/components/EmptyState";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
+import { cn } from "@/shared/utils/cn";
+
+const LIMIT = 5;
 
 function UserListInner() {
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
+  const [skip, setSkip] = useState(0);
 
-  const { data, isLoading, isError, error } = useUsers({
-    search,
-    page,
-    limit: 5,
-  });
+  const isSearching = search.length > 0;
+
+  const listQuery = useUsers({ skip, limit: LIMIT });
+  const searchQuery = useSearchUsers(search);
+
+  const { data, isLoading, isError, error } = isSearching ? searchQuery : listQuery;
+
+  const users = data?.users ?? [];
+  const totalPages = data ? Math.ceil(data.total / LIMIT) : 0;
+  const currentPage = data ? Math.floor(data.skip / LIMIT) + 1 : 1;
 
   if (isLoading) {
     return <LoadingState rows={5} message="Loading users..." />;
@@ -24,14 +33,11 @@ function UserListInner() {
     return (
       <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950">
         <p className="text-sm text-red-600 dark:text-red-400">
-          Failed to load users: {error.message}
+          Failed to load users: {error instanceof Error ? error.message : "Unknown error"}
         </p>
       </div>
     );
   }
-
-  const users = data?.data ?? [];
-  const meta = data?.meta;
 
   return (
     <div className="space-y-4">
@@ -41,7 +47,7 @@ function UserListInner() {
         value={search}
         onChange={(e) => {
           setSearch(e.target.value);
-          setPage(1);
+          setSkip(0);
         }}
         placeholder="Search by name or email..."
         className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
@@ -71,11 +77,12 @@ function UserListInner() {
                   {user.role}
                 </span>
                 <span
-                  className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                  className={cn(
+                    "rounded-full px-2.5 py-0.5 text-xs font-medium",
                     user.status === "active"
                       ? "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
-                      : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
-                  }`}
+                      : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+                  )}
                 >
                   {user.status}
                 </span>
@@ -85,23 +92,23 @@ function UserListInner() {
         </ul>
       )}
 
-      {/* Pagination */}
-      {meta && meta.totalPages > 1 && (
+      {/* Pagination — hidden when searching */}
+      {!isSearching && totalPages > 1 && (
         <div className="flex items-center justify-between">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Page {meta.page} of {meta.totalPages} ({meta.total} total)
+            Page {currentPage} of {totalPages} ({data?.total ?? 0} total)
           </p>
           <div className="flex gap-2">
             <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page <= 1}
+              onClick={() => setSkip((s) => Math.max(0, s - LIMIT))}
+              disabled={skip <= 0}
               className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-800"
             >
               Previous
             </button>
             <button
-              onClick={() => setPage((p) => Math.min(meta.totalPages, p + 1))}
-              disabled={page >= meta.totalPages}
+              onClick={() => setSkip((s) => s + LIMIT)}
+              disabled={currentPage >= totalPages}
               className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-800"
             >
               Next

--- a/src/features/examples/hooks/useCreateUser.ts
+++ b/src/features/examples/hooks/useCreateUser.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { createUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 import type { CreateUserInput } from "@/shared/types/user";
 
 export function useCreateUser() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateUserInput) => createUser(data),
+    mutationFn: (data: CreateUserInput) => usersService.create(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
     },

--- a/src/features/examples/hooks/useSearchUsers.ts
+++ b/src/features/examples/hooks/useSearchUsers.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebounce } from "@/shared/hooks";
+import { queryKeys } from "@/lib/query-keys";
+import { usersService } from "@/lib/services/users";
+
+export function useSearchUsers(query: string) {
+  const debouncedQuery = useDebounce(query, 300);
+
+  return useQuery({
+    queryKey: queryKeys.users.search(debouncedQuery),
+    queryFn: () => usersService.search({ q: debouncedQuery }),
+    enabled: debouncedQuery.length > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/features/examples/hooks/useUpdateUser.ts
+++ b/src/features/examples/hooks/useUpdateUser.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { updateUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 import type { UpdateUserInput } from "@/shared/types/user";
 
 export function useUpdateUser(id: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: UpdateUserInput) => updateUser(id, data),
+    mutationFn: (data: UpdateUserInput) => usersService.update(id, data),
     onSuccess: (updatedUser) => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
       queryClient.setQueryData(queryKeys.users.detail(id), updatedUser);

--- a/src/features/examples/hooks/useUser.ts
+++ b/src/features/examples/hooks/useUser.ts
@@ -1,11 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { getUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 
 export function useUser(id: string) {
   return useQuery({
     queryKey: queryKeys.users.detail(id),
-    queryFn: () => getUser(id),
+    queryFn: () => usersService.getById(id),
     enabled: !!id,
+    staleTime: 1000 * 60 * 10,
   });
 }

--- a/src/features/examples/hooks/useUsers.ts
+++ b/src/features/examples/hooks/useUsers.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { getUsers, type GetUsersParams } from "@/lib/mock-data";
+import { usersService, type GetUsersParams } from "@/lib/services/users";
 
 export function useUsers(params: GetUsersParams = {}) {
   return useQuery({
     queryKey: queryKeys.users.list(params as Record<string, unknown>),
-    queryFn: () => getUsers(params),
+    queryFn: () => usersService.getAll(params),
+    staleTime: 1000 * 60 * 5,
+    placeholderData: (prev) => prev,
   });
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -12,6 +12,7 @@ export const ENDPOINTS = {
   },
   users: {
     list: "/users",
+    search: "/users/search",
     detail: (id: string) => `/users/${id}`,
     create: "/users",
     update: (id: string) => `/users/${id}`,

--- a/src/lib/get-query-client.ts
+++ b/src/lib/get-query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
+
+export const getQueryClient = cache(
+  () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 60 * 1000,
+        },
+      },
+    }),
+);

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -6,5 +6,7 @@ export const queryKeys = {
       [...queryKeys.users.lists(), params] as const,
     details: () => [...queryKeys.users.all, "detail"] as const,
     detail: (id: string) => [...queryKeys.users.details(), id] as const,
+    searches: () => [...queryKeys.users.all, "search"] as const,
+    search: (query: string) => [...queryKeys.users.searches(), query] as const,
   },
 };

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -1,4 +1,5 @@
 import type { User } from "@/shared/types/common";
+import type { CreateUserInput, UpdateUserInput } from "@/shared/types/user";
 import { createApiClient } from "@/lib/api-client";
 import { ENDPOINTS } from "@/lib/endpoints";
 
@@ -34,6 +35,14 @@ export interface SearchUsersParams {
   q: string;
   limit?: number;
   skip?: number;
+}
+
+function splitName(fullName: string): { firstName: string; lastName: string } {
+  const parts = fullName.split(" ");
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
 }
 
 function mapUser(raw: DummyJsonUser): User {
@@ -78,5 +87,45 @@ export const usersService = {
         params: { q, ...rest } as Record<string, string | number | boolean | undefined>,
       })
       .then(mapResponse);
+  },
+
+  create(data: CreateUserInput): Promise<User> {
+    const { firstName, lastName } = splitName(data.name);
+    return dummyJsonClient
+      .post<DummyJsonUser>(ENDPOINTS.users.create, {
+        firstName,
+        lastName,
+        email: data.email,
+      })
+      .then(() => ({
+        id: String(Date.now()),
+        name: data.name,
+        email: data.email,
+        role: data.role,
+        status: data.status,
+        createdAt: new Date().toISOString(),
+      }));
+  },
+
+  update(id: string, data: UpdateUserInput): Promise<User> {
+    const body: Record<string, unknown> = {};
+    if (data.name !== undefined) {
+      const { firstName, lastName } = splitName(data.name);
+      body.firstName = firstName;
+      body.lastName = lastName;
+    }
+    if (data.email !== undefined) {
+      body.email = data.email;
+    }
+    return dummyJsonClient
+      .put<DummyJsonUser>(ENDPOINTS.users.update(id), body)
+      .then((raw) => ({
+        id: String(raw.id),
+        name: data.name ?? `${raw.firstName} ${raw.lastName}`,
+        email: data.email ?? raw.email,
+        role: data.role ?? "viewer",
+        status: data.status ?? "active",
+        createdAt: new Date().toISOString(),
+      }));
   },
 };

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -1,0 +1,82 @@
+import type { User } from "@/shared/types/common";
+import { createApiClient } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+
+const dummyJsonClient = createApiClient({ baseUrl: "https://dummyjson.com" });
+
+interface DummyJsonUser {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+interface DummyUsersResponse {
+  users: DummyJsonUser[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface UsersResponse {
+  users: User[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface GetUsersParams {
+  limit?: number;
+  skip?: number;
+}
+
+export interface SearchUsersParams {
+  q: string;
+  limit?: number;
+  skip?: number;
+}
+
+function mapUser(raw: DummyJsonUser): User {
+  return {
+    id: String(raw.id),
+    name: `${raw.firstName} ${raw.lastName}`,
+    email: raw.email,
+    role: "viewer",
+    status: "active",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function mapResponse(raw: DummyUsersResponse): UsersResponse {
+  return {
+    users: raw.users.map(mapUser),
+    total: raw.total,
+    skip: raw.skip,
+    limit: raw.limit,
+  };
+}
+
+export const usersService = {
+  getAll(params: GetUsersParams = {}): Promise<UsersResponse> {
+    return dummyJsonClient
+      .get<DummyUsersResponse>(ENDPOINTS.users.list, {
+        params: params as Record<string, string | number | boolean | undefined>,
+      })
+      .then(mapResponse);
+  },
+
+  getById(id: string): Promise<User> {
+    return dummyJsonClient
+      .get<DummyJsonUser>(ENDPOINTS.users.detail(id))
+      .then(mapUser);
+  },
+
+  search(params: SearchUsersParams): Promise<UsersResponse> {
+    const { q, ...rest } = params;
+    return dummyJsonClient
+      .get<DummyUsersResponse>(ENDPOINTS.users.search, {
+        params: { q, ...rest } as Record<string, string | number | boolean | undefined>,
+      })
+      .then(mapResponse);
+  },
+};


### PR DESCRIPTION
## Summary

- **#64 — Server State with React Query**: Added `usersService` with DummyJSON API integration (getAll, getById, search), `useUsers` with `staleTime`/`placeholderData`, `useSearchUsers` with debounce, `HydrationBoundary` prefetch in server component, and updated recipe to match actual import paths.

- **#65 — Client State with Zustand**: Added `ExamplesNavbar` (theme toggle + sidebar toggle via `useAppStore`), `UserFilters` component using `Input`/`NativeSelect` from `@/ui/` with `useShallow`, `ExamplesShell`/`ExamplesSidebar`, and updated recipe to cover all 3 stores (`useAppStore`, `useFilterStore`, `useSearchStore`) with `'use client'` guidance.

- **#66 — Form Validation with Zod**: Added `UserEditForm` with pre-populated `defaultValues` via `useEffect`+`reset()`, `/users/new` and `/users/[id]/edit` pages, `usersService.create()`/`update()` methods hitting DummyJSON API, switched mutations from `mock-data` to `usersService`, and aligned recipe code with actual implementation.

## Files changed (23)

- New: `usersService`, `getQueryClient`, `useSearchUsers`, `ExamplesNavbar`, `ExamplesShell`, `ExamplesSidebar`, `UserFilters`, `UserEditForm`, `/users/new`, `/users/[id]/edit`
- Updated: `useUsers`, `useUser`, `useCreateUser`, `useUpdateUser`, `UserList`, recipes (server-state, client-state, form-validation), `endpoints`, `query-keys`

Closes #64
Closes #65
Closes #66