### PR TITLE
chore(cookbook): publish server-state, client-state, form-validation

### DIFF
--- a/src/features/cookbook/data/cookbook-data.ts
+++ b/src/features/cookbook/data/cookbook-data.ts
@@ -136,7 +136,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%)",
     tags: ["Standard", "React Query"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 9,
   },
   {
@@ -149,7 +149,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)",
     tags: ["Standard", "Zustand"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 10,
   },
   {
@@ -162,7 +162,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #f97316 0%, #c2410c 100%)",
     tags: ["Standard", "Zod"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 11,
   },
   {


### PR DESCRIPTION
## Summary

- Flips status from \`coming-soon\` to \`published\` for three Applied recipes: Server State with React Query, Client State with Zustand, and Form Validation with Zod
- Recipe content and implementation were merged in #172 — this follow-up publishes them on the cookbook page

## Related

- Closes #64 — Recipe: Server State with React Query
- Closes #65 — Recipe: Client State with Zustand
- Closes #66 — Recipe: Form Validation with Zod
- Relates to #53 — Audit cookbook Applied recipes