### PR TITLE
fix(landing): publish status for server-state and form-validation

### DIFF
--- a/src/features/landing/components/CookbookTeaserSection.tsx
+++ b/src/features/landing/components/CookbookTeaserSection.tsx
@@ -31,7 +31,7 @@ const FEATURED_RECIPES = [
     icon: "cloud_sync",
     gradient: "linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%)",
     category: "Patterns",
-    published: false,
+    published: true,
   },
   {
     slug: "form-validation",
@@ -41,7 +41,7 @@ const FEATURED_RECIPES = [
     icon: "fact_check",
     gradient: "linear-gradient(135deg, #f97316 0%, #c2410c 100%)",
     category: "Patterns",
-    published: false,
+    published: true,
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

- The CookbookTeaserSection has hardcoded \`published: false\` for \`server-state\` and \`form-validation\` recipes, but both have been published in \`cookbook-data.ts\` since PR #174
- This caused those featured recipe cards on the landing page to show "Coming soon" badge incorrectly
- Fixed by flipping both to \`published: true\`

## Note on the duplication

The \`FEATURED_RECIPES\` array in CookbookTeaserSection duplicates data from \`cookbook-data.ts\`. Other components (CookbookListPage, DocsSidebar, MobileNav) read directly from cookbook-data and auto-sync. This is the only place that needs manual update when status changes — consider refactoring to read from cookbook-data in a future cleanup.

## Related

- Caught during AI corpus landing page review