### PR TITLE
feat: add llms-full.txt route with code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ react-principles/
 | `/nextjs/cookbook` | Cookbook (Next.js) |
 | `/vitejs/cookbook` | Cookbook (Vite) |
 | `/docs` | Component docs |
-| `/llms.txt` | AI-readable compact cookbook (markdown) |
+| `/llms.txt` | AI-readable compact cookbook (principles + rules) |
+| `/llms-full.txt` | AI-readable full cookbook (with code examples) |
 
 ---
 
@@ -153,7 +154,8 @@ react-principles/
 
 React Principles is structured so AI assistants (Claude, Cursor, Copilot, GPT) can consume the cookbook directly:
 
-- **`/llms.txt`** — compact markdown of all published recipes (principles + rules, no code). Drop into AI context for principle-aware help.
+- **`/llms.txt`** — compact markdown (principles + rules, no code). ~5K tokens. Drop into any AI context for quick principle-aware help.
+- **`/llms-full.txt`** — full markdown with pattern code and framework-specific (Next.js + Vite) implementations. ~17K tokens. Use as RAG context, fine-tuning corpus, or long-form briefing for AI tools.
 - **AI Skills** — invocable commands like `/reactprinciples-review` and `/reactprinciples-component`. Install via [skills.sh](https://www.skills.sh):
   ```bash
   npx skills add sindev08/react-principles-skills

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,11 @@
+import { generateFullLlmsTxt } from "@/lib/llms-txt";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(generateFullLlmsTxt(), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/lib/llms-txt.ts
+++ b/src/lib/llms-txt.ts
@@ -4,7 +4,9 @@ import type { RecipeDetail, RuleItem } from "@/features/cookbook/data/types";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
 
-const HEADER = `# React Principles — Cookbook
+// ─── Headers / Footers ────────────────────────────────────────────────────────
+
+const COMPACT_HEADER = `# React Principles — Cookbook
 
 > Production-grade React patterns and principles. A curated curriculum for modern React development covering folder structure, TypeScript, components, state, forms, services, and more.
 
@@ -18,31 +20,64 @@ Stack: Next.js 16, React 19, TypeScript 5, Tailwind CSS v4, TanStack Query v5, Z
 ---
 `;
 
+const FULL_HEADER = `# React Principles — Cookbook (Full)
+
+> Production-grade React patterns and principles. A curated curriculum for modern React development covering folder structure, TypeScript, components, state, forms, services, and more.
+
+This is the **full** version of the cookbook — every published recipe with principle, rules, pattern code, and framework-specific implementations (Next.js and Vite). For a lighter version without code, see ${SITE_URL}/llms.txt.
+
+Stack: Next.js 16, React 19, TypeScript 5, Tailwind CSS v4, TanStack Query v5, Zustand v5, React Hook Form + Zod.
+
+Use this file as:
+- RAG context for a custom AI assistant
+- Long-form context to drop into Claude / Cursor / Copilot for principle-aware help
+- Reference for fine-tuning or evaluation
+
+---
+`;
+
 const FOOTER = `---
 
 ## More
 
-- Full cookbook (with code examples): ${SITE_URL}/llms-full.txt
+- Compact cookbook (no code): ${SITE_URL}/llms.txt
+- Full cookbook (with code): ${SITE_URL}/llms-full.txt
 - Interactive web version: ${SITE_URL}/cookbook
 - UI Kit components: ${SITE_URL}/docs
 - AI skills (Claude/Cursor/Copilot): https://github.com/sindev08/react-principles-skills
 `;
 
+// ─── Public API ───────────────────────────────────────────────────────────────
+
 export function generateCompactLlmsTxt(): string {
+  return buildLlmsTxt({ mode: "compact" });
+}
+
+export function generateFullLlmsTxt(): string {
+  return buildLlmsTxt({ mode: "full" });
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+interface BuildOptions {
+  mode: "compact" | "full";
+}
+
+function buildLlmsTxt(opts: BuildOptions): string {
   const publishedRecipes = RECIPES.filter((r) => r.status === "published").sort(
     (a, b) => a.order - b.order,
   );
 
   const grouped = groupByCategory(publishedRecipes);
 
-  const sections: string[] = [HEADER];
+  const sections: string[] = [opts.mode === "full" ? FULL_HEADER : COMPACT_HEADER];
 
   for (const [category, recipes] of grouped) {
     sections.push(`\n## ${category}\n`);
     for (const recipe of recipes) {
       const detail = RECIPE_DETAILS[recipe.slug];
       if (!detail) continue;
-      sections.push(formatRecipe(detail));
+      sections.push(formatRecipe(detail, opts.mode));
     }
   }
 
@@ -62,7 +97,7 @@ function groupByCategory(recipes: Recipe[]): Map<string, Recipe[]> {
   return map;
 }
 
-function formatRecipe(recipe: RecipeDetail): string {
+function formatRecipe(recipe: RecipeDetail, mode: BuildOptions["mode"]): string {
   const lines: string[] = [];
 
   lines.push(`### ${recipe.title}\n`);
@@ -84,10 +119,55 @@ function formatRecipe(recipe: RecipeDetail): string {
     lines.push("");
   }
 
+  if (mode === "full") {
+    appendCodeSections(lines, recipe);
+  }
+
   lines.push(`Read more: ${SITE_URL}/cookbook/${recipe.slug}\n`);
 
   return lines.join("\n");
 }
 
-// Exported for testing or future full-version use
+function appendCodeSections(lines: string[], recipe: RecipeDetail): void {
+  if (recipe.pattern) {
+    lines.push(`**Pattern** — \`${recipe.pattern.filename}\`\n`);
+    lines.push(fenceCode(recipe.pattern.code, languageFor(recipe.pattern.filename)));
+    lines.push("");
+  }
+
+  if (recipe.implementation?.nextjs) {
+    const impl = recipe.implementation.nextjs;
+    lines.push(`**Implementation — Next.js**\n`);
+    lines.push(`${impl.description}\n`);
+    lines.push(`File: \`${impl.filename}\`\n`);
+    lines.push(fenceCode(impl.code, languageFor(impl.filename)));
+    lines.push("");
+  }
+
+  if (recipe.implementation?.vite) {
+    const impl = recipe.implementation.vite;
+    lines.push(`**Implementation — Vite**\n`);
+    lines.push(`${impl.description}\n`);
+    lines.push(`File: \`${impl.filename}\`\n`);
+    lines.push(fenceCode(impl.code, languageFor(impl.filename)));
+    lines.push("");
+  }
+}
+
+function fenceCode(code: string, language: string): string {
+  return `\`\`\`${language}\n${code}\n\`\`\``;
+}
+
+function languageFor(filename: string): string {
+  if (filename.endsWith(".tsx")) return "tsx";
+  if (filename.endsWith(".ts")) return "ts";
+  if (filename.endsWith(".js")) return "js";
+  if (filename.endsWith(".jsx")) return "jsx";
+  if (filename.endsWith(".css")) return "css";
+  if (filename.endsWith(".json")) return "json";
+  if (filename.endsWith(".md")) return "markdown";
+  return "";
+}
+
+// Exported for testing
 export type { RecipeDetail, RuleItem };


### PR DESCRIPTION
## Summary

- New \`/llms-full.txt\` route — comprehensive AI-readable markdown including pattern code and framework-specific implementations (Next.js + Vite) for every published recipe
- Extends \`src/lib/llms-txt.ts\` with \`generateFullLlmsTxt()\` — shared with compact version, mode-based formatting
- README updated: new route in Key Routes table, \"For AI Tools\" section now describes both compact and full versions with token sizes

## Stats

- Output: ~70KB, ~17K tokens
- 13 published recipes covered
- 76 code blocks (pattern + Next.js + Vite per recipe where applicable)
- Code blocks fenced with correct language (\`tsx\`, \`ts\`, etc.) based on filename

## Base branch

This PR is stacked on \`feat/llms-txt-compact\` (#186) because it extends the same helper file. Should be merged after #186.

## Related

- Closes #181
- Stacked on #186 (llms.txt compact)