### PR TITLE
docs: define three core products — cookbook, ui kit, configurator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,41 @@
 # React Principles
 
 ## Project Overview
-A living cookbook and UI kit for modern React development. Provides production-grade pattern examples (forms, data fetching, state management) alongside a reusable component library distributed via a CLI (`npx react-principles add`). Published at reactprinciples.dev.
+
+React Principles is an umbrella that contains three distinct products. Understanding which product a task belongs to is critical — scope, audience, and boundaries differ per product.
+
+Published at reactprinciples.dev.
+
+### 1. Cookbook (main product)
+
+The principles. Opinionated, curated guide to modern React development — production-grade patterns and principles organized as a progressive curriculum (Foundation → Applied → Patterns).
+
+- **For:** Mid-level React developers; AI tools that need a structured corpus of React principles.
+- **NOT:** Not a beginner tutorial. Not a comprehensive React reference. Not framework documentation (Next.js / Vite docs are not duplicated). Not a collection of disconnected blog posts.
+- **Output:** Knowledge — web pages (reactprinciples.dev/cookbook), AI corpus (llms.txt), invocable skills (`/reactprinciples-*`).
+
+### 2. UI Kit (supporting product)
+
+The building blocks. Copy-paste React component library — production-ready components (Tailwind v4, accessibility built-in) that developers own fully after install. No runtime dependency on a package.
+
+- **For:** React developers who want pre-built, accessible components they can freely customize.
+- **NOT:** Not an npm package to import from (no `import { Button } from 'react-principles'`). Not a CSS framework. Not a design system with Figma kit. Not opinionated about app architecture.
+- **Output:** Component files (Button.tsx, Dialog.tsx, etc.) copied to user's project via `npx react-principles add <name>`.
+
+### 3. Configurator (supporting tool)
+
+The starter generator. Browser-based wizard that generates a customized React project starter — user picks style system, fonts, colors, components, then downloads a ready-to-run codebase aligned with Cookbook patterns.
+
+- **For:** Developers starting a new project who want to skip boilerplate.
+- **NOT:** Not a CLI tool (browser-based). Not a replacement for `create-next-app`. Not for adding components to existing projects (that's UI Kit's CLI). Doesn't replace the Cookbook or UI Kit — it uses them.
+- **Output:** A downloadable project starter — codebase + pre-configured dependencies, generated client-side.
+
+### Relationships
+
+- Cookbook recipes reference UI Kit components in code examples
+- Configurator uses UI Kit internally and picks UI Kit components to include in generated starters
+- Configurator generates starter projects aligned with Cookbook patterns
+- All three live in the same monorepo but serve different audiences and have independent v1.0 milestones
 
 ## Stack
 - **Runtime:** Node.js >=18

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # React Principles
 
-**Production-grade React patterns, 30+ copy-paste UI components, and a project configurator.**
+**A cookbook of React patterns, a copy-paste UI Kit, and a project configurator.**
 
 [![Live Site](https://img.shields.io/badge/site-reactprinciples.dev-4628F1?style=flat-square)](https://reactprinciples.dev)
 [![npm](https://img.shields.io/npm/v/react-principles?style=flat-square&color=4628F1)](https://www.npmjs.com/package/react-principles)
@@ -18,15 +18,28 @@
 
 ## What is this?
 
-React Principles is a reference implementation for modern React development. Not just a component library — a full production codebase with patterns, architecture decisions, and tradeoffs documented.
+React Principles is an umbrella that contains three distinct products. Each one serves a different audience and has different boundaries.
 
-**Three things in one:**
+### Cookbook — the main product
 
-| | |
-|---|---|
-| **Cookbook** | Real-world React patterns: server state, forms, data tables, auth flows, and more. Each recipe is runnable and explained. |
-| **UI Components** | 30+ copy-paste components installable via CLI. You own the source — no dependency lock-in. |
-| **Configurator** | Web wizard at `/create` to scaffold a React project with your chosen style, stack, and components. |
+A curated, opinionated guide to modern React development. Production-grade patterns and principles organized as a progressive curriculum (Foundation → Applied → Patterns).
+
+- **For:** Mid-level React developers; AI tools that need a structured corpus of React principles.
+- **Not:** Not a beginner tutorial, not a comprehensive React reference, not framework documentation.
+
+### UI Kit — supporting product
+
+A copy-paste React component library. Production-ready components (Tailwind v4, accessibility built-in) that you own fully after install. No runtime dependency on a package.
+
+- **For:** Developers who want pre-built, accessible components they can freely customize.
+- **Not:** Not an npm package to import from. Not a CSS framework. Not a design system with a Figma kit.
+
+### Configurator — supporting tool
+
+A browser-based wizard at `/create` that generates a customized React project starter — pick style system, fonts, colors, and components, then download a ready-to-run codebase aligned with Cookbook patterns.
+
+- **For:** Developers starting a new project who want sensible defaults.
+- **Not:** Not a CLI. Not a replacement for `create-next-app`. Not for adding components to existing projects (that's UI Kit's CLI).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-principles",
   "version": "0.0.1",
   "private": true,
-  "description": "A living cookbook and UI kit for modern React development",
+  "description": "React Principles — cookbook of React patterns, copy-paste UI Kit, and project configurator",
   "author": "Singgih Budi Purnadi",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Clarify React Principles as an umbrella over three distinct products: Cookbook (main), UI Kit (supporting), and Configurator (supporting tool)
- Each product now has explicit definition with audience, boundaries (\"What it's NOT\"), and output
- Update CLAUDE.md, README.md, and package.json description so AI tools, contributors, and end users see consistent definitions
- No code changes — documentation only

## Related

- Relates to #41 — clarifies product scope ahead of v1.0 release