### PR TITLE
chore(landing): replace early access badge with v1.0 launch state

### DIFF
--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -100,7 +100,7 @@ export function Footer() {
         {/* Bottom bar */}
         <div className="flex flex-col items-center justify-between gap-4 pt-8 border-t border-slate-100 dark:border-white/5 md:flex-row">
           <p className="text-sm text-slate-400">
-            © 2026 react-principles · Early access · npm: react-principles@{CLI_VERSION}
+            © 2026 react-principles · v1.0 · npm: react-principles@{CLI_VERSION}
           </p>
         </div>
       </div>

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -170,7 +170,7 @@ export function HeroSection() {
           <span className="material-symbols-outlined text-sm">
             auto_awesome
           </span>
-          Early access
+          v1.0 is now live
         </Badge>
 
         <h1 className="mb-8 text-5xl font-black leading-[1.1] tracking-tight text-slate-900 md:text-7xl dark:text-white">


### PR DESCRIPTION
## Summary

- Hero badge on landing changed from "Early access" → "v1.0 is now live"
- Footer bottom-bar text changed from "Early access" → "v1.0"

## Related

- Resolves the "Hero badge updated from Early access → v1.0 is now live" criterion in #41