### PR TITLE
fix(cli): rename scrollarea registry entry to scroll-area

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -275,7 +275,7 @@ Installed automatically as dependencies of any component, or added directly.
 | `progress` | `Progress.tsx` | — |
 | `radio-group` | `RadioGroup.tsx` | — |
 | `resizable` | `Resizable.tsx` | — |
-| `scrollarea` | `ScrollArea.tsx` | — |
+| `scroll-area` | `ScrollArea.tsx` | — |
 | `search-dialog` | `SearchDialog.tsx` | `use-animated-mount` |
 | `select` | `Select.tsx` | — |
 | `separator` | `Separator.tsx` | — |

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -406,7 +406,7 @@ export const REGISTRY: RegistryEntry[] = [
     target: "components",
   },
   {
-    name: "scrollarea",
+    name: "scroll-area",
     description: "Scrollable container with custom scrollbar styling",
     templateKey: "ScrollArea",
     outputFile: "ScrollArea.tsx",

--- a/src/app/docs/scroll-area/page.tsx
+++ b/src/app/docs/scroll-area/page.tsx
@@ -240,7 +240,7 @@ export default function ScrollAreaDocPage() {
           </div>
         </div>
 
-        <CliInstallBlock name="scrollarea" />
+        <CliInstallBlock name="scroll-area" />
 
         {/* 01 Live Demo */}
         <section id="demo" className="mb-16">

--- a/src/features/docs/components/docs-nav.ts
+++ b/src/features/docs/components/docs-nav.ts
@@ -61,7 +61,7 @@ export const DOCS_NAV: NavGroup[] = [
       { label: "Radio Group", href: "/docs/radio-group" },
       { label: "Resizable", href: "/docs/resizable" },
       { label: "Select", href: "/docs/select" },
-      { label: "ScrollArea", href: "/docs/scrollarea" },
+      { label: "ScrollArea", href: "/docs/scroll-area" },
       { label: "Sheet", href: "/docs/sheet" },
       { label: "Separator", href: "/docs/separator" },
       { label: "Skeleton", href: "/docs/skeleton" },


### PR DESCRIPTION
## Summary

- Rename CLI registry entry \`scrollarea\` → \`scroll-area\` to match the kebab-case convention used by every other multi-word component (radio-group, dropdown-menu, alert-dialog, etc.) and to align with the PascalCase→kebab-case conversion introduced in #192
- Move docs page \`src/app/docs/scrollarea/\` → \`src/app/docs/scroll-area/\` and update internal references (\`CliInstallBlock\` name, \`docs-nav.ts\` href, README components table)

## ⚠️ Breaking change

\`npx react-principles add scrollarea\` no longer resolves. Users must use \`npx react-principles add scroll-area\`. The commit body includes a \`BREAKING CHANGE\` footer so release-please picks it up.

This PR touches \`packages/cli/\` with a \`fix:\` commit — release-please will bump the CLI package version on merge to main. Documentation of this and the earlier Radio/Dropdown rename is tracked separately.

## Related

- Relates to #41 — v1.0 launch (UI Kit "CLI stable" criterion)
- Relates to #196 — pre-1.0 breaking change documentation in release notes