### PR TITLE
feat(ai): add skill detail pages with markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@iconify/react": "^6.0.2",
     "fflate": "^0.8.2",
     "lucide-react": "^1.9.0",
+    "marked": "^18.0.4",
     "recharts": "^3.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       lucide-react:
         specifier: ^1.9.0
         version: 1.9.0(react@19.2.4)
+      marked:
+        specifier: ^18.0.4
+        version: 18.0.4
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
@@ -2963,6 +2966,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.4:
+    resolution: {integrity: sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6724,6 +6732,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.4: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -369,9 +369,12 @@ function OfferingCard({
 
 function SkillCard({ skill }: { skill: Skill }) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
+    <Link
+      href={`/ai/skills/${skill.name}`}
+      className="group block rounded-xl border border-slate-200 bg-white p-5 transition-colors hover:border-primary/40 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900/50 dark:hover:border-primary/40 dark:hover:bg-slate-900"
+    >
       <div className="mb-3 flex items-start justify-between gap-3">
-        <code className="font-mono text-sm font-semibold text-slate-900 dark:text-white">
+        <code className="font-mono text-sm font-semibold text-slate-900 group-hover:text-primary dark:text-white dark:group-hover:text-primary">
           /{skill.name}
         </code>
         <span
@@ -386,7 +389,7 @@ function SkillCard({ skill }: { skill: Skill }) {
       <p className="text-sm leading-6 text-slate-600 dark:text-slate-400">
         {skill.description}
       </p>
-    </div>
+    </Link>
   );
 }
 

--- a/src/app/ai/skills/[name]/CopyButton.tsx
+++ b/src/app/ai/skills/[name]/CopyButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/shared/utils/cn";
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  variant?: "icon" | "labeled";
+  className?: string;
+}
+
+export function CopyButton({
+  text,
+  label = "Copy",
+  variant = "icon",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : label}
+        className={cn(
+          "rounded-md p-1.5 transition-colors",
+          copied
+            ? "text-green-500"
+            : "text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300",
+          className,
+        )}
+      >
+        <span className="material-symbols-outlined text-[18px]">
+          {copied ? "check" : "content_copy"}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold transition-colors dark:border-slate-700",
+        copied
+          ? "border-green-500 text-green-600 dark:border-green-500 dark:text-green-400"
+          : "text-slate-900 hover:bg-slate-100 dark:text-white dark:hover:bg-slate-800",
+        className,
+      )}
+    >
+      <span className="material-symbols-outlined text-base">
+        {copied ? "check" : "content_copy"}
+      </span>
+      {copied ? "Copied" : label}
+    </button>
+  );
+}

--- a/src/app/ai/skills/[name]/page.tsx
+++ b/src/app/ai/skills/[name]/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Navbar, Footer } from "@/features/landing/components";
+import { cn } from "@/shared/utils/cn";
+import { getSkill, getSkillsBundle, type SkillCategory } from "@/lib/skills";
+import { CopyButton } from "./CopyButton";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+const CATEGORY_LABELS: Record<SkillCategory, string> = {
+  umbrella: "Master",
+  review: "Review",
+  scaffolding: "Scaffolding",
+  internal: "Internal",
+};
+
+const CATEGORY_BADGE_CLASSES: Record<SkillCategory, string> = {
+  umbrella: "bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary",
+  review: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  scaffolding:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  internal: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
+};
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+export async function generateStaticParams() {
+  const bundle = await getSkillsBundle();
+  return bundle.skills.map((s) => ({ name: s.name }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { name } = await params;
+  const result = await getSkill(name);
+  if (!result) return { title: "Skill not found — React Principles" };
+  const { skill } = result;
+  const title = `/${skill.name} — React Principles Skill`;
+  return {
+    title,
+    description: skill.description,
+    openGraph: {
+      title,
+      description: skill.description,
+      type: "article",
+      url: `${SITE_URL}/ai/skills/${skill.name}`,
+    },
+    twitter: { card: "summary", title, description: skill.description },
+    alternates: { canonical: `${SITE_URL}/ai/skills/${skill.name}` },
+  };
+}
+
+export default async function SkillDetailPage({ params }: PageProps) {
+  const { name } = await params;
+  const result = await getSkill(name);
+  if (!result) notFound();
+  const { skill, bundle } = result;
+
+  return (
+    <>
+      <Navbar />
+      <main className="mx-auto max-w-4xl px-6 pt-32 pb-20 lg:pt-40">
+        {/* Breadcrumb */}
+        <nav className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+          <Link href="/ai" className="hover:text-slate-900 dark:hover:text-white">
+            AI Corpus
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-900 dark:text-white">Skills</span>
+        </nav>
+
+        {/* Header */}
+        <header className="mb-10 border-b border-slate-200 pb-8 dark:border-slate-800">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-xs font-medium",
+                CATEGORY_BADGE_CLASSES[skill.category],
+              )}
+            >
+              {CATEGORY_LABELS[skill.category]}
+            </span>
+            {bundle.version && (
+              <span className="rounded-md bg-slate-100 px-2 py-0.5 font-mono text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400">
+                {bundle.version}
+              </span>
+            )}
+          </div>
+          <h1 className="mb-3 font-mono text-3xl font-bold text-slate-900 dark:text-white sm:text-4xl">
+            /{skill.name}
+          </h1>
+          <p className="text-base leading-7 text-slate-600 dark:text-slate-400">
+            {skill.description}
+          </p>
+          {skill.allowedTools.length > 0 && (
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-xs">
+              <span className="text-slate-500 dark:text-slate-500">Allowed tools:</span>
+              {skill.allowedTools.map((tool) => (
+                <code
+                  key={tool}
+                  className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-slate-700 dark:bg-slate-800 dark:text-slate-300"
+                >
+                  {tool}
+                </code>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {/* Install */}
+        <section className="mb-10">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+            Install
+          </h2>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-900/50">
+            <span className="select-none text-slate-400 dark:text-slate-500">$</span>
+            <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-slate-800 dark:text-slate-200">
+              {bundle.installCommand}
+            </code>
+            <CopyButton text={bundle.installCommand} label="Copy install command" />
+          </div>
+          <p className="mt-3 text-xs text-slate-500 dark:text-slate-500">
+            Installs all skills from{" "}
+            <Link
+              href={bundle.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              the repo
+            </Link>
+            . To copy only this skill manually, use the button below.
+          </p>
+        </section>
+
+        {/* Manual copy + GitHub link */}
+        <section className="mb-12 flex flex-wrap gap-3">
+          <CopyButton
+            text={skill.rawMarkdown}
+            label="Copy SKILL.md"
+            variant="labeled"
+          />
+          <Link
+            href={`${bundle.repoUrl}/blob/main/skills/${skill.name}/SKILL.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
+          >
+            <span className="material-symbols-outlined text-base">open_in_new</span>
+            View on GitHub
+          </Link>
+        </section>
+
+        {/* Markdown body */}
+        <article
+          className="skill-markdown"
+          dangerouslySetInnerHTML={{ __html: skill.bodyHtml }}
+        />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -206,3 +206,99 @@
   .animate-slide-right { animation: slide-in-right 0.6s ease-out both; }
   .animate-float { animation: float 3s ease-in-out infinite; }
 }
+
+/* ─── Skill markdown rendering ─────────────────────────────────────────── */
+
+.skill-markdown {
+  color: var(--color-slate-700);
+  line-height: 1.7;
+}
+.dark .skill-markdown { color: var(--color-slate-300); }
+
+.skill-markdown h1,
+.skill-markdown h2,
+.skill-markdown h3,
+.skill-markdown h4 {
+  color: var(--color-slate-900);
+  font-weight: 700;
+  line-height: 1.3;
+  scroll-margin-top: 6rem;
+}
+.dark .skill-markdown h1,
+.dark .skill-markdown h2,
+.dark .skill-markdown h3,
+.dark .skill-markdown h4 { color: #fff; }
+
+.skill-markdown h1 { font-size: 1.875rem; margin-top: 2.5rem; margin-bottom: 1rem; }
+.skill-markdown h2 { font-size: 1.5rem; margin-top: 2.5rem; margin-bottom: 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--color-slate-200); }
+.dark .skill-markdown h2 { border-color: var(--color-slate-800); }
+.skill-markdown h3 { font-size: 1.25rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+.skill-markdown h4 { font-size: 1.0625rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+
+.skill-markdown p { margin: 1rem 0; }
+
+.skill-markdown a { color: var(--color-primary); text-decoration: underline; text-underline-offset: 2px; }
+.skill-markdown a:hover { text-decoration: none; }
+
+.skill-markdown ul,
+.skill-markdown ol { margin: 1rem 0; padding-left: 1.5rem; }
+.skill-markdown ul { list-style: disc; }
+.skill-markdown ol { list-style: decimal; }
+.skill-markdown li { margin: 0.375rem 0; }
+.skill-markdown li > ul,
+.skill-markdown li > ol { margin: 0.5rem 0; }
+
+.skill-markdown strong { color: var(--color-slate-900); font-weight: 600; }
+.dark .skill-markdown strong { color: #fff; }
+
+.skill-markdown code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-slate-100);
+  color: var(--color-slate-800);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+}
+.dark .skill-markdown code { background: var(--color-slate-800); color: var(--color-slate-200); }
+
+.skill-markdown pre {
+  background: #0d1117;
+  color: var(--color-slate-100);
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  margin: 1.25rem 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+.skill-markdown pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.skill-markdown blockquote {
+  border-left: 3px solid var(--color-primary);
+  padding: 0.25rem 1rem;
+  margin: 1.25rem 0;
+  color: var(--color-slate-600);
+  font-style: italic;
+}
+.dark .skill-markdown blockquote { color: var(--color-slate-400); }
+
+.skill-markdown hr {
+  border: 0;
+  border-top: 1px solid var(--color-slate-200);
+  margin: 2rem 0;
+}
+.dark .skill-markdown hr { border-color: var(--color-slate-800); }
+
+.skill-markdown table { width: 100%; border-collapse: collapse; margin: 1.25rem 0; font-size: 0.9375rem; }
+.skill-markdown th,
+.skill-markdown td { padding: 0.5rem 0.75rem; border: 1px solid var(--color-slate-200); text-align: left; }
+.dark .skill-markdown th,
+.dark .skill-markdown td { border-color: var(--color-slate-800); }
+.skill-markdown th { background: var(--color-slate-50); font-weight: 600; }
+.dark .skill-markdown th { background: var(--color-slate-900); }

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,144 @@
+import { marked } from "marked";
+
+const REPO_OWNER = "sindev08";
+const REPO_NAME = "react-principles-skills";
+const GITHUB_API_BASE = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
+const REVALIDATE_SECONDS = 3600;
+
+export type SkillCategory = "umbrella" | "review" | "scaffolding" | "internal";
+
+export interface Skill {
+  name: string;
+  description: string;
+  category: SkillCategory;
+  allowedTools: string[];
+  rawMarkdown: string;
+  bodyHtml: string;
+}
+
+export interface SkillsBundle {
+  skills: Skill[];
+  version: string | null;
+  repoUrl: string;
+  installCommand: string;
+}
+
+const CATEGORY_MAP: Record<string, SkillCategory> = {
+  reactprinciples: "umbrella",
+  "reactprinciples-review": "review",
+  "reactprinciples-audit-recipe": "internal",
+  "reactprinciples-component": "scaffolding",
+  "reactprinciples-folder-structure": "scaffolding",
+  "reactprinciples-form": "scaffolding",
+  "reactprinciples-hook": "scaffolding",
+  "reactprinciples-query": "scaffolding",
+  "reactprinciples-recipe": "internal",
+  "reactprinciples-store": "scaffolding",
+};
+
+interface FrontmatterResult {
+  data: { name?: string; description?: string; "allowed-tools"?: string };
+  body: string;
+}
+
+function parseFrontmatter(raw: string): FrontmatterResult | null {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match?.[1] || match[2] === undefined) return null;
+  const [, fm, body] = match;
+  const data: Record<string, string> = {};
+  for (const line of fm.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    data[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+  }
+  return { data, body };
+}
+
+interface GitHubContentItem {
+  name: string;
+  type: "file" | "dir";
+}
+
+async function ghFetch<T>(path: string): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(`${GITHUB_API_BASE}${path}`, {
+    headers,
+    next: { revalidate: REVALIDATE_SECONDS },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${path} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function fetchRaw(url: string): Promise<string> {
+  const res = await fetch(url, { next: { revalidate: REVALIDATE_SECONDS } });
+  if (!res.ok) {
+    throw new Error(`Raw fetch ${url} failed: ${res.status}`);
+  }
+  return res.text();
+}
+
+async function fetchSkillFolders(): Promise<string[]> {
+  const items = await ghFetch<GitHubContentItem[]>("/contents/skills");
+  return items.filter((i) => i.type === "dir").map((i) => i.name);
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const release = await ghFetch<{ tag_name: string }>("/releases/latest");
+    return release.tag_name;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchSkill(folder: string): Promise<Skill | null> {
+  const rawUrl = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/skills/${folder}/SKILL.md`;
+  const raw = await fetchRaw(rawUrl);
+  const parsed = parseFrontmatter(raw);
+  if (!parsed) return null;
+  const allowedTools = parsed.data["allowed-tools"]
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) ?? [];
+  return {
+    name: parsed.data.name ?? folder,
+    description: parsed.data.description ?? "",
+    category: CATEGORY_MAP[folder] ?? "internal",
+    allowedTools,
+    rawMarkdown: raw,
+    bodyHtml: await marked.parse(parsed.body),
+  };
+}
+
+export async function getSkillsBundle(): Promise<SkillsBundle> {
+  const folders = await fetchSkillFolders();
+  const [skills, version] = await Promise.all([
+    Promise.all(folders.map(fetchSkill)),
+    fetchLatestVersion(),
+  ]);
+  return {
+    skills: skills.filter((s): s is Skill => s !== null),
+    version,
+    repoUrl: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+    installCommand: `npx skills add ${REPO_OWNER}/${REPO_NAME}`,
+  };
+}
+
+export async function getSkill(name: string): Promise<{ skill: Skill; bundle: SkillsBundle } | null> {
+  const bundle = await getSkillsBundle();
+  const skill = bundle.skills.find((s) => s.name === name);
+  if (!skill) return null;
+  return { skill, bundle };
+}
+
+export function getSkillNames(skills: Skill[]): string[] {
+  return skills.map((s) => s.name);
+}


### PR DESCRIPTION
## Summary

- Add `/ai/skills/[name]` route with SSG via `generateStaticParams` — 10 pages prerendered at build time by fetching `SKILL.md` files from `sindev08/react-principles-skills` (1h revalidate, optional `GITHUB_TOKEN`)
- Per-skill view: category badge, version from latest git tag, install command with copy, allowed tools, copy SKILL.md, view-on-GitHub link, rendered markdown body via `marked` with scoped `.skill-markdown` styles (no `@tailwindcss/typography` dep)
- Link existing SkillCard on `/ai` listing to the new detail page (hover affordance added)

## Related

- Relates to #175 — addresses the "skill detail pages display install instructions + copy button + version" acceptance criterion