### PR TITLE
chore: merge development into main for v1.0.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,41 @@
 # React Principles
 
 ## Project Overview
-A living cookbook and UI kit for modern React development. Provides production-grade pattern examples (forms, data fetching, state management) alongside a reusable component library distributed via a CLI (`npx react-principles add`). Published at reactprinciples.dev.
+
+React Principles is an umbrella that contains three distinct products. Understanding which product a task belongs to is critical — scope, audience, and boundaries differ per product.
+
+Published at reactprinciples.dev.
+
+### 1. Cookbook (main product)
+
+The principles. Opinionated, curated guide to modern React development — production-grade patterns and principles organized as a progressive curriculum (Foundation → Applied → Patterns).
+
+- **For:** Mid-level React developers; AI tools that need a structured corpus of React principles.
+- **NOT:** Not a beginner tutorial. Not a comprehensive React reference. Not framework documentation (Next.js / Vite docs are not duplicated). Not a collection of disconnected blog posts.
+- **Output:** Knowledge — web pages (reactprinciples.dev/cookbook), AI corpus (llms.txt), invocable skills (`/reactprinciples-*`).
+
+### 2. UI Kit (supporting product)
+
+The building blocks. Copy-paste React component library — production-ready components (Tailwind v4, accessibility built-in) that developers own fully after install. No runtime dependency on a package.
+
+- **For:** React developers who want pre-built, accessible components they can freely customize.
+- **NOT:** Not an npm package to import from (no `import { Button } from 'react-principles'`). Not a CSS framework. Not a design system with Figma kit. Not opinionated about app architecture.
+- **Output:** Component files (Button.tsx, Dialog.tsx, etc.) copied to user's project via `npx react-principles add <name>`.
+
+### 3. Configurator (supporting tool)
+
+The starter generator. Browser-based wizard that generates a customized React project starter — user picks style system, fonts, colors, components, then downloads a ready-to-run codebase aligned with Cookbook patterns.
+
+- **For:** Developers starting a new project who want to skip boilerplate.
+- **NOT:** Not a CLI tool (browser-based). Not a replacement for `create-next-app`. Not for adding components to existing projects (that's UI Kit's CLI). Doesn't replace the Cookbook or UI Kit — it uses them.
+- **Output:** A downloadable project starter — codebase + pre-configured dependencies, generated client-side.
+
+### Relationships
+
+- Cookbook recipes reference UI Kit components in code examples
+- Configurator uses UI Kit internally and picks UI Kit components to include in generated starters
+- Configurator generates starter projects aligned with Cookbook patterns
+- All three live in the same monorepo but serve different audiences and have independent v1.0 milestones
 
 ## Stack
 - **Runtime:** Node.js >=18

--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ react-principles/
 | `/nextjs/cookbook` | Cookbook (Next.js) |
 | `/vitejs/cookbook` | Cookbook (Vite) |
 | `/docs` | Component docs |
+| `/llms.txt` | AI-readable compact cookbook (markdown) |
+
+---
+
+## For AI Tools
+
+React Principles is structured so AI assistants (Claude, Cursor, Copilot, GPT) can consume the cookbook directly:
+
+- **`/llms.txt`** — compact markdown of all published recipes (principles + rules, no code). Drop into AI context for principle-aware help.
+- **AI Skills** — invocable commands like `/reactprinciples-review` and `/reactprinciples-component`. Install via [skills.sh](https://www.skills.sh):
+  ```bash
+  npx skills add sindev08/react-principles-skills
+  ```
+
+See [github.com/sindev08/react-principles-skills](https://github.com/sindev08/react-principles-skills) for the full skills catalog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ react-principles/
 | `/nextjs/cookbook` | Cookbook (Next.js) |
 | `/vitejs/cookbook` | Cookbook (Vite) |
 | `/docs` | Component docs |
-| `/llms.txt` | AI-readable compact cookbook (markdown) |
+| `/llms.txt` | AI-readable compact cookbook (principles + rules) |
+| `/llms-full.txt` | AI-readable full cookbook (with code examples) |
 
 ---
 
@@ -153,7 +154,8 @@ react-principles/
 
 React Principles is structured so AI assistants (Claude, Cursor, Copilot, GPT) can consume the cookbook directly:
 
-- **`/llms.txt`** — compact markdown of all published recipes (principles + rules, no code). Drop into AI context for principle-aware help.
+- **`/llms.txt`** — compact markdown (principles + rules, no code). ~5K tokens. Drop into any AI context for quick principle-aware help.
+- **`/llms-full.txt`** — full markdown with pattern code and framework-specific (Next.js + Vite) implementations. ~17K tokens. Use as RAG context, fine-tuning corpus, or long-form briefing for AI tools.
 - **AI Skills** — invocable commands like `/reactprinciples-review` and `/reactprinciples-component`. Install via [skills.sh](https://www.skills.sh):
   ```bash
   npx skills add sindev08/react-principles-skills

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # React Principles
 
-**Production-grade React patterns, 30+ copy-paste UI components, and a project configurator.**
+**A cookbook of React patterns, a copy-paste UI Kit, and a project configurator.**
 
 [![Live Site](https://img.shields.io/badge/site-reactprinciples.dev-4628F1?style=flat-square)](https://reactprinciples.dev)
 [![npm](https://img.shields.io/npm/v/react-principles?style=flat-square&color=4628F1)](https://www.npmjs.com/package/react-principles)
@@ -18,15 +18,28 @@
 
 ## What is this?
 
-React Principles is a reference implementation for modern React development. Not just a component library — a full production codebase with patterns, architecture decisions, and tradeoffs documented.
+React Principles is an umbrella that contains three distinct products. Each one serves a different audience and has different boundaries.
 
-**Three things in one:**
+### Cookbook — the main product
 
-| | |
-|---|---|
-| **Cookbook** | Real-world React patterns: server state, forms, data tables, auth flows, and more. Each recipe is runnable and explained. |
-| **UI Components** | 30+ copy-paste components installable via CLI. You own the source — no dependency lock-in. |
-| **Configurator** | Web wizard at `/create` to scaffold a React project with your chosen style, stack, and components. |
+A curated, opinionated guide to modern React development. Production-grade patterns and principles organized as a progressive curriculum (Foundation → Applied → Patterns).
+
+- **For:** Mid-level React developers; AI tools that need a structured corpus of React principles.
+- **Not:** Not a beginner tutorial, not a comprehensive React reference, not framework documentation.
+
+### UI Kit — supporting product
+
+A copy-paste React component library. Production-ready components (Tailwind v4, accessibility built-in) that you own fully after install. No runtime dependency on a package.
+
+- **For:** Developers who want pre-built, accessible components they can freely customize.
+- **Not:** Not an npm package to import from. Not a CSS framework. Not a design system with a Figma kit.
+
+### Configurator — supporting tool
+
+A browser-based wizard at `/create` that generates a customized React project starter — pick style system, fonts, colors, and components, then download a ready-to-run codebase aligned with Cookbook patterns.
+
+- **For:** Developers starting a new project who want sensible defaults.
+- **Not:** Not a CLI. Not a replacement for `create-next-app`. Not for adding components to existing projects (that's UI Kit's CLI).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-principles",
   "version": "0.0.1",
   "private": true,
-  "description": "A living cookbook and UI kit for modern React development",
+  "description": "React Principles — cookbook of React patterns, copy-paste UI Kit, and project configurator",
   "author": "Singgih Budi Purnadi",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@iconify/react": "^6.0.2",
     "fflate": "^0.8.2",
     "lucide-react": "^1.9.0",
+    "marked": "^18.0.4",
     "recharts": "^3.8.1"
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -275,7 +275,7 @@ Installed automatically as dependencies of any component, or added directly.
 | `progress` | `Progress.tsx` | — |
 | `radio-group` | `RadioGroup.tsx` | — |
 | `resizable` | `Resizable.tsx` | — |
-| `scrollarea` | `ScrollArea.tsx` | — |
+| `scroll-area` | `ScrollArea.tsx` | — |
 | `search-dialog` | `SearchDialog.tsx` | `use-animated-mount` |
 | `select` | `Select.tsx` | — |
 | `separator` | `Separator.tsx` | — |

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -472,7 +472,9 @@ export async function create(
   const skipped: string[] = [];
 
   for (const compName of preset.components) {
-    const entryName = compName.toLowerCase();
+    const entryName = compName
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .toLowerCase();
     const entry = getEntry(entryName);
     if (!entry) { skipped.push(compName); continue; }
 

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -298,6 +298,15 @@ export const REGISTRY: RegistryEntry[] = [
     target: "components",
   },
   {
+    name: "label",
+    description: "Styled form label with required indicator",
+    templateKey: "Label",
+    outputFile: "Label.tsx",
+    internalDeps: ["utils"],
+    npmDeps: [],
+    target: "components",
+  },
+  {
     name: "kbd",
     description: "Keyboard shortcut and key combination display",
     templateKey: "Kbd",

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -406,7 +406,7 @@ export const REGISTRY: RegistryEntry[] = [
     target: "components",
   },
   {
-    name: "scrollarea",
+    name: "scroll-area",
     description: "Scrollable container with custom scrollbar styling",
     templateKey: "ScrollArea",
     outputFile: "ScrollArea.tsx",

--- a/packages/cli/src/utils/deps.ts
+++ b/packages/cli/src/utils/deps.ts
@@ -16,7 +16,7 @@ const COMPONENT_DEPS: Record<string, PackageEntry[]> = {
   Toast:       [{ name: "sonner", version: "^2.0.0" }],
   Select:      [{ name: "@radix-ui/react-select", version: "^2.1.6" }],
   Checkbox:    [{ name: "@radix-ui/react-checkbox", version: "^1.1.4" }],
-  Radio:       [{ name: "@radix-ui/react-radio-group", version: "^1.2.3" }],
+  RadioGroup:   [{ name: "@radix-ui/react-radio-group", version: "^1.2.3" }],
   Switch:      [{ name: "@radix-ui/react-switch", version: "^1.1.3" }],
   Slider:      [{ name: "@radix-ui/react-slider", version: "^1.2.3" }],
   Tabs:        [{ name: "@radix-ui/react-tabs", version: "^1.1.3" }],
@@ -26,7 +26,7 @@ const COMPONENT_DEPS: Record<string, PackageEntry[]> = {
   Drawer:      [{ name: "@radix-ui/react-dialog", version: "^1.1.6" }],
   Separator:   [{ name: "@radix-ui/react-separator", version: "^1.1.2" }],
   Collapsible: [{ name: "@radix-ui/react-collapsible", version: "^1.1.3" }],
-  Dropdown:    [{ name: "@radix-ui/react-dropdown-menu", version: "^2.1.6" }],
+  DropdownMenu: [{ name: "@radix-ui/react-dropdown-menu", version: "^2.1.6" }],
   Carousel:    [{ name: "embla-carousel-react", version: "^8.5.0" }],
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       lucide-react:
         specifier: ^1.9.0
         version: 1.9.0(react@19.2.4)
+      marked:
+        specifier: ^18.0.4
+        version: 18.0.4
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
@@ -2963,6 +2966,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@18.0.4:
+    resolution: {integrity: sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6724,6 +6732,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@18.0.4: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/app/(examples)/layout.tsx
+++ b/src/app/(examples)/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ExamplesShell } from "@/features/examples/components/ExamplesShell";
 
 export const metadata: Metadata = {
   robots: {
@@ -12,5 +13,5 @@ export default function ExamplesLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return <ExamplesShell>{children}</ExamplesShell>;
 }

--- a/src/app/(examples)/react-query/page.tsx
+++ b/src/app/(examples)/react-query/page.tsx
@@ -1,6 +1,16 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/get-query-client";
+import { queryKeys } from "@/lib/query-keys";
+import { usersService } from "@/lib/services/users";
 import { UserList } from "@/features/examples/components/UserList";
 
-export default function ReactQueryPage() {
+export default async function ReactQueryPage() {
+  const qc = getQueryClient();
+  await qc.prefetchQuery({
+    queryKey: queryKeys.users.list({}),
+    queryFn: () => usersService.getAll({}),
+  });
+
   return (
     <main className="mx-auto max-w-4xl px-6 py-12">
       <h1 className="text-3xl font-bold tracking-tight">React Query Example</h1>
@@ -8,7 +18,9 @@ export default function ReactQueryPage() {
         Fetching and displaying users with TanStack React Query.
       </p>
       <div className="mt-8">
-        <UserList />
+        <HydrationBoundary state={dehydrate(qc)}>
+          <UserList />
+        </HydrationBoundary>
       </div>
     </main>
   );

--- a/src/app/(examples)/state/page.tsx
+++ b/src/app/(examples)/state/page.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useShallow } from "zustand/shallow";
 import { useAppStore } from "@/shared/stores/useAppStore";
-import { useFilterStore } from "@/shared/stores/useFilterStore";
+import { UserFilters } from "@/features/examples/components/UserFilters";
 
 export default function StatePage() {
-  const { theme, sidebarOpen, toggleTheme, toggleSidebar } = useAppStore();
-  const { search, role, status, setSearch, setRole, setStatus, reset } =
-    useFilterStore();
+  const { theme, sidebarOpen, toggleTheme, toggleSidebar } = useAppStore(
+    useShallow((s) => ({
+      theme: s.theme,
+      sidebarOpen: s.sidebarOpen,
+      toggleTheme: s.toggleTheme,
+      toggleSidebar: s.toggleSidebar,
+    })),
+  );
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-12">
@@ -40,12 +46,14 @@ export default function StatePage() {
             </div>
             <div className="flex gap-2 pt-2">
               <button
+                type="button"
                 onClick={toggleTheme}
                 className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-300"
               >
                 Toggle Theme
               </button>
               <button
+                type="button"
                 onClick={toggleSidebar}
                 className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
               >
@@ -58,62 +66,8 @@ export default function StatePage() {
         {/* Filter Store */}
         <section className="rounded-xl border border-gray-200 p-6 dark:border-gray-800">
           <h2 className="text-xl font-semibold">Filter Store</h2>
-          <div className="mt-4 space-y-3">
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Search
-              </label>
-              <input
-                type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search users..."
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              />
-            </div>
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Role
-              </label>
-              <select
-                value={role ?? ""}
-                onChange={(e) =>
-                  setRole(
-                    (e.target.value || null) as "admin" | "editor" | "viewer" | null,
-                  )
-                }
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              >
-                <option value="">All roles</option>
-                <option value="admin">Admin</option>
-                <option value="editor">Editor</option>
-                <option value="viewer">Viewer</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm text-gray-600 dark:text-gray-400">
-                Status
-              </label>
-              <select
-                value={status ?? ""}
-                onChange={(e) =>
-                  setStatus(
-                    (e.target.value || null) as "active" | "inactive" | null,
-                  )
-                }
-                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
-              >
-                <option value="">All statuses</option>
-                <option value="active">Active</option>
-                <option value="inactive">Inactive</option>
-              </select>
-            </div>
-            <button
-              onClick={reset}
-              className="mt-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
-            >
-              Reset Filters
-            </button>
+          <div className="mt-4">
+            <UserFilters />
           </div>
         </section>
       </div>

--- a/src/app/(examples)/users/[id]/edit/page.tsx
+++ b/src/app/(examples)/users/[id]/edit/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { use } from "react";
+import { UserEditForm } from "@/features/examples/components/UserEditForm";
+
+export default function EditUserPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">Edit User</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">
+        Update user details with pre-populated form fields.
+      </p>
+      <div className="mt-8">
+        <UserEditForm id={id} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(examples)/users/new/page.tsx
+++ b/src/app/(examples)/users/new/page.tsx
@@ -1,0 +1,15 @@
+import { UserForm } from "@/features/examples/components/UserForm";
+
+export default function NewUserPage() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">New User</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">
+        Create a user with React Hook Form and Zod validation.
+      </p>
+      <div className="mt-8">
+        <UserForm />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(examples)/users/page.tsx
+++ b/src/app/(examples)/users/page.tsx
@@ -1,0 +1,15 @@
+import { UserTable } from "@/features/examples/components/UserTable";
+
+export default function UsersPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-12">
+      <h1 className="text-3xl font-bold tracking-tight">Users</h1>
+      <p className="mt-2 text-gray-600 dark:text-gray-400">
+        Sortable, filterable, and paginated table powered by TanStack Table v8.
+      </p>
+      <div className="mt-8">
+        <UserTable />
+      </div>
+    </main>
+  );
+}

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -1,0 +1,463 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Navbar, Footer } from "@/features/landing/components";
+import { cn } from "@/shared/utils/cn";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+const SKILLS_REPO_URL = "https://github.com/sindev08/react-principles-skills";
+const SKILLS_INSTALL_CMD = "npx skills add sindev08/react-principles-skills";
+
+export const metadata: Metadata = {
+  title: "AI Corpus — React Principles",
+  description:
+    "Make your AI tools React Principles-aware. Drop-in context for Claude, Cursor, Copilot, and GPT — plus invocable skills for code review and scaffolding.",
+  openGraph: {
+    title: "AI Corpus — React Principles",
+    description:
+      "Make your AI tools React Principles-aware. llms.txt + Agent Skills for Claude, Cursor, Copilot, and GPT.",
+    type: "website",
+    url: `${SITE_URL}/ai`,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI Corpus — React Principles",
+    description:
+      "Make your AI tools React Principles-aware. llms.txt + Agent Skills for any AI assistant.",
+  },
+  alternates: {
+    canonical: `${SITE_URL}/ai`,
+  },
+};
+
+interface Skill {
+  name: string;
+  description: string;
+  category: "review" | "scaffolding" | "internal" | "umbrella";
+}
+
+const SKILLS: Skill[] = [
+  {
+    name: "reactprinciples",
+    description:
+      "Umbrella skill — routes intent to the right sub-skill (review, scaffold, audit).",
+    category: "umbrella",
+  },
+  {
+    name: "reactprinciples-review",
+    description:
+      "Review React/TypeScript code against 13 principle categories. Flags violations with reasoning and fixes.",
+    category: "review",
+  },
+  {
+    name: "reactprinciples-folder-structure",
+    description:
+      "Scaffold a feature-sliced folder layout (components, hooks, stores, data).",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-component",
+    description:
+      "Scaffold a UI component — props extending HTMLAttributes, Record variants, cn() for class merging.",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-hook",
+    description:
+      "Scaffold a custom hook with proper naming, stable return shape, and colocated test.",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-store",
+    description:
+      "Scaffold a Zustand store with selectors, actions, reset, and 'use client' boundary.",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-query",
+    description:
+      "Scaffold a React Query hook (list, detail, search, or mutation) with staleTime and enabled.",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-form",
+    description:
+      "Scaffold a React Hook Form + Zod form. Shares schemas between create and edit via .omit/.pick.",
+    category: "scaffolding",
+  },
+  {
+    name: "reactprinciples-recipe",
+    description:
+      "Draft a new cookbook recipe in the standard structure. (Cookbook maintainer skill.)",
+    category: "internal",
+  },
+  {
+    name: "reactprinciples-audit-recipe",
+    description:
+      "Audit an existing recipe for accuracy against the codebase. (Cookbook maintainer skill.)",
+    category: "internal",
+  },
+];
+
+const CATEGORY_LABELS: Record<Skill["category"], string> = {
+  umbrella: "Master",
+  review: "Review",
+  scaffolding: "Scaffolding",
+  internal: "Internal",
+};
+
+const CATEGORY_BADGE_CLASSES: Record<Skill["category"], string> = {
+  umbrella:
+    "bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary",
+  review:
+    "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  scaffolding:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  internal:
+    "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
+};
+
+export default function AICorpusPage() {
+  return (
+    <>
+      <Navbar />
+      <main className="mx-auto max-w-5xl px-6 pt-32 pb-20 lg:pt-40">
+        {/* Hero */}
+        <section className="mb-20 text-center">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-1.5 text-xs font-semibold tracking-wider uppercase text-primary">
+            <span className="material-symbols-outlined text-sm">
+              auto_awesome
+            </span>
+            AI Corpus
+          </div>
+          <h1 className="mb-6 text-4xl font-extrabold tracking-tight text-slate-900 dark:text-white lg:text-6xl">
+            Make your AI tools{" "}
+            <span className="text-primary">React Principles–aware</span>
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg leading-8 text-slate-600 dark:text-slate-400">
+            Drop-in context for Claude, Cursor, Copilot, and GPT. Plus
+            invocable skills that scaffold code and review against documented
+            patterns — installable in one command.
+          </p>
+        </section>
+
+        {/* Two main offerings */}
+        <section className="mb-20 grid gap-6 md:grid-cols-2">
+          <OfferingCard
+            icon="terminal"
+            title="Skills"
+            subtitle="Invocable commands"
+            description="10 Agent Skills following the open standard. Works with Claude Code, Cursor, and any AI tool that supports skills.sh."
+            cta={{ label: "View skills below", href: "#skills" }}
+          />
+          <OfferingCard
+            icon="description"
+            title="llms.txt"
+            subtitle="Drop-in AI context"
+            description="The cookbook as AI-readable markdown. Two versions: compact for quick reference, full for deep RAG context."
+            cta={{ label: "See files below", href: "#llms-txt" }}
+          />
+        </section>
+
+        {/* Skills */}
+        <section id="skills" className="mb-20 scroll-mt-24">
+          <SectionHeader
+            eyebrow="Skills"
+            title="Invocable commands"
+            description="Install once, invoke when needed. Each skill encodes a workflow — from reviewing code to scaffolding components — following React Principles patterns exactly."
+          />
+
+          {/* Install instructions */}
+          <div className="mb-10 rounded-xl border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900/50">
+            <p className="mb-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+              Install all skills with one command:
+            </p>
+            <pre className="overflow-x-auto rounded-lg bg-slate-900 px-4 py-3 text-sm text-slate-100 dark:bg-black">
+              <code>{SKILLS_INSTALL_CMD}</code>
+            </pre>
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-500">
+              Or manually copy any{" "}
+              <code className="rounded bg-slate-200 px-1 py-0.5 font-mono dark:bg-slate-800">
+                SKILL.md
+              </code>{" "}
+              from the{" "}
+              <Link
+                href={SKILLS_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                react-principles-skills repo
+              </Link>{" "}
+              into{" "}
+              <code className="rounded bg-slate-200 px-1 py-0.5 font-mono dark:bg-slate-800">
+                ~/.claude/skills/
+              </code>
+              .
+            </p>
+          </div>
+
+          {/* Skills grid */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            {SKILLS.map((skill) => (
+              <SkillCard key={skill.name} skill={skill} />
+            ))}
+          </div>
+        </section>
+
+        {/* llms.txt */}
+        <section id="llms-txt" className="mb-20 scroll-mt-24">
+          <SectionHeader
+            eyebrow="llms.txt"
+            title="Drop-in AI context"
+            description="The cookbook compiled into AI-readable markdown. Auto-rebuilds on every publish. No setup — just point your AI at the URL."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <LlmsCard
+              title="Compact"
+              size="~5K tokens"
+              href={`${SITE_URL}/llms.txt`}
+              description="Principles + rules only, no code. Drop into any AI context window for quick principle-aware help."
+              useCase="Best for: quick chat sessions, lightweight rules in Cursor."
+            />
+            <LlmsCard
+              title="Full"
+              size="~17K tokens"
+              href={`${SITE_URL}/llms-full.txt`}
+              description="Every recipe with pattern code and Next.js + Vite implementations. Suitable for RAG, fine-tuning, or long-form briefing."
+              useCase="Best for: custom AI assistants, retrieval pipelines, deep context."
+            />
+          </div>
+        </section>
+
+        {/* Use cases */}
+        <section className="mb-20">
+          <SectionHeader
+            eyebrow="Use cases"
+            title="How developers use this"
+            description="Practical patterns for getting AI tools aligned with React Principles."
+          />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <UseCaseCard
+              icon="rule"
+              title="Code review in editor"
+              description={`Invoke "/reactprinciples-review" in Claude Code or Cursor to audit your changes against documented patterns before opening a PR.`}
+            />
+            <UseCaseCard
+              icon="construction"
+              title="Scaffold features faster"
+              description={`Use "/reactprinciples-component", "/reactprinciples-query", or "/reactprinciples-form" to generate code that already follows the conventions — no boilerplate copy-paste.`}
+            />
+            <UseCaseCard
+              icon="psychology"
+              title="Project-aware chat context"
+              description="Paste llms.txt into Claude Projects, ChatGPT custom GPTs, or Cursor rules so every conversation stays principle-aligned."
+            />
+            <UseCaseCard
+              icon="all_inclusive"
+              title="Custom AI assistants"
+              description="Use llms-full.txt as RAG corpus or fine-tuning data to build a React Principles assistant for your team."
+            />
+          </div>
+        </section>
+
+        {/* Final CTA */}
+        <section className="rounded-2xl border border-slate-200 bg-gradient-to-br from-primary/5 to-transparent p-10 text-center dark:border-slate-800">
+          <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-900 dark:text-white lg:text-3xl">
+            Ready to install?
+          </h2>
+          <p className="mb-6 text-base text-slate-600 dark:text-slate-400">
+            One command. Works across Claude Code, Cursor, and any tool
+            supporting Agent Skills.
+          </p>
+          <pre className="mx-auto mb-4 inline-block rounded-lg bg-slate-900 px-5 py-3 text-sm text-slate-100 dark:bg-black">
+            <code>{SKILLS_INSTALL_CMD}</code>
+          </pre>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Link
+              href={SKILLS_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
+            >
+              View skills repo
+              <span className="material-symbols-outlined text-base">
+                open_in_new
+              </span>
+            </Link>
+            <Link
+              href="/cookbook"
+              className="flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              Browse the cookbook
+            </Link>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SectionHeader({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-10 max-w-3xl">
+      <p className="mb-2 text-xs font-semibold tracking-wider uppercase text-primary">
+        {eyebrow}
+      </p>
+      <h2 className="mb-3 text-3xl font-bold tracking-tight text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <p className="text-base leading-7 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function OfferingCard({
+  icon,
+  title,
+  subtitle,
+  description,
+  cta,
+}: {
+  icon: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  cta: { label: string; href: string };
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 transition-colors hover:border-primary/40 dark:border-slate-800 dark:bg-slate-900/50">
+      <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+        <span className="material-symbols-outlined text-primary">{icon}</span>
+      </div>
+      <h3 className="mb-1 text-lg font-bold text-slate-900 dark:text-white">
+        {title}
+      </h3>
+      <p className="mb-3 text-xs font-medium tracking-wide uppercase text-slate-500 dark:text-slate-500">
+        {subtitle}
+      </p>
+      <p className="mb-4 text-sm leading-6 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+      <Link
+        href={cta.href}
+        className="inline-flex items-center gap-1 text-sm font-semibold text-primary hover:underline"
+      >
+        {cta.label}
+        <span className="material-symbols-outlined text-base">
+          arrow_forward
+        </span>
+      </Link>
+    </div>
+  );
+}
+
+function SkillCard({ skill }: { skill: Skill }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <code className="font-mono text-sm font-semibold text-slate-900 dark:text-white">
+          /{skill.name}
+        </code>
+        <span
+          className={cn(
+            "shrink-0 rounded-md px-2 py-0.5 text-xs font-medium",
+            CATEGORY_BADGE_CLASSES[skill.category],
+          )}
+        >
+          {CATEGORY_LABELS[skill.category]}
+        </span>
+      </div>
+      <p className="text-sm leading-6 text-slate-600 dark:text-slate-400">
+        {skill.description}
+      </p>
+    </div>
+  );
+}
+
+function LlmsCard({
+  title,
+  size,
+  href,
+  description,
+  useCase,
+}: {
+  title: string;
+  size: string;
+  href: string;
+  description: string;
+  useCase: string;
+}) {
+  return (
+    <div className="flex flex-col rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-lg font-bold text-slate-900 dark:text-white">
+          {title}
+        </h3>
+        <span className="rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400">
+          {size}
+        </span>
+      </div>
+      <p className="mb-4 text-sm leading-6 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+      <p className="mb-5 text-xs italic text-slate-500 dark:text-slate-500">
+        {useCase}
+      </p>
+      <div className="mt-auto">
+        <Link
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
+        >
+          Open {title.toLowerCase()} version
+          <span className="material-symbols-outlined text-base">
+            open_in_new
+          </span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function UseCaseCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
+      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+        <span className="material-symbols-outlined text-slate-700 dark:text-slate-300">
+          {icon}
+        </span>
+      </div>
+      <h3 className="mb-2 text-base font-bold text-slate-900 dark:text-white">
+        {title}
+      </h3>
+      <p className="text-sm leading-6 text-slate-600 dark:text-slate-400">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -264,7 +264,7 @@ export default function AICorpusPage() {
         </section>
 
         {/* Final CTA */}
-        <section className="rounded-2xl border border-slate-200 bg-gradient-to-br from-primary/5 to-transparent p-10 text-center dark:border-slate-800">
+        <section className="rounded-2xl border border-slate-200 bg-gradient-to-br from-primary/5 to-transparent p-6 text-center sm:p-10 dark:border-slate-800">
           <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-900 dark:text-white lg:text-3xl">
             Ready to install?
           </h2>
@@ -272,15 +272,15 @@ export default function AICorpusPage() {
             One command. Works across Claude Code, Cursor, and any tool
             supporting Agent Skills.
           </p>
-          <pre className="mx-auto mb-4 inline-block rounded-lg bg-slate-900 px-5 py-3 text-sm text-slate-100 dark:bg-black">
+          <pre className="mb-4 overflow-x-auto rounded-lg bg-slate-900 px-4 py-3 text-left text-xs text-slate-100 sm:px-5 sm:text-center sm:text-sm dark:bg-black">
             <code>{SKILLS_INSTALL_CMD}</code>
           </pre>
-          <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <div className="mt-6 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
             <Link
               href={SKILLS_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
+              className="flex items-center justify-center gap-2 rounded-lg border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
             >
               View skills repo
               <span className="material-symbols-outlined text-base">
@@ -289,7 +289,7 @@ export default function AICorpusPage() {
             </Link>
             <Link
               href="/cookbook"
-              className="flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+              className="flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
             >
               Browse the cookbook
             </Link>

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -369,9 +369,12 @@ function OfferingCard({
 
 function SkillCard({ skill }: { skill: Skill }) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
+    <Link
+      href={`/ai/skills/${skill.name}`}
+      className="group block rounded-xl border border-slate-200 bg-white p-5 transition-colors hover:border-primary/40 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900/50 dark:hover:border-primary/40 dark:hover:bg-slate-900"
+    >
       <div className="mb-3 flex items-start justify-between gap-3">
-        <code className="font-mono text-sm font-semibold text-slate-900 dark:text-white">
+        <code className="font-mono text-sm font-semibold text-slate-900 group-hover:text-primary dark:text-white dark:group-hover:text-primary">
           /{skill.name}
         </code>
         <span
@@ -386,7 +389,7 @@ function SkillCard({ skill }: { skill: Skill }) {
       <p className="text-sm leading-6 text-slate-600 dark:text-slate-400">
         {skill.description}
       </p>
-    </div>
+    </Link>
   );
 }
 

--- a/src/app/ai/skills/[name]/CopyButton.tsx
+++ b/src/app/ai/skills/[name]/CopyButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/shared/utils/cn";
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  variant?: "icon" | "labeled";
+  className?: string;
+}
+
+export function CopyButton({
+  text,
+  label = "Copy",
+  variant = "icon",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : label}
+        className={cn(
+          "rounded-md p-1.5 transition-colors",
+          copied
+            ? "text-green-500"
+            : "text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300",
+          className,
+        )}
+      >
+        <span className="material-symbols-outlined text-[18px]">
+          {copied ? "check" : "content_copy"}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold transition-colors dark:border-slate-700",
+        copied
+          ? "border-green-500 text-green-600 dark:border-green-500 dark:text-green-400"
+          : "text-slate-900 hover:bg-slate-100 dark:text-white dark:hover:bg-slate-800",
+        className,
+      )}
+    >
+      <span className="material-symbols-outlined text-base">
+        {copied ? "check" : "content_copy"}
+      </span>
+      {copied ? "Copied" : label}
+    </button>
+  );
+}

--- a/src/app/ai/skills/[name]/page.tsx
+++ b/src/app/ai/skills/[name]/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Navbar, Footer } from "@/features/landing/components";
+import { cn } from "@/shared/utils/cn";
+import { getSkill, getSkillsBundle, type SkillCategory } from "@/lib/skills";
+import { CopyButton } from "./CopyButton";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+const CATEGORY_LABELS: Record<SkillCategory, string> = {
+  umbrella: "Master",
+  review: "Review",
+  scaffolding: "Scaffolding",
+  internal: "Internal",
+};
+
+const CATEGORY_BADGE_CLASSES: Record<SkillCategory, string> = {
+  umbrella: "bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary",
+  review: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  scaffolding:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  internal: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
+};
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+export async function generateStaticParams() {
+  const bundle = await getSkillsBundle();
+  return bundle.skills.map((s) => ({ name: s.name }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { name } = await params;
+  const result = await getSkill(name);
+  if (!result) return { title: "Skill not found — React Principles" };
+  const { skill } = result;
+  const title = `/${skill.name} — React Principles Skill`;
+  return {
+    title,
+    description: skill.description,
+    openGraph: {
+      title,
+      description: skill.description,
+      type: "article",
+      url: `${SITE_URL}/ai/skills/${skill.name}`,
+    },
+    twitter: { card: "summary", title, description: skill.description },
+    alternates: { canonical: `${SITE_URL}/ai/skills/${skill.name}` },
+  };
+}
+
+export default async function SkillDetailPage({ params }: PageProps) {
+  const { name } = await params;
+  const result = await getSkill(name);
+  if (!result) notFound();
+  const { skill, bundle } = result;
+
+  return (
+    <>
+      <Navbar />
+      <main className="mx-auto max-w-4xl px-6 pt-32 pb-20 lg:pt-40">
+        {/* Breadcrumb */}
+        <nav className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+          <Link href="/ai" className="hover:text-slate-900 dark:hover:text-white">
+            AI Corpus
+          </Link>
+          <span className="mx-2">/</span>
+          <span className="text-slate-900 dark:text-white">Skills</span>
+        </nav>
+
+        {/* Header */}
+        <header className="mb-10 border-b border-slate-200 pb-8 dark:border-slate-800">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-xs font-medium",
+                CATEGORY_BADGE_CLASSES[skill.category],
+              )}
+            >
+              {CATEGORY_LABELS[skill.category]}
+            </span>
+            {bundle.version && (
+              <span className="rounded-md bg-slate-100 px-2 py-0.5 font-mono text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400">
+                {bundle.version}
+              </span>
+            )}
+          </div>
+          <h1 className="mb-3 font-mono text-3xl font-bold text-slate-900 dark:text-white sm:text-4xl">
+            /{skill.name}
+          </h1>
+          <p className="text-base leading-7 text-slate-600 dark:text-slate-400">
+            {skill.description}
+          </p>
+          {skill.allowedTools.length > 0 && (
+            <div className="mt-4 flex flex-wrap items-center gap-2 text-xs">
+              <span className="text-slate-500 dark:text-slate-500">Allowed tools:</span>
+              {skill.allowedTools.map((tool) => (
+                <code
+                  key={tool}
+                  className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-slate-700 dark:bg-slate-800 dark:text-slate-300"
+                >
+                  {tool}
+                </code>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {/* Install */}
+        <section className="mb-10">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-widest text-slate-500 dark:text-slate-400">
+            Install
+          </h2>
+          <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-900/50">
+            <span className="select-none text-slate-400 dark:text-slate-500">$</span>
+            <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-slate-800 dark:text-slate-200">
+              {bundle.installCommand}
+            </code>
+            <CopyButton text={bundle.installCommand} label="Copy install command" />
+          </div>
+          <p className="mt-3 text-xs text-slate-500 dark:text-slate-500">
+            Installs all skills from{" "}
+            <Link
+              href={bundle.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              the repo
+            </Link>
+            . To copy only this skill manually, use the button below.
+          </p>
+        </section>
+
+        {/* Manual copy + GitHub link */}
+        <section className="mb-12 flex flex-wrap gap-3">
+          <CopyButton
+            text={skill.rawMarkdown}
+            label="Copy SKILL.md"
+            variant="labeled"
+          />
+          <Link
+            href={`${bundle.repoUrl}/blob/main/skills/${skill.name}/SKILL.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-white dark:hover:bg-slate-800"
+          >
+            <span className="material-symbols-outlined text-base">open_in_new</span>
+            View on GitHub
+          </Link>
+        </section>
+
+        {/* Markdown body */}
+        <article
+          className="skill-markdown"
+          dangerouslySetInnerHTML={{ __html: skill.bodyHtml }}
+        />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/create/_CreatePageContent.tsx
+++ b/src/app/create/_CreatePageContent.tsx
@@ -11,6 +11,7 @@ import { useWizardStore } from "@/features/configurator/stores/useWizardStore";
 import { useDebounce } from "@/shared/hooks/useDebounce";
 import { Button } from "@/ui/Button";
 import { Drawer } from "@/ui/Drawer";
+import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
 
 export function CreatePageContent() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
@@ -84,7 +85,9 @@ export function CreatePageContent() {
           </div>
 
           <div className="p-4 sm:p-6">
-            <LivePreviewPanel />
+            <ErrorBoundary fallback={<PreviewErrorFallback />}>
+              <LivePreviewPanel />
+            </ErrorBoundary>
           </div>
         </section>
       </main>
@@ -107,6 +110,16 @@ export function CreatePageFallback() {
           Loading configurator...
         </div>
       </main>
+    </div>
+  );
+}
+
+function PreviewErrorFallback() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <span className="material-symbols-outlined mb-4 text-[40px] text-slate-300 dark:text-slate-600">error_outline</span>
+      <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Preview failed to render</p>
+      <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">Try changing your selections or refreshing the page.</p>
     </div>
   );
 }

--- a/src/app/docs/button/page.tsx
+++ b/src/app/docs/button/page.tsx
@@ -139,6 +139,7 @@ const PROPS_ROWS = [
   { prop: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls height, padding, and font size." },
   { prop: "isLoading", type: "boolean", default: "false", description: "Shows a spinner and disables the button while true." },
   { prop: "disabled", type: "boolean", default: "false", description: "Disables interaction and reduces opacity." },
+  { prop: "asChild", type: "boolean", default: "false", description: "Evaluates children as the trigger element instead of rendering a <button>." },
   { prop: "children", type: "ReactNode", default: "—", description: "Button label content." },
   { prop: "className", type: "string", default: "—", description: "Extra CSS classes merged via cn()." },
 ];

--- a/src/app/docs/collapsible/page.tsx
+++ b/src/app/docs/collapsible/page.tsx
@@ -204,6 +204,13 @@ export default function CollapsibleDocsPage() {
             A simpler expand/collapse primitive compared to Accordion. For single-section toggling
             without the accordion group behavior.
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "Controlled/Uncontrolled", "Animated", "Disabled State"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/kbd/page.tsx
+++ b/src/app/docs/kbd/page.tsx
@@ -3,10 +3,12 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Kbd } from "@/ui/Kbd";
+import type { KbdSize } from "@/ui/Kbd";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
@@ -14,6 +16,46 @@ const TOC_ITEMS = [
 ];
 
 const STORYBOOK_HREF = "https://storybook.reactprinciples.dev/?path=/story/ui-kbd--default";
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+const KBD_BASE_LIGHT =
+  "inline-flex items-center justify-center rounded-sm border border-slate-200 bg-white text-slate-700 font-mono transition-colors";
+
+const KBD_BASE_DARK =
+  "inline-flex items-center justify-center rounded-sm border border-[#1f2937] bg-[#0d1117] text-slate-300 font-mono transition-colors";
+
+const KBD_SIZE_CLASSES: Record<KbdSize, string> = {
+  sm: "text-[10px] px-1.5 py-0.5 font-medium",
+  md: "text-xs px-2 py-1 font-medium",
+};
+
+function ThemedKbdGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const base = d ? KBD_BASE_DARK : KBD_BASE_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="flex flex-wrap items-center gap-3">
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>⌘</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>K</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.md}`}>⌘</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.md}`}>K</kbd>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 mt-3">
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>Ctrl</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>Shift</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>Alt</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>Esc</kbd>
+        <kbd className={`${base} ${KBD_SIZE_CLASSES.sm}`}>Enter</kbd>
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { Kbd } from "@/ui/Kbd";
 
@@ -115,11 +157,41 @@ export default function KbdDocPage() {
 
         <CliInstallBlock name="kbd" />
 
-        {/* 01 Live Demo */}
-        <section id="demo" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            Both sizes across both themes — forced styling for
+            accurate side-by-side comparison.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedKbdGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedKbdGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Live Demo */}
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
           </div>
@@ -214,11 +286,11 @@ export default function KbdDocPage() {
           </div>
         </section>
 
-        {/* 02 Code Snippet */}
+        {/* 03 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
           </div>
@@ -227,11 +299,11 @@ export default function KbdDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 03 Copy-Paste */}
+        {/* 04 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
           </div>
@@ -240,11 +312,11 @@ export default function KbdDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 04 Props */}
+        {/* 05 Props */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
           </div>

--- a/src/app/docs/menubar/page.tsx
+++ b/src/app/docs/menubar/page.tsx
@@ -94,6 +94,13 @@ export default function MenubarDocsPage() {
             A desktop-style menu bar with top-level menus, nested dropdowns, checkbox and radio items,
             keyboard navigation, and shortcut hints.
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "Keyboard Nav", "Nested Menus", "Compound Component"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/native-select/page.tsx
+++ b/src/app/docs/native-select/page.tsx
@@ -3,11 +3,13 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { NativeSelect } from "@/ui/NativeSelect";
+import type { NativeSelectSize } from "@/ui/NativeSelect";
 import { useState } from "react";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
@@ -15,6 +17,68 @@ const TOC_ITEMS = [
 ];
 
 const STORYBOOK_HREF = "https://storybook.reactprinciples.dev/?path=/story/ui-nativeselect--default";
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+const SELECT_BASE_LIGHT =
+  "appearance-none w-full rounded-lg border border-slate-200 bg-white text-slate-900";
+
+const SELECT_BASE_DARK =
+  "appearance-none w-full rounded-lg border border-[#1f2937] bg-[#0d1117] text-white";
+
+const SELECT_SIZE_CLASSES: Record<NativeSelectSize, string> = {
+  sm: "h-8 px-3 pr-9 text-xs",
+  md: "h-10 px-3.5 pr-10 text-sm",
+  lg: "h-12 px-4 pr-11 text-base",
+};
+
+function DropdownIcon() {
+  return (
+    <svg
+      className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-slate-500"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 4.5L6 7.5L9 4.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ThemedSelectGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const base = d ? SELECT_BASE_DARK : SELECT_BASE_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="flex flex-wrap items-center gap-4">
+        {(["sm", "md", "lg"] as NativeSelectSize[]).map((size) => (
+          <div key={size} className="relative w-40">
+            <select className={`${base} ${SELECT_SIZE_CLASSES[size]}`} defaultValue="">
+              <option value="" disabled>Select size: {size}</option>
+              <option value="a">Option A</option>
+              <option value="b">Option B</option>
+              <option value="c">Option C</option>
+            </select>
+            <DropdownIcon />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { NativeSelect } from "@/ui/NativeSelect";
 
@@ -153,7 +217,7 @@ const PROPS_ROWS = [
   { prop: "options", type: "NativeSelectOption[]", default: "—", description: "Array of { label, value, disabled? } for programmatic rendering." },
   { prop: "placeholder", type: "string", default: "—", description: "Text for empty first option (renders as disabled)." },
   { prop: "size", type: '"sm" | "md" | "lg"', default: '"md"', description: "Controls select height and text size." },
-  { prop: "error", type: "string", default: "—", description: "Error message — turns border red and replaces description." },
+  { prop: "error", type: "string", default: "—", description: "Error message - turns border red and replaces description." },
   { prop: "disabled", type: "boolean", default: "false", description: "Disables interaction and reduces opacity." },
   { prop: "label", type: "string", default: "—", description: "Label text displayed above the select." },
   { prop: "description", type: "string", default: "—", description: "Helper text displayed below the select (hidden when error present)." },
@@ -205,7 +269,7 @@ export default function NativeSelectDocPage() {
             Native Select
           </h1>
           <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
-            A styled native select element. Lightweight alternative to custom dropdowns — uses OS-optimized pickers on mobile devices.
+            A styled native select element. Lightweight alternative to custom dropdowns - uses OS-optimized pickers on mobile devices.
           </p>
           <div className="flex flex-wrap gap-2 mt-6">
             {["Accessible", "Dark Mode", "3 Sizes", "Mobile Optimized", "Lightweight"].map((tag) => (
@@ -218,11 +282,41 @@ export default function NativeSelectDocPage() {
 
         <CliInstallBlock name="native-select" />
 
-        {/* 01 Live Demo */}
-        <section id="demo" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            All three sizes across both themes - forced styling for
+            accurate side-by-side comparison.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedSelectGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedSelectGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Live Demo */}
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
           </div>
@@ -279,11 +373,11 @@ export default function NativeSelectDocPage() {
           </div>
         </section>
 
-        {/* 02 Code Snippet */}
+        {/* 03 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
           </div>
@@ -292,11 +386,11 @@ export default function NativeSelectDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 03 Copy-Paste */}
+        {/* 04 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
           </div>
@@ -305,11 +399,11 @@ export default function NativeSelectDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 04 Props */}
+        {/* 05 Props */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
           </div>

--- a/src/app/docs/navigation-menu/page.tsx
+++ b/src/app/docs/navigation-menu/page.tsx
@@ -380,6 +380,13 @@ export default function NavigationMenuDocsPage() {
             Horizontal navigation bar with dropdown/flyout panels for site-level navigation. Supports
             hover and click interactions with keyboard navigation.
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "Keyboard Nav", "Dropdown Panels", "Compound Component"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/scroll-area/page.tsx
+++ b/src/app/docs/scroll-area/page.tsx
@@ -240,7 +240,7 @@ export default function ScrollAreaDocPage() {
           </div>
         </div>
 
-        <CliInstallBlock name="scrollarea" />
+        <CliInstallBlock name="scroll-area" />
 
         {/* 01 Live Demo */}
         <section id="demo" className="mb-16">

--- a/src/app/docs/search-dialog/page.tsx
+++ b/src/app/docs/search-dialog/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
+import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
+import { SearchDialog } from "@/ui/SearchDialog";
+import type { SearchItem } from "@/ui/SearchDialog";
+
+const TOC_ITEMS = [
+  { label: "Live Demo", href: "#demo" },
+  { label: "Code Snippet", href: "#snippet" },
+  { label: "Copy-Paste", href: "#copy-paste" },
+  { label: "Props", href: "#props" },
+];
+
+const STORYBOOK_HREF = "https://storybook.reactprinciples.dev/?path=/story/ui-searchdialog--default";
+
+const DEMO_ITEMS: SearchItem[] = [
+  { title: "Getting Started", href: "/docs/introduction", description: "Learn the basics of the platform", group: "Docs" },
+  { title: "Installation", href: "/docs/installation", description: "Set up your development environment", group: "Docs" },
+  { title: "Theming", href: "/docs/theming", description: "Customize colors and typography", group: "Docs" },
+  { title: "Server State", href: "/cookbook/server-state", description: "Manage server data with React Query", group: "Cookbook" },
+  { title: "Form Validation", href: "/cookbook/form-validation", description: "Validate forms with React Hook Form + Zod", group: "Cookbook" },
+  { title: "Component Anatomy", href: "/cookbook/component-anatomy", description: "Build composable UI components", group: "Cookbook" },
+];
+
+const CODE_SNIPPET = `import { useState } from "react";
+import { SearchDialog } from "@/ui/SearchDialog";
+
+function MyApp() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SearchDialog
+      open={open}
+      items={searchItems}
+      onClose={() => setOpen(false)}
+      onNavigate={(href) => {
+        router.push(href);
+        setOpen(false);
+      }}
+    />
+  );
+}`;
+
+const COPY_PASTE_SNIPPET = `"use client";
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
+import { cn } from "@/lib/utils";
+
+export interface SearchItem {
+  title: string;
+  href: string;
+  description?: string;
+  group: "Docs" | "Cookbook";
+  section?: string;
+  icon?: string;
+}
+
+interface SearchDialogProps {
+  open: boolean;
+  items: SearchItem[];
+  onClose: () => void;
+  onNavigate: (href: string) => void;
+  savedSlugs?: string[];
+  initialQuery?: string;
+}
+
+export function SearchDialog({
+  open,
+  items,
+  onClose,
+  onNavigate,
+  savedSlugs = [],
+  initialQuery = "",
+}: SearchDialogProps) {
+  // See component file for full implementation
+}`;
+
+const PROPS_ROWS = [
+  { prop: "open", type: "boolean", default: "—", description: "Whether the search dialog is visible." },
+  { prop: "items", type: "SearchItem[]", default: "—", description: "Array of searchable items with title, href, description, group, and optional section/icon." },
+  { prop: "onClose", type: "() => void", default: "—", description: "Called when the dialog should close (Escape, backdrop click)." },
+  { prop: "onNavigate", type: "(href: string) => void", default: "—", description: "Called when a search result is selected with the target href." },
+  { prop: "savedSlugs", type: "string[]", default: "[]", description: "Slugs of bookmarked/saved cookbook recipes for the bookmark indicator." },
+  { prop: "initialQuery", type: "string", default: '""', description: "Pre-populates the search input when the dialog opens." },
+];
+
+export default function SearchDialogDocPage() {
+  return (
+    <DocsPageLayout tocItems={TOC_ITEMS}>
+      <div className="max-w-4xl">
+        <nav className="flex items-center gap-2 mb-8 text-sm font-medium text-slate-500">
+          <span className="transition-colors cursor-pointer hover:text-primary">Components</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="transition-colors cursor-pointer hover:text-primary">Navigation</span>
+          <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+          <span className="text-slate-900 dark:text-white">Search Dialog</span>
+        </nav>
+
+        <div className="mb-12">
+          <h1 className="mb-4 text-4xl font-black tracking-tight text-slate-900 dark:text-white md:text-5xl">
+            Search Dialog
+          </h1>
+          <p className="text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+            Full-screen command-palette-style search dialog with keyboard navigation,
+            grouped results, animated enter/exit transitions, and focus trap.
+          </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "Keyboard Nav", "Focus Trap", "Animated", "Bookmark Support"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <CliInstallBlock name="search-dialog" />
+
+        <section id="demo" className="mb-16">
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
+          </div>
+          <a
+            href={STORYBOOK_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="animate-fade-in mb-4 flex w-full items-center gap-3 rounded-lg border border-[#FF4785]/20 bg-[#FF4785]/5 px-4 py-3 transition-opacity hover:opacity-80"
+          >
+            <span className="relative flex h-2 w-2 shrink-0">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#FF4785] opacity-75"></span>
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-[#FF4785]"></span>
+            </span>
+            <p className="flex-1 text-xs text-slate-500 dark:text-slate-400">Explore all variants and interactive states in Storybook.</p>
+            <span className="inline-flex shrink-0 items-center gap-1 text-xs font-bold text-[#FF4785]">
+              Open Storybook
+              <span className="material-symbols-outlined text-[13px]">open_in_new</span>
+            </span>
+          </a>
+          <div className="rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] p-6 shadow-xs">
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              The Search Dialog is a full-screen overlay. Open a live demo via the{" "}
+              <strong>Storybook link above</strong> or click below to trigger an inline
+              preview.
+            </p>
+            <div className="mt-4">
+              <InlineSearchPreview items={DEMO_ITEMS} />
+            </div>
+          </div>
+        </section>
+
+        <section id="snippet" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
+          </div>
+          <CodeBlock filename="src/ui/SearchDialog.tsx" copyText={CODE_SNIPPET}>
+            {CODE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="copy-paste" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">03</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
+          </div>
+          <CodeBlock filename="SearchDialog.tsx" copyText={COPY_PASTE_SNIPPET}>
+            {COPY_PASTE_SNIPPET}
+          </CodeBlock>
+        </section>
+
+        <section id="props" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">04</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
+          </div>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-[#1f2937]">
+            <table className="w-full text-sm text-left">
+              <thead className="border-b border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22]">
+                <tr>
+                  {["Prop", "Type", "Default", "Description"].map((h) => (
+                    <th key={h} className="px-4 py-3 text-xs font-semibold tracking-wide uppercase text-slate-500 dark:text-slate-400">
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-[#1f2937] bg-white dark:bg-[#0d1117]">
+                {PROPS_ROWS.map((row) => (
+                  <tr key={row.prop} className="transition-colors hover:bg-slate-50 dark:hover:bg-[#161b22]">
+                    <td className="px-4 py-3">
+                      <code className="font-mono text-xs font-semibold text-primary">{row.prop}</code>
+                    </td>
+                    <td className="px-4 py-3 max-w-[200px]">
+                      <code className="font-mono text-xs text-slate-600 dark:text-slate-400 wrap-break-word">{row.type}</code>
+                    </td>
+                    <td className="px-4 py-3">
+                      <code className="font-mono text-xs text-slate-500 dark:text-slate-400">{row.default}</code>
+                    </td>
+                    <td className="px-4 py-3 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                      {row.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </DocsPageLayout>
+  );
+}
+
+function InlineSearchPreview({ items }: { items: SearchItem[] }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-lg border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#0d1117] px-4 py-2 text-sm text-slate-600 dark:text-slate-400 hover:border-slate-300 dark:hover:border-slate-600 transition-colors"
+      >
+        <span className="material-symbols-outlined text-[18px]">search</span>
+        Search docs...
+        <kbd className="ml-auto rounded-sm border border-slate-200 dark:border-[#1f2937] px-1.5 py-0.5 text-[10px] font-medium text-slate-400">
+          Ctrl K
+        </kbd>
+      </button>
+      {open && (
+        <SearchDialog
+          open={open}
+          items={items}
+          onClose={() => setOpen(false)}
+          onNavigate={(href) => {
+            window.location.href = href;
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/docs/sheet/page.tsx
+++ b/src/app/docs/sheet/page.tsx
@@ -78,6 +78,8 @@ export interface SheetProps {
 interface SheetContextValue {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  side: SheetSide;
+  size: SheetSize;
 }
 
 const SheetContext = createContext<SheetContextValue | null>(null);
@@ -119,9 +121,7 @@ const SIDE_CLASSES: Record<SheetSide, { panel: string; hidden: string }> = {
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
-export function Sheet({ open, onOpenChange, side = "right", size = "md", children, className }: SheetProps) {
-  const { mounted, visible } = useAnimatedMount(open, 300);
-
+export function Sheet({ open, onOpenChange, side = "right", size = "md", children }: SheetProps) {
   useEffect(() => {
     if (!open) return;
 
@@ -138,63 +138,11 @@ export function Sheet({ open, onOpenChange, side = "right", size = "md", childre
     };
   }, [open, onOpenChange]);
 
-  if (!mounted) return null;
-
-  const { panel, hidden } = SIDE_CLASSES[side];
-
-  const sheet = (
-    <SheetContext.Provider value={{ open, onOpenChange }}>
-      <div className="fixed inset-0 z-50 flex">
-        {/* Backdrop */}
-        <div
-          className={cn(
-            "absolute inset-0 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
-            visible ? "opacity-100" : "opacity-0"
-          )}
-          onClick={() => onOpenChange(false)}
-        />
-
-        {/* Panel */}
-        <div
-          role="dialog"
-          aria-modal="true"
-          className={cn(
-            "absolute flex flex-col bg-white dark:bg-[#161b22]",
-            "border-slate-200 dark:border-[#1f2937]",
-            side === "right" && "border-l",
-            side === "left" && "border-r",
-            side === "top" && "border-b",
-            side === "bottom" && "border-t",
-            "shadow-2xl shadow-black/20",
-            "transition-transform duration-300 ease-in-out",
-            // For top/bottom: size controls height, width is full
-            // For left/right: size controls width, height is full
-            side === "top" || side === "bottom"
-              ? \`w-full \${HEIGHT_CLASSES[size]}\`
-              : \`h-full \${WIDTH_CLASSES[size]}\`,
-            panel,
-            visible ? "translate-x-0 translate-y-0" : hidden,
-            className
-          )}
-        >
-          {/* Close button */}
-          <button
-            onClick={() => onOpenChange(false)}
-            className="absolute right-4 top-4 z-10 rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-[#1f2937] hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
-            aria-label="Close sheet"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none">
-              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-          </button>
-
-          {children}
-        </div>
-      </div>
+  return (
+    <SheetContext.Provider value={{ open, onOpenChange, side, size }}>
+      {children}
     </SheetContext.Provider>
   );
-
-  return createPortal(sheet, document.body);
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -220,10 +168,62 @@ Sheet.Trigger = function SheetTrigger({ children, className, ...props }) {
 };
 
 Sheet.Content = function SheetContent({ children, className, ...props }) {
-  return (
-    <div className={cn("flex-1 overflow-y-auto px-6 py-4", className)} {...props}>
-      {children}
-    </div>
+  const { open, onOpenChange, side, size } = useSheetContext();
+  const { mounted, visible } = useAnimatedMount(open, 300);
+
+  if (!mounted) return null;
+
+  const { panel, hidden } = SIDE_CLASSES[side];
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div
+        className={cn(
+          "absolute inset-0 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
+          visible ? "opacity-100" : "opacity-0"
+        )}
+        onClick={() => onOpenChange(false)}
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          "absolute flex flex-col bg-white dark:bg-[#161b22]",
+          "border-slate-200 dark:border-[#1f2937]",
+          side === "right" && "border-l",
+          side === "left" && "border-r",
+          side === "top" && "border-b",
+          side === "bottom" && "border-t",
+          "shadow-2xl shadow-black/20",
+          "transition-transform duration-300 ease-in-out",
+          side === "top" || side === "bottom"
+            ? \`w-full \${HEIGHT_CLASSES[size]}\`
+            : \`h-full \${WIDTH_CLASSES[size]}\`,
+          panel,
+          visible ? "translate-x-0 translate-y-0" : hidden,
+          className
+        )}
+      >
+        {/* Close button */}
+        <button
+          onClick={() => onOpenChange(false)}
+          className="absolute right-4 top-4 z-10 rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-[#1f2937] hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+          aria-label="Close sheet"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none">
+            <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4" {...props}>
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.body
   );
 };
 

--- a/src/app/docs/sheet/page.tsx
+++ b/src/app/docs/sheet/page.tsx
@@ -305,6 +305,13 @@ export default function SheetDocsPage() {
             A panel that slides in from the edge of the screen. More flexible than Drawer with
             support for all four sides (top, right, bottom, left).
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "4 Sides", "6 Sizes", "Animated"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/spinner/page.tsx
+++ b/src/app/docs/spinner/page.tsx
@@ -3,10 +3,12 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Spinner } from "@/ui/Spinner";
+import type { SpinnerVariant, SpinnerSize } from "@/ui/Spinner";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
@@ -14,6 +16,75 @@ const TOC_ITEMS = [
 ];
 
 const STORYBOOK_HREF = "https://storybook.reactprinciples.dev/?path=/story/ui-spinner--default";
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+const FORCED_SPINNER_LIGHT: Record<SpinnerVariant, string> = {
+  default: "text-[#4628F1]",
+  muted: "text-slate-400",
+};
+
+const FORCED_SPINNER_DARK: Record<SpinnerVariant, string> = {
+  default: "text-[#4628F1]",
+  muted: "text-slate-600",
+};
+
+const SPINNER_VARIANTS: { variant: SpinnerVariant; label: string }[] = [
+  { variant: "default", label: "Default" },
+  { variant: "muted", label: "Muted" },
+];
+
+function SpinnerSvg({ size = "md", colorClass }: { size?: SpinnerSize; colorClass: string }) {
+  const sizeMap: Record<SpinnerSize, string> = { sm: "w-4 h-4", md: "w-5 h-5", lg: "w-6 h-6" };
+  return (
+    <svg
+      aria-hidden="true"
+      className={`animate-spin ${sizeMap[size]} ${colorClass}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  );
+}
+
+function ThemedSpinnerGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const forced = d ? FORCED_SPINNER_DARK : FORCED_SPINNER_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="flex flex-wrap items-center gap-6">
+        {SPINNER_VARIANTS.map(({ variant, label }) => (
+          <div key={variant} className="flex items-center gap-2">
+            <SpinnerSvg colorClass={forced[variant]} />
+            <span className={`text-xs font-medium ${d ? "text-slate-300" : "text-slate-700"}`}>{label}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-6 mt-4">
+        <div className="flex items-center gap-2">
+          <SpinnerSvg size="sm" colorClass={forced.default} />
+          <span className={`text-xs font-medium ${d ? "text-slate-300" : "text-slate-700"}`}>Small</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <SpinnerSvg size="md" colorClass={forced.default} />
+          <span className={`text-xs font-medium ${d ? "text-slate-300" : "text-slate-700"}`}>Medium</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <SpinnerSvg size="lg" colorClass={forced.default} />
+          <span className={`text-xs font-medium ${d ? "text-slate-300" : "text-slate-700"}`}>Large</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { Spinner } from "@/ui/Spinner";
 
@@ -122,11 +193,41 @@ export default function SpinnerDocPage() {
 
         <CliInstallBlock name="spinner" />
 
-        {/* 01 Live Demo */}
-        <section id="demo" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            Both variants and three sizes across both themes — forced styling for
+            accurate side-by-side comparison.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedSpinnerGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedSpinnerGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Live Demo */}
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
           </div>
@@ -220,11 +321,11 @@ export default function SpinnerDocPage() {
           </div>
         </section>
 
-        {/* 02 Code Snippet */}
+        {/* 03 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
           </div>
@@ -233,11 +334,11 @@ export default function SpinnerDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 03 Copy-Paste */}
+        {/* 04 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
           </div>
@@ -246,11 +347,11 @@ export default function SpinnerDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 04 Props */}
+        {/* 05 Props */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
           </div>

--- a/src/app/docs/spinner/page.tsx
+++ b/src/app/docs/spinner/page.tsx
@@ -29,7 +29,7 @@ const FORCED_SPINNER_DARK: Record<SpinnerVariant, string> = {
   muted: "text-slate-600",
 };
 
-const SPINNER_VARIANTS: { variant: SpinnerVariant; label: string }[] = [
+const SPINNER_VARIANTS: Array<{ variant: SpinnerVariant; label: string }> = [
   { variant: "default", label: "Default" },
   { variant: "muted", label: "Muted" },
 ];

--- a/src/app/docs/toggle-group/page.tsx
+++ b/src/app/docs/toggle-group/page.tsx
@@ -298,6 +298,13 @@ export default function ToggleGroupDocsPage() {
             A set of toggle buttons where one or multiple can be active. Supports single
             selection (segmented control) and multiple selection (toolbar) modes.
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "Single/Multi Select", "Keyboard Nav", "Connected Borders"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/toggle-group/page.tsx
+++ b/src/app/docs/toggle-group/page.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { ToggleGroup } from "@/ui/ToggleGroup";
+import type { ToggleVariant, ToggleSize } from "@/ui/Toggle";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Features", href: "#features" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
@@ -15,6 +17,79 @@ const TOC_ITEMS = [
   { label: "Usage Examples", href: "#examples" },
   { label: "Props", href: "#props" },
 ];
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+type ToggleThemeState = "on" | "off";
+
+const FORCED_TOGGLE_LIGHT: Record<ToggleVariant, Record<ToggleThemeState, string>> = {
+  default: {
+    on: "bg-[#4628F1] text-white",
+    off: "bg-slate-100 text-slate-700",
+  },
+  outline: {
+    on: "bg-slate-100 text-slate-900 border border-slate-300",
+    off: "border border-slate-300 text-slate-700",
+  },
+};
+
+const FORCED_TOGGLE_DARK: Record<ToggleVariant, Record<ToggleThemeState, string>> = {
+  default: {
+    on: "bg-[#4628F1] text-white",
+    off: "bg-slate-800 text-slate-100",
+  },
+  outline: {
+    on: "bg-slate-800 text-white border border-slate-600",
+    off: "border border-slate-600 text-slate-300",
+  },
+};
+
+const TOGGLE_BASE = "inline-flex items-center justify-center font-semibold transition-all";
+
+const TOGGLE_VARIANTS: { variant: ToggleVariant; label: string }[] = [
+  { variant: "default", label: "Default" },
+  { variant: "outline", label: "Outline" },
+];
+
+function ThemedToggleGroupGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const forced = d ? FORCED_TOGGLE_DARK : FORCED_TOGGLE_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="space-y-4">
+        {TOGGLE_VARIANTS.map(({ variant }) => (
+          <div key={variant} className="inline-flex items-center">
+            <button className={`${TOGGLE_BASE} ${forced[variant].on} text-sm px-4 py-2 h-9 first:rounded-l-lg first:rounded-r-none`}>
+              A
+            </button>
+            <button className={`${TOGGLE_BASE} ${forced[variant].off} text-sm px-4 py-2 h-9 rounded-none -ml-px`}>
+              B
+            </button>
+            <button className={`${TOGGLE_BASE} ${forced[variant].off} text-sm px-4 py-2 h-9 last:rounded-r-lg last:rounded-l-none rounded-none -ml-px`}>
+              C
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="inline-flex items-center mt-4">
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-xs px-3 py-1.5 h-7 first:rounded-l-lg first:rounded-r-none`}>
+          sm
+        </button>
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-xs px-3 py-1.5 h-7 rounded-none -ml-px`}>
+          sm
+        </button>
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-xs px-3 py-1.5 h-7 last:rounded-r-lg last:rounded-l-none rounded-none -ml-px`}>
+          sm
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { ToggleGroup } from "@/ui/ToggleGroup";
 
@@ -230,11 +305,41 @@ export default function ToggleGroupDocsPage() {
           <CliInstallBlock name="toggle-group" />
         </section>
 
-        {/* Features */}
-        <section id="features" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            Both variants and three sizes across both themes — forced styling for
+            accurate side-by-side comparison.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedToggleGroupGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedToggleGroupGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Features */}
+        <section id="features" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Features</h2>
           </div>
@@ -272,11 +377,11 @@ export default function ToggleGroupDocsPage() {
           </ul>
         </section>
 
-        {/* Live Demo */}
+        {/* 03 Live Demo */}
         <section id="demo" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
           </div>
@@ -327,11 +432,11 @@ export default function ToggleGroupDocsPage() {
           </div>
         </section>
 
-        {/* Code Snippet */}
+        {/* 04 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
           </div>
@@ -340,11 +445,11 @@ export default function ToggleGroupDocsPage() {
           </CodeBlock>
         </section>
 
-        {/* Copy-Paste */}
+        {/* 05 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
           </div>
@@ -353,11 +458,11 @@ export default function ToggleGroupDocsPage() {
           </CodeBlock>
         </section>
 
-        {/* Usage Examples */}
+        {/* 06 Usage Examples */}
         <section id="examples" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">05</span>
+              <span className="text-sm font-bold">06</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Usage Examples</h2>
           </div>
@@ -445,11 +550,11 @@ export default function ToggleGroupDocsPage() {
           </div>
         </section>
 
-        {/* Props Table */}
+        {/* 07 Props Table */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">06</span>
+              <span className="text-sm font-bold">07</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
           </div>

--- a/src/app/docs/toggle-group/page.tsx
+++ b/src/app/docs/toggle-group/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { ToggleGroup } from "@/ui/ToggleGroup";
-import type { ToggleVariant, ToggleSize } from "@/ui/Toggle";
+import type { ToggleVariant } from "@/ui/Toggle";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -46,7 +46,7 @@ const FORCED_TOGGLE_DARK: Record<ToggleVariant, Record<ToggleThemeState, string>
 
 const TOGGLE_BASE = "inline-flex items-center justify-center font-semibold transition-all";
 
-const TOGGLE_VARIANTS: { variant: ToggleVariant; label: string }[] = [
+const TOGGLE_VARIANTS: Array<{ variant: ToggleVariant; label: string }> = [
   { variant: "default", label: "Default" },
   { variant: "outline", label: "Outline" },
 ];

--- a/src/app/docs/toggle/page.tsx
+++ b/src/app/docs/toggle/page.tsx
@@ -195,6 +195,13 @@ export default function ToggleDocsPage() {
             A two-state button that persists its pressed/active state. Visually reflects
             on/off state and supports controlled and uncontrolled modes.
           </p>
+          <div className="flex flex-wrap gap-2 mt-6">
+            {["Accessible", "Dark Mode", "2 Variants", "3 Sizes", "Pressed State"].map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-200 dark:border-[#1f2937] bg-slate-50 dark:bg-[#161b22] px-3 py-1 text-xs font-medium text-slate-600 dark:text-slate-400">
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
 
         {/* CliInstallBlock */}

--- a/src/app/docs/toggle/page.tsx
+++ b/src/app/docs/toggle/page.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Toggle } from "@/ui/Toggle";
+import type { ToggleVariant, ToggleSize } from "@/ui/Toggle";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Features", href: "#features" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
@@ -15,6 +17,71 @@ const TOC_ITEMS = [
   { label: "Usage Examples", href: "#examples" },
   { label: "Props", href: "#props" },
 ];
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+type ToggleThemeState = "on" | "off";
+
+const FORCED_TOGGLE_LIGHT: Record<ToggleVariant, Record<ToggleThemeState, string>> = {
+  default: {
+    on: "bg-[#4628F1] text-white",
+    off: "bg-slate-100 text-slate-700",
+  },
+  outline: {
+    on: "bg-slate-100 text-slate-900 border border-slate-300",
+    off: "border border-slate-300 text-slate-700",
+  },
+};
+
+const FORCED_TOGGLE_DARK: Record<ToggleVariant, Record<ToggleThemeState, string>> = {
+  default: {
+    on: "bg-[#4628F1] text-white",
+    off: "bg-slate-800 text-slate-100",
+  },
+  outline: {
+    on: "bg-slate-800 text-white border border-slate-600",
+    off: "border border-slate-600 text-slate-300",
+  },
+};
+
+const TOGGLE_BASE = "inline-flex items-center justify-center font-semibold rounded-lg transition-all";
+
+const TOGGLE_VARIANTS: { variant: ToggleVariant; label: string }[] = [
+  { variant: "default", label: "Default" },
+  { variant: "outline", label: "Outline" },
+];
+
+function ThemedToggleGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const forced = d ? FORCED_TOGGLE_DARK : FORCED_TOGGLE_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="flex flex-wrap gap-3">
+        {TOGGLE_VARIANTS.map(({ variant, label }) => (
+          <button key={variant} className={`${TOGGLE_BASE} ${forced[variant].on} text-sm px-4 py-2 h-9`}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-3 mt-4">
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-xs px-3 py-1.5 h-7`}>
+          Small
+        </button>
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-sm px-4 py-2 h-9`}>
+          Medium
+        </button>
+        <button className={`${TOGGLE_BASE} ${forced.default.on} text-base px-6 py-2.5 h-11`}>
+          Large
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { Toggle } from "@/ui/Toggle";
 
@@ -135,11 +202,41 @@ export default function ToggleDocsPage() {
           <CliInstallBlock name="toggle" />
         </section>
 
-        {/* Features */}
-        <section id="features" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Theme Preview</h2>
+          </div>
+          <p className="mb-8 leading-relaxed text-slate-600 dark:text-slate-400">
+            Both variants and three sizes across both themes — forced styling for
+            accurate side-by-side comparison.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedToggleGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedToggleGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Features */}
+        <section id="features" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Features</h2>
           </div>
@@ -177,11 +274,11 @@ export default function ToggleDocsPage() {
           </ul>
         </section>
 
-        {/* Live Demo */}
+        {/* 03 Live Demo */}
         <section id="demo" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Live Demo</h2>
           </div>
@@ -218,11 +315,11 @@ export default function ToggleDocsPage() {
           </div>
         </section>
 
-        {/* Code Snippet */}
+        {/* 04 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Code Snippet</h2>
           </div>
@@ -231,11 +328,11 @@ export default function ToggleDocsPage() {
           </CodeBlock>
         </section>
 
-        {/* Copy-Paste */}
+        {/* 05 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Copy-Paste (Single File)</h2>
           </div>
@@ -244,11 +341,11 @@ export default function ToggleDocsPage() {
           </CodeBlock>
         </section>
 
-        {/* Usage Examples */}
+        {/* 06 Usage Examples */}
         <section id="examples" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">05</span>
+              <span className="text-sm font-bold">06</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Usage Examples</h2>
           </div>
@@ -299,11 +396,11 @@ export default function ToggleDocsPage() {
           </div>
         </section>
 
-        {/* Props Table */}
+        {/* 07 Props Table */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">06</span>
+              <span className="text-sm font-bold">07</span>
             </div>
             <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Props</h2>
           </div>

--- a/src/app/docs/toggle/page.tsx
+++ b/src/app/docs/toggle/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Toggle } from "@/ui/Toggle";
-import type { ToggleVariant, ToggleSize } from "@/ui/Toggle";
+import type { ToggleVariant } from "@/ui/Toggle";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -46,7 +46,7 @@ const FORCED_TOGGLE_DARK: Record<ToggleVariant, Record<ToggleThemeState, string>
 
 const TOGGLE_BASE = "inline-flex items-center justify-center font-semibold rounded-lg transition-all";
 
-const TOGGLE_VARIANTS: { variant: ToggleVariant; label: string }[] = [
+const TOGGLE_VARIANTS: Array<{ variant: ToggleVariant; label: string }> = [
   { variant: "default", label: "Default" },
   { variant: "outline", label: "Outline" },
 ];

--- a/src/app/docs/typography/page.tsx
+++ b/src/app/docs/typography/page.tsx
@@ -3,10 +3,12 @@
 import { DocsPageLayout, CliInstallBlock } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
 import { Typography } from "@/ui/Typography";
+import type { TypographyVariant } from "@/ui/Typography";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOC_ITEMS = [
+  { label: "Theme Preview", href: "#comparison" },
   { label: "Live Demo", href: "#demo" },
   { label: "Code Snippet", href: "#snippet" },
   { label: "Copy-Paste", href: "#copy-paste" },
@@ -14,6 +16,70 @@ const TOC_ITEMS = [
 ];
 
 const STORYBOOK_HREF = "https://storybook.reactprinciples.dev/?path=/story/ui-typography--default";
+
+// ─── Forced-theme preview ─────────────────────────────────────────────────────
+
+const FORCED_TYPOGRAPHY_LIGHT: Record<TypographyVariant, string> = {
+  h1: "text-4xl font-black tracking-tight text-slate-900 md:text-5xl",
+  h2: "text-2xl font-bold text-slate-900",
+  h3: "text-xl font-bold text-slate-900",
+  h4: "text-lg font-semibold text-slate-900",
+  p: "text-sm leading-relaxed text-slate-600",
+  lead: "text-lg leading-relaxed text-slate-700",
+  muted: "text-sm text-slate-500",
+  small: "text-xs text-slate-500",
+  blockquote: "border-l-4 border-[#4628F1] pl-4 italic text-slate-700",
+  code: "font-mono text-xs bg-slate-100 px-1.5 py-0.5 rounded text-slate-900",
+  list: "list-disc pl-4 space-y-1 text-sm text-slate-600",
+};
+
+const FORCED_TYPOGRAPHY_DARK: Record<TypographyVariant, string> = {
+  h1: "text-4xl font-black tracking-tight text-white md:text-5xl",
+  h2: "text-2xl font-bold text-white",
+  h3: "text-xl font-bold text-white",
+  h4: "text-lg font-semibold text-white",
+  p: "text-sm leading-relaxed text-slate-400",
+  lead: "text-lg leading-relaxed text-slate-300",
+  muted: "text-sm text-slate-400",
+  small: "text-xs text-slate-400",
+  blockquote: "border-l-4 border-[#4628F1] pl-4 italic text-slate-300",
+  code: "font-mono text-xs bg-[#1f2937] px-1.5 py-0.5 rounded text-white",
+  list: "list-disc pl-4 space-y-1 text-sm text-slate-400",
+};
+
+function ThemedTypographyGrid({ theme }: { theme: "light" | "dark" }) {
+  const d = theme === "dark";
+  const bg = d ? "bg-[#0d1117]" : "bg-white";
+  const border = d ? "border-[#1f2937]" : "border-slate-200";
+  const forced = d ? FORCED_TYPOGRAPHY_DARK : FORCED_TYPOGRAPHY_LIGHT;
+
+  return (
+    <div className={`rounded-xl border ${border} ${bg} p-6`}>
+      <div className="space-y-4">
+        <div>
+          <h1 className={forced.h1}>Heading 1</h1>
+          <h2 className={forced.h2}>Heading 2</h2>
+          <h3 className={forced.h3}>Heading 3</h3>
+          <h4 className={forced.h4}>Heading 4</h4>
+        </div>
+        <div className="space-y-2">
+          <p className={forced.lead}>This is lead text — perfect for introductions.</p>
+          <p className={forced.p}>This is body text for regular content paragraphs.</p>
+          <p className={forced.muted}>This is muted text for secondary information.</p>
+          <small className={forced.small}>This is small text for fine print.</small>
+        </div>
+        <div className="space-y-2">
+          <blockquote className={forced.blockquote}>
+            Good typography is invisible — it lets the content shine.
+          </blockquote>
+          <code className={forced.code}>const example = "inline code";</code>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Code Snippets ────────────────────────────────────────────────────────────
 
 const CODE_SNIPPET = `import { Typography } from "@/ui/Typography";
 
@@ -128,11 +194,41 @@ export default function TypographyDocPage() {
 
         <CliInstallBlock name="typography" />
 
-        {/* 01 Live Demo */}
-        <section id="demo" className="mb-16">
+        {/* 01 Theme Preview */}
+        <section id="comparison" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
               <span className="text-sm font-bold">01</span>
+            </div>
+            <Typography variant="h2">Theme Preview</Typography>
+          </div>
+          <Typography variant="p" className="mb-8">
+            All typography variants across both themes — forced styling for
+            accurate side-by-side comparison.
+          </Typography>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 rounded-full shadow-xs bg-amber-400 shadow-amber-300" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Light</span>
+              </div>
+              <ThemedTypographyGrid theme="light" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="w-3 h-3 bg-indigo-500 rounded-full shadow-xs shadow-indigo-400" />
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Dark</span>
+              </div>
+              <ThemedTypographyGrid theme="dark" />
+            </div>
+          </div>
+        </section>
+
+        {/* 02 Live Demo */}
+        <section id="demo" className="mb-16">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
+              <span className="text-sm font-bold">02</span>
             </div>
             <Typography variant="h2">Live Demo</Typography>
           </div>
@@ -208,11 +304,11 @@ export default function TypographyDocPage() {
           </div>
         </section>
 
-        {/* 02 Code Snippet */}
+        {/* 03 Code Snippet */}
         <section id="snippet" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">02</span>
+              <span className="text-sm font-bold">03</span>
             </div>
             <Typography variant="h2">Code Snippet</Typography>
           </div>
@@ -221,11 +317,11 @@ export default function TypographyDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 03 Copy-Paste */}
+        {/* 04 Copy-Paste */}
         <section id="copy-paste" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">03</span>
+              <span className="text-sm font-bold">04</span>
             </div>
             <Typography variant="h2">Copy-Paste (Single File)</Typography>
           </div>
@@ -234,11 +330,11 @@ export default function TypographyDocPage() {
           </CodeBlock>
         </section>
 
-        {/* 04 Props */}
+        {/* 05 Props */}
         <section id="props" className="mb-16">
           <div className="flex items-center gap-3 mb-6">
             <div className="flex items-center justify-center w-8 h-8 rounded-sm bg-primary/10 text-primary">
-              <span className="text-sm font-bold">04</span>
+              <span className="text-sm font-bold">05</span>
             </div>
             <Typography variant="h2">Props</Typography>
           </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -206,3 +206,99 @@
   .animate-slide-right { animation: slide-in-right 0.6s ease-out both; }
   .animate-float { animation: float 3s ease-in-out infinite; }
 }
+
+/* ─── Skill markdown rendering ─────────────────────────────────────────── */
+
+.skill-markdown {
+  color: var(--color-slate-700);
+  line-height: 1.7;
+}
+.dark .skill-markdown { color: var(--color-slate-300); }
+
+.skill-markdown h1,
+.skill-markdown h2,
+.skill-markdown h3,
+.skill-markdown h4 {
+  color: var(--color-slate-900);
+  font-weight: 700;
+  line-height: 1.3;
+  scroll-margin-top: 6rem;
+}
+.dark .skill-markdown h1,
+.dark .skill-markdown h2,
+.dark .skill-markdown h3,
+.dark .skill-markdown h4 { color: #fff; }
+
+.skill-markdown h1 { font-size: 1.875rem; margin-top: 2.5rem; margin-bottom: 1rem; }
+.skill-markdown h2 { font-size: 1.5rem; margin-top: 2.5rem; margin-bottom: 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--color-slate-200); }
+.dark .skill-markdown h2 { border-color: var(--color-slate-800); }
+.skill-markdown h3 { font-size: 1.25rem; margin-top: 2rem; margin-bottom: 0.75rem; }
+.skill-markdown h4 { font-size: 1.0625rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+
+.skill-markdown p { margin: 1rem 0; }
+
+.skill-markdown a { color: var(--color-primary); text-decoration: underline; text-underline-offset: 2px; }
+.skill-markdown a:hover { text-decoration: none; }
+
+.skill-markdown ul,
+.skill-markdown ol { margin: 1rem 0; padding-left: 1.5rem; }
+.skill-markdown ul { list-style: disc; }
+.skill-markdown ol { list-style: decimal; }
+.skill-markdown li { margin: 0.375rem 0; }
+.skill-markdown li > ul,
+.skill-markdown li > ol { margin: 0.5rem 0; }
+
+.skill-markdown strong { color: var(--color-slate-900); font-weight: 600; }
+.dark .skill-markdown strong { color: #fff; }
+
+.skill-markdown code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background: var(--color-slate-100);
+  color: var(--color-slate-800);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+}
+.dark .skill-markdown code { background: var(--color-slate-800); color: var(--color-slate-200); }
+
+.skill-markdown pre {
+  background: #0d1117;
+  color: var(--color-slate-100);
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  margin: 1.25rem 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+.skill-markdown pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.skill-markdown blockquote {
+  border-left: 3px solid var(--color-primary);
+  padding: 0.25rem 1rem;
+  margin: 1.25rem 0;
+  color: var(--color-slate-600);
+  font-style: italic;
+}
+.dark .skill-markdown blockquote { color: var(--color-slate-400); }
+
+.skill-markdown hr {
+  border: 0;
+  border-top: 1px solid var(--color-slate-200);
+  margin: 2rem 0;
+}
+.dark .skill-markdown hr { border-color: var(--color-slate-800); }
+
+.skill-markdown table { width: 100%; border-collapse: collapse; margin: 1.25rem 0; font-size: 0.9375rem; }
+.skill-markdown th,
+.skill-markdown td { padding: 0.5rem 0.75rem; border: 1px solid var(--color-slate-200); text-align: left; }
+.dark .skill-markdown th,
+.dark .skill-markdown td { border-color: var(--color-slate-800); }
+.skill-markdown th { background: var(--color-slate-50); font-weight: 600; }
+.dark .skill-markdown th { background: var(--color-slate-900); }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -153,6 +153,12 @@ export default function RootLayout({
           media="(prefers-color-scheme: dark)"
         />
         <link rel="icon" href="/favicon-light.svg?v=3" type="image/svg+xml" />
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="/llms.txt"
+          title="React Principles cookbook (compact, for AI tools)"
+        />
       </head>
       <body className="min-h-screen bg-(--background) text-(--foreground) antialiased">
                 {process.env.NODE_ENV === "production" && (

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,11 @@
+import { generateFullLlmsTxt } from "@/lib/llms-txt";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(generateFullLlmsTxt(), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,11 @@
+import { generateCompactLlmsTxt } from "@/lib/llms-txt";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(generateCompactLlmsTxt(), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   DocsSection,
   ComponentShowcaseSection,
   ConfiguratorTeaserSection,
+  AICorpusTeaserSection,
   TechStackSection,
   ProjectStructureSection,
   Footer,
@@ -66,6 +67,7 @@ export default function LandingPage() {
         <DocsSection />
         <ComponentShowcaseSection />
         <ConfiguratorTeaserSection />
+        <AICorpusTeaserSection />
         <TechStackSection />
         <ProjectStructureSection />
       </main>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -28,6 +28,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.85,
     },
+    {
+      url: `${BASE_URL}/ai`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.85,
+    },
   ];
 
   // Docs pages (only published — skip "soon" items)

--- a/src/features/configurator/components/ConfiguratorSidebar.tsx
+++ b/src/features/configurator/components/ConfiguratorSidebar.tsx
@@ -44,6 +44,7 @@ const ALL_COMPONENTS = [
   "Alert",
   "Avatar",
   "Badge",
+  "Breadcrumb",
   "Button",
   "Calendar",
   "Card",
@@ -56,13 +57,13 @@ const ALL_COMPONENTS = [
   "DatePicker",
   "Dialog",
   "Drawer",
-  "Dropdown",
+  "DropdownMenu",
   "Input",
   "Label",
   "Pagination",
   "Popover",
   "Progress",
-  "Radio",
+  "RadioGroup",
   "Select",
   "Separator",
   "Skeleton",
@@ -76,10 +77,10 @@ const ALL_COMPONENTS = [
 ];
 
 const COMPONENT_CATEGORIES: Record<string, string[]> = {
-  Forms: ["Input", "Textarea", "Select", "Checkbox", "Radio", "Switch", "Slider", "Label"],
+  Forms: ["Input", "Textarea", "Select", "Checkbox", "RadioGroup", "Switch", "Slider", "Label"],
   Feedback: ["Alert", "Progress", "Skeleton", "Spinner", "Toast"],
   Navigation: ["Tabs", "Pagination", "Breadcrumb", "Command"],
-  Overlays: ["Dialog", "Drawer", "Popover", "Tooltip", "Dropdown"],
+  Overlays: ["Dialog", "Drawer", "Popover", "Tooltip", "DropdownMenu"],
   Data: ["DataTable", "Chart", "Calendar", "DatePicker"],
   Layout: ["Card", "Separator", "Collapsible", "Avatar", "Badge", "Carousel", "Button"],
 };

--- a/src/features/configurator/data/dependency-map.ts
+++ b/src/features/configurator/data/dependency-map.ts
@@ -51,7 +51,7 @@ export const COMPONENT_DEPENDENCIES: Record<string, PackageEntry[]> = {
   Checkbox: [
     { name: "@radix-ui/react-checkbox", version: "^1.1.4" },
   ],
-  Radio: [
+  RadioGroup: [
     { name: "@radix-ui/react-radio-group", version: "^1.2.3" },
   ],
   Switch: [
@@ -94,7 +94,7 @@ export const COMPONENT_DEPENDENCIES: Record<string, PackageEntry[]> = {
   // Other
   Avatar: [], // No external dependencies
   Button: [], // No external dependencies
-  Dropdown: [
+  DropdownMenu: [
     { name: "@radix-ui/react-dropdown-menu", version: "^2.1.6" },
   ],
   Carousel: [

--- a/src/features/cookbook/components/CookbookDetailPage.tsx
+++ b/src/features/cookbook/components/CookbookDetailPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { DocsPageLayout } from "@/features/docs/components";
 import { CodeBlock } from "@/features/cookbook/components/CodeBlock";
@@ -131,8 +131,13 @@ function SectionBadge({ n }: { n: number }) {
 
 function DetailContent({ detail, framework }: { detail: RecipeDetail; framework: Framework }) {
   const [copied, setCopied] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const { isSaved, toggleSaved } = useSavedStore();
-  const saved = isSaved(detail.slug);
+  const saved = mounted && isSaved(detail.slug);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const activeImpl =
     framework === "nextjs"

--- a/src/features/cookbook/data/cookbook-data.ts
+++ b/src/features/cookbook/data/cookbook-data.ts
@@ -136,7 +136,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%)",
     tags: ["Standard", "React Query"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 9,
   },
   {
@@ -149,7 +149,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%)",
     tags: ["Standard", "Zustand"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 10,
   },
   {
@@ -162,7 +162,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #f97316 0%, #c2410c 100%)",
     tags: ["Standard", "Zod"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 11,
   },
   {

--- a/src/features/cookbook/data/cookbook-data.ts
+++ b/src/features/cookbook/data/cookbook-data.ts
@@ -175,7 +175,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #14b8a6 0%, #0f766e 100%)",
     tags: ["Advanced", "TanStack"],
     category: "Patterns",
-    status: "coming-soon",
+    status: "published",
     order: 12,
   },
   {
@@ -214,7 +214,7 @@ export const RECIPES: Recipe[] = [
     gradient: "linear-gradient(135deg, #f43f5e 0%, #be123c 100%)",
     tags: ["Pro", "GraphQL"],
     category: "API Integration",
-    status: "coming-soon",
+    status: "published",
     order: 15,
   },
   {

--- a/src/features/cookbook/data/recipes/api-integration.ts
+++ b/src/features/cookbook/data/recipes/api-integration.ts
@@ -5,63 +5,173 @@ export const apiIntegration: RecipeDetail = {
   title: "API Integration",
   breadcrumbCategory: "API Integration",
   description:
-    "Typed REST and GraphQL clients with interceptors, retry logic, and centralized error handling using React Query.",
+    "A custom fetch-based API client factory with typed methods, centralized error handling, and optional auth — no Axios needed.",
   principle: {
-    text: "All API calls flow through a single typed client layer. React Query wraps the client for caching and synchronization. Components never call fetch() directly — they use custom hooks that compose the query client and API client together.",
-    tip: "Use Zod to validate API responses at the boundary. This catches backend contract violations early and ensures your types are always accurate.",
+    text: "All API calls flow through a single typed client created by createApiClient(). The factory configures the base URL, auth headers, and error handling once. Services wrap the client with domain-specific methods. React Query hooks wrap services for caching. Components never call fetch() directly.",
+    tip: "The native Fetch API covers most use cases without a library. createApiClient adds type safety, automatic JSON serialization, query parameter handling, and centralized error handling — the exact gaps fetch leaves open — without pulling in Axios as a dependency.",
   },
   rules: [
-    { title: "Single API Client Instance", description: "One Axios/fetch instance with all interceptors. Import it everywhere via a singleton." },
-    { title: "Type All Responses", description: "Define TypeScript interfaces for every endpoint. Use Zod for runtime validation." },
-    { title: "Centralized Error Handling", description: "Map API error codes to user-friendly messages in one place — not scattered in components." },
-    { title: "Retry Transient Failures", description: "Configure React Query retry logic for 5xx errors. Never retry 4xx client errors." },
+    { title: "Single API Client Instance", description: "Create one instance via createApiClient() in lib/api.ts and import it everywhere. All requests share the same base URL, headers, and error handler." },
+    { title: "Type All Responses", description: "Pass a generic type to every api.get<T>() call. TypeScript interfaces define the contract — if the backend changes shape, the compiler catches it." },
+    { title: "Centralized Error Handling", description: "Pass an onError callback to createApiClient(). It fires on every failed request — connect it to a toast or error reporting service. Components never parse error responses." },
+    { title: "Service → Hook → Component", description: "Services handle HTTP calls. Hooks wrap services with React Query. Components consume hooks. Each layer has one job — when the API changes, only the service file changes." },
   ],
   pattern: {
     filename: "lib/api-client.ts",
-    code: `import axios from 'axios';
-import { z } from 'zod';
+    code: `import type { ApiError } from '@/shared/types/api';
 
-const apiClient = axios.create({ baseURL: process.env.NEXT_PUBLIC_API_URL });
+interface ApiClientConfig {
+  baseUrl: string;
+  defaultHeaders?: Record<string, string>;
+  onError?: (error: ApiError) => void;
+  getAuthToken?: () => string | null;
+}
 
-export async function fetchTyped<T>(
-  url: string,
-  schema: z.ZodType<T>,
-): Promise<T> {
-  const { data } = await apiClient.get(url);
-  return schema.parse(data);
-}`,
+interface RequestOptions extends Omit<RequestInit, 'body'> {
+  params?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+}
+
+export function createApiClient(config: ApiClientConfig) {
+  const { baseUrl, defaultHeaders = {}, onError, getAuthToken } = config;
+
+  async function request<T>(method: string, path: string, options: RequestOptions = {}): Promise<T> {
+    const { params, body, headers: reqHeaders, ...fetchOptions } = options;
+    const url = new URL(path, baseUrl);
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...defaultHeaders,
+      ...(reqHeaders as Record<string, string> | undefined),
+    };
+    const token = getAuthToken?.();
+    if (token) headers['Authorization'] = \`Bearer \${token}\`;
+
+    const res = await fetch(url, {
+      method, headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      ...fetchOptions,
+    });
+
+    if (!res.ok) {
+      const err: ApiError = await res.json().catch(() => ({
+        message: res.statusText, statusCode: res.status,
+      }));
+      onError?.(err);
+      throw err;
+    }
+
+    return (await res.json()) as T;
+  }
+
+  return {
+    get<T>(path: string, opts?: RequestOptions) { return request<T>('GET', path, opts); },
+    post<T>(path: string, body?: unknown, opts?: RequestOptions) { return request<T>('POST', path, { ...opts, body }); },
+    put<T>(path: string, body?: unknown, opts?: RequestOptions) { return request<T>('PUT', path, { ...opts, body }); },
+    patch<T>(path: string, body?: unknown, opts?: RequestOptions) { return request<T>('PATCH', path, { ...opts, body }); },
+    delete<T>(path: string, opts?: RequestOptions) { return request<T>('DELETE', path, opts); },
+  };
+}
+
+export type ApiClient = ReturnType<typeof createApiClient>;`,
   },
   implementation: {
     nextjs: {
-      description: "In Next.js, use Route Handlers as a BFF (Backend for Frontend) layer to proxy external APIs and add auth headers server-side.",
-      filename: "app/api/posts/route.ts",
-      code: `import { NextResponse } from 'next/server';
-import { postListSchema } from '@/lib/schemas';
+      description:
+        "Create a singleton instance in lib/api.ts, then build a service layer with typed methods. React Query hooks wrap the service for caching. The chain: createApiClient → usersService → useUsers → UserList.",
+      filename: "lib/api.ts + lib/services/users.ts",
+      code: `// lib/api.ts — singleton instance
+import { createApiClient } from './api-client';
 
-export async function GET() {
-  const res = await fetch(process.env.EXTERNAL_API + '/posts', {
-    headers: { Authorization: \`Bearer \${process.env.API_SECRET}\` },
-    next: { revalidate: 60 },
+export const api = createApiClient({
+  baseUrl: process.env.NEXT_PUBLIC_API_URL ?? 'https://dummyjson.com',
+  onError: (err) => console.error(\`[API] \${err.statusCode}: \${err.message}\`),
+});
+
+// lib/services/users.ts — typed service layer
+import { api } from '@/lib/api';
+import { ENDPOINTS } from '@/lib/endpoints';
+import type { User, UsersResponse, CreateUserInput, UpdateUserInput } from '@/shared/types/user';
+
+export const usersService = {
+  getAll: (params?: { limit?: number; skip?: number }): Promise<UsersResponse> =>
+    api.get<UsersResponse>(ENDPOINTS.users.list, { params }),
+  getById: (id: number): Promise<User> =>
+    api.get<User>(ENDPOINTS.users.detail(id)),
+  create: (data: CreateUserInput): Promise<User> =>
+    api.post<User>(ENDPOINTS.users.create, data),
+  update: (id: number, data: UpdateUserInput): Promise<User> =>
+    api.put<User>(ENDPOINTS.users.update(id), data),
+  delete: (id: number): Promise<User> =>
+    api.delete<User>(ENDPOINTS.users.delete(id)),
+  search: (q: string): Promise<UsersResponse> =>
+    api.get<UsersResponse>(ENDPOINTS.users.search, { params: { q } }),
+};
+
+// features/users/hooks/useUsers.ts — React Query hook
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query-keys';
+import { usersService } from '@/lib/services/users';
+
+export function useUsers(params?: { limit?: number; skip?: number }) {
+  return useQuery({
+    queryKey: queryKeys.users.list(params ?? {}),
+    queryFn: () => usersService.getAll(params),
   });
-  const data = postListSchema.parse(await res.json());
-  return NextResponse.json(data);
 }`,
     },
     vite: {
-      description: "In Vite, call external APIs directly from custom hooks using the typed API client. Use environment variables for base URLs.",
-      filename: "hooks/queries/usePosts.ts",
-      code: `import { useQuery } from '@tanstack/react-query';
-import { fetchTyped } from '@/lib/api-client';
-import { postListSchema } from '@/lib/schemas';
+      description:
+        "The pattern is identical in Vite — the API client and services are framework-agnostic. Only the environment variable syntax changes.",
+      filename: "lib/api.ts + hooks/useUsers.ts",
+      code: `// lib/api.ts — same factory, Vite env syntax
+import { createApiClient } from './api-client';
 
-export const usePosts = () =>
-  useQuery({
-    queryKey: ['posts', 'list'],
-    queryFn: () => fetchTyped('/posts', postListSchema),
-    staleTime: 1000 * 60,
-  });`,
+export const api = createApiClient({
+  baseUrl: import.meta.env.VITE_API_URL ?? 'https://dummyjson.com',
+  onError: (err) => console.error(\`[API] \${err.statusCode}: \${err.message}\`),
+});
+
+// lib/services/users.ts — same pattern as Next.js (showing key methods)
+import { api } from '@/lib/api';
+import { ENDPOINTS } from '@/lib/endpoints';
+import type { User, UsersResponse, CreateUserInput, UpdateUserInput } from '@/shared/types/user';
+
+export const usersService = {
+  getAll: (params?: { limit?: number; skip?: number }): Promise<UsersResponse> =>
+    api.get<UsersResponse>(ENDPOINTS.users.list, { params }),
+  getById: (id: number): Promise<User> =>
+    api.get<User>(ENDPOINTS.users.detail(id)),
+  create: (data: CreateUserInput): Promise<User> =>
+    api.post<User>(ENDPOINTS.users.create, data),
+  update: (id: number, data: UpdateUserInput): Promise<User> =>
+    api.put<User>(ENDPOINTS.users.update(id), data),
+  delete: (id: number): Promise<User> =>
+    api.delete<User>(ENDPOINTS.users.delete(id)),
+};
+
+// features/users/hooks/useUsers.ts — React Query hook
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query-keys';
+import { usersService } from '@/lib/services/users';
+
+export function useUsers(params?: { limit?: number; skip?: number }) {
+  return useQuery({
+    queryKey: queryKeys.users.list(params ?? {}),
+    queryFn: () => usersService.getAll(params),
+  });
+}`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 10, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
+  starterLink: {
+    label: "View API client in starter",
+    href: "https://github.com/sindev08/react-principles-nextjs/tree/main/src/lib",
+  },
 };

--- a/src/features/cookbook/data/recipes/client-state.ts
+++ b/src/features/cookbook/data/recipes/client-state.ts
@@ -5,21 +5,26 @@ export const clientState: RecipeDetail = {
   title: "Client State with Zustand",
   breadcrumbCategory: "Patterns",
   description:
-    "Manage global UI state across multiple Zustand stores. Covers store slices, selectors, actions, and a computed filter store with reset.",
+    "Manage global UI state across multiple Zustand stores. Covers selectors, actions, computed selectors, reset, and the 'use client' boundary in Next.js.",
   principle: {
     text: "Client state — UI toggles, filter state, user preferences — belongs in Zustand, not React Query. Each store owns one domain. Components read a slice of state via selectors and call actions. No prop drilling, no context boilerplate.",
     tip: "One store per feature domain. Never put server state (API data) in Zustand — if it comes from an endpoint, it belongs in React Query.",
   },
   rules: [
-    { title: "One store per domain", description: "useAppStore for app-wide settings, useFilterStore for filters. Never mix concerns in a single store." },
+    { title: "One store per domain", description: "useAppStore for app-wide settings, useFilterStore for filters, useSearchStore for search UI. Never mix concerns in a single store." },
     { title: "Actions inside the store", description: "Mutations happen in store actions, not in component event handlers. Keeps logic close to state." },
-    { title: "Selectors over full-state", description: "Pass selector functions: useAppStore(s => s.theme) not useAppStore(). Prevents unnecessary re-renders." },
+    { title: "Selectors over full-state", description: "Pass selector functions: useAppStore(s => s.theme) not useAppStore(). For multiple values, use useShallow from zustand/shallow." },
     { title: "Reset is first-class", description: "Always define a reset() action for stores that can be cleared. Useful for logout, navigation, and testing." },
+    { title: "'use client' on the store file", description: "Zustand hooks call React internals (useState, useSyncExternalStore). Put 'use client' on the store file itself — never on barrel exports — so Server Components can still import types." },
   ],
   pattern: {
-    filename: "stores/useFilterStore.ts",
-    code: `import { create } from 'zustand';
-import type { UserRole, UserStatus } from '@/types';
+    filename: "stores/useFilterStore.ts · useAppStore.ts · useSearchStore.ts",
+    code: `'use client';
+
+import { create } from 'zustand';
+import type { UserRole, UserStatus } from '@/shared/types/common';
+
+// ─── useFilterStore (feature-scoped filters) ─────────────────────────────────
 
 interface FilterState {
   search: string;
@@ -31,71 +36,161 @@ interface FilterState {
   reset: () => void;
 }
 
-const initialState = { search: '', role: null, status: null };
+const initialFilterState = {
+  search: '',
+  role: null as UserRole | null,
+  status: null as UserStatus | null,
+};
 
 export const useFilterStore = create<FilterState>((set) => ({
-  ...initialState,
+  ...initialFilterState,
   setSearch: (search) => set({ search }),
   setRole: (role) => set({ role }),
   setStatus: (status) => set({ status }),
-  reset: () => set(initialState),
+  reset: () => set(initialFilterState),
 }));
 
-// Computed selector — avoids inline logic in components
 export const useHasActiveFilters = () =>
-  useFilterStore((s) => s.search !== '' || s.role !== null || s.status !== null);`,
+  useFilterStore(
+    (s) => s.search !== '' || s.role !== null || s.status !== null,
+  );
+
+// ─── useAppStore (app-wide settings) ─────────────────────────────────────────
+
+type Theme = 'light' | 'dark';
+
+interface AppState {
+  theme: Theme;
+  sidebarOpen: boolean;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  setSidebarOpen: (open: boolean) => void;
+  toggleSidebar: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  theme: 'dark',
+  sidebarOpen: true,
+  setTheme: (theme) => set({ theme }),
+  toggleTheme: () =>
+    set((state) => ({ theme: state.theme === 'light' ? 'dark' : 'light' })),
+  setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
+  toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+}));
+
+// ─── useSearchStore (search dialog UI) ───────────────────────────────────────
+
+interface SearchState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+export const useSearchStore = create<SearchState>()((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((s) => ({ open: !s.open })),
+}));`,
   },
   implementation: {
     nextjs: {
       description:
-        "Zustand stores are client-side only. In Next.js, use them inside Client Components marked with 'use client'. No HydrationBoundary needed — client state is not serialized.",
+        "Zustand stores are client-side only. In Next.js, use them inside Client Components marked with 'use client'. No HydrationBoundary needed — client state is not serialized. Use useShallow when reading multiple values to avoid unnecessary re-renders.",
       filename: "components/UserFilters.tsx",
       code: `'use client';
 
-import { useFilterStore, useHasActiveFilters } from '@/stores/useFilterStore';
+import { useShallow } from 'zustand/shallow';
+import { useFilterStore, useHasActiveFilters } from '@/shared/stores/useFilterStore';
+import { Input } from '@/ui/Input';
+import { NativeSelect } from '@/ui/NativeSelect';
+import type { UserRole } from '@/shared/types/common';
 
 export function UserFilters() {
-  const { search, role, setSearch, setRole, reset } = useFilterStore();
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
   const hasFilters = useHasActiveFilters();
 
   return (
-    <div className="flex gap-3">
-      <input value={search} onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search..." />
-      <select value={role ?? ''} onChange={(e) => setRole(e.target.value || null)}>
+    <div className="flex items-end gap-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+      />
+      <NativeSelect
+        value={role ?? ''}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+      >
         <option value="">All roles</option>
         <option value="admin">Admin</option>
-      </select>
-      {hasFilters && <button onClick={reset}>Reset</button>}
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button onClick={reset}>Reset</button>
+      )}
     </div>
   );
 }`,
     },
     vite: {
       description:
-        "In Vite, Zustand works identically — no special setup required. Import the store hook directly in any component.",
+        "In Vite, Zustand works identically — no special setup required. Import the store hook directly in any component. useShallow is still recommended for multi-value subscriptions.",
       filename: "components/UserFilters.tsx",
-      code: `import { useFilterStore, useHasActiveFilters } from '@/stores/useFilterStore';
+      code: `import { useShallow } from 'zustand/shallow';
+import { useFilterStore, useHasActiveFilters } from '@/shared/stores/useFilterStore';
+import { Input } from '@/ui/Input';
+import { NativeSelect } from '@/ui/NativeSelect';
+import type { UserRole } from '@/shared/types/common';
 
 export function UserFilters() {
-  const { search, role, setSearch, setRole, reset } = useFilterStore();
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
   const hasFilters = useHasActiveFilters();
 
   return (
-    <div className="flex gap-3">
-      <input value={search} onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search..." />
-      <select value={role ?? ''} onChange={(e) => setRole(e.target.value || null)}>
+    <div className="flex items-end gap-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+      />
+      <NativeSelect
+        value={role ?? ''}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+      >
         <option value="">All roles</option>
         <option value="admin">Admin</option>
-      </select>
-      {hasFilters && <button onClick={reset}>Reset</button>}
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button onClick={reset}>Reset</button>
+      )}
     </div>
   );
 }`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 11, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
   demoKey: "zustand",
 };

--- a/src/features/cookbook/data/recipes/data-tables.ts
+++ b/src/features/cookbook/data/recipes/data-tables.ts
@@ -24,7 +24,7 @@ import {
   getFilteredRowModel, getPaginationRowModel,
   flexRender, type ColumnDef, type SortingState,
 } from '@tanstack/react-table';
-import type { User } from '@/types';
+import type { User } from '@/shared/types/user';
 
 const columns: ColumnDef<User>[] = [
   { accessorKey: 'name',   header: 'Name' },
@@ -48,25 +48,85 @@ export function UserTable({ data }: { data: User[] }) {
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
   });
-  // render table.getHeaderGroups() and table.getRowModel().rows
+
+  return (
+    <div>
+      <input
+        value={globalFilter}
+        onChange={(e) => setGlobalFilter(e.target.value)}
+        placeholder="Filter all columns..."
+      />
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  onClick={header.column.getToggleSortingHandler()}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {{ asc: ' ↑', desc: ' ↓' }[header.column.getIsSorted() as string] ?? null}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div>
+        <button onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+          Previous
+        </button>
+        <span>
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+        </span>
+        <button onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
 }`,
   },
   implementation: {
     nextjs: {
       description:
-        "In Next.js, prefetch the initial page of data in a Server Component and pass it as initialData. The table renders immediately without a loading state.",
+        "In Next.js, prefetch user data in a Server Component and hydrate it via HydrationBoundary. The table renders immediately with cached data while staying reactive to updates.",
       filename: "app/users/page.tsx",
-      code: `import { UserTable } from '@/components/UserTable';
+      code: `import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/get-query-client';
+import { queryKeys } from '@/lib/query-keys';
 import { getUsers } from '@/services/users';
+import { UserTable } from '@/components/UserTable';
 
 export default async function UsersPage() {
-  const initialData = await getUsers({ page: 1, limit: 20 });
-  return <UserTable initialData={initialData} />;
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.users.all,
+    queryFn: () => getUsers({ page: 1, limit: 100 }),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <UserTable />
+    </HydrationBoundary>
+  );
 }`,
     },
     vite: {
       description:
-        "In Vite, fetch data via a React Query hook and pass it to the table. For datasets under 1,000 rows, all filtering and sorting can stay client-side.",
+        "In Vite, fetch data via a React Query hook and pass it to the table. DummyJSON returns users under data.users. For datasets under 1,000 rows, all filtering and sorting can stay client-side.",
       filename: "pages/UsersPage.tsx",
       code: `import { useUsers } from '@/hooks/queries/useUsers';
 import { UserTable } from '@/components/UserTable';
@@ -76,7 +136,7 @@ export function UsersPage() {
 
   if (isLoading) return <TableSkeleton />;
 
-  return <UserTable data={data?.data ?? []} />;
+  return <UserTable data={data?.users ?? []} />;
 }`,
     },
   },

--- a/src/features/cookbook/data/recipes/data-tables.ts
+++ b/src/features/cookbook/data/recipes/data-tables.ts
@@ -27,10 +27,15 @@ import {
 import type { User } from '@/shared/types/user';
 
 const columns: ColumnDef<User>[] = [
-  { accessorKey: 'name',   header: 'Name' },
+  {
+    id: 'name',
+    header: 'Name',
+    // accessorFn combines two fields into one sortable, filterable column
+    accessorFn: (row) => \`\${row.firstName} \${row.lastName}\`,
+  },
   { accessorKey: 'email',  header: 'Email' },
-  { accessorKey: 'role',   header: 'Role' },
-  { accessorKey: 'status', header: 'Status' },
+  { accessorKey: 'age',    header: 'Age' },
+  { accessorKey: 'gender', header: 'Gender' },
 ];
 
 export function UserTable({ data }: { data: User[] }) {
@@ -105,16 +110,16 @@ export function UserTable({ data }: { data: User[] }) {
         "In Next.js, prefetch user data in a Server Component and hydrate it via HydrationBoundary. The table renders immediately with cached data while staying reactive to updates.",
       filename: "app/users/page.tsx",
       code: `import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
-import { getQueryClient } from '@/lib/get-query-client';
+import { getQueryClient } from '@/lib/query-client';
 import { queryKeys } from '@/lib/query-keys';
-import { getUsers } from '@/services/users';
-import { UserTable } from '@/components/UserTable';
+import { usersService } from '@/lib/services/users';
+import { UserTable } from '@/features/users';
 
 export default async function UsersPage() {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery({
     queryKey: queryKeys.users.all,
-    queryFn: () => getUsers({ page: 1, limit: 100 }),
+    queryFn: () => usersService.getAll({ limit: 100 }),
   });
 
   return (
@@ -128,8 +133,7 @@ export default async function UsersPage() {
       description:
         "In Vite, fetch data via a React Query hook and pass it to the table. DummyJSON returns users under data.users. For datasets under 1,000 rows, all filtering and sorting can stay client-side.",
       filename: "pages/UsersPage.tsx",
-      code: `import { useUsers } from '@/hooks/queries/useUsers';
-import { UserTable } from '@/components/UserTable';
+      code: `import { useUsers, UserTable } from '@/features/users';
 
 export function UsersPage() {
   const { data, isLoading } = useUsers({ limit: 100 });
@@ -140,7 +144,11 @@ export function UsersPage() {
 }`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 10, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
   demoKey: "table",
+  starterLink: {
+    label: "View UserTable in starter",
+    href: "https://github.com/sindev08/react-principles-nextjs/blob/main/src/features/users/components/UserTable.tsx",
+  },
 };

--- a/src/features/cookbook/data/recipes/form-validation.ts
+++ b/src/features/cookbook/data/recipes/form-validation.ts
@@ -18,23 +18,24 @@ export const formValidation: RecipeDetail = {
     { title: "Share schemas between create and edit", description: "Define a base schema, then derive create and edit variants with .omit() or .partial(). Single source of truth for all validation rules." },
   ],
   pattern: {
-    filename: "lib/schemas/user.ts",
+    filename: "shared/utils/validators.ts",
     code: `import { z } from 'zod';
 
-// Base schema matching DummyJSON user payload
-const baseUserSchema = z.object({
-  firstName: z.string().min(1, 'First name is required'),
-  lastName:  z.string().min(1, 'Last name is required'),
+// Base schema matching the User interface
+const userSchema = z.object({
+  id:        z.string().min(1, 'ID is required'),
+  name:      z.string().min(1, 'Name is required'),
   email:     z.string().email('Enter a valid email address'),
   role:      z.enum(['viewer', 'editor', 'admin']),
-  age:       z.number().int().min(18, 'Must be at least 18').max(120),
+  status:    z.enum(['active', 'inactive']),
+  createdAt: z.string().datetime({ message: 'Invalid ISO date string' }),
 });
 
-// Create: user provides all fields, no id/createdAt
-export const createUserSchema = baseUserSchema;
+// Create: omit server-generated fields
+export const createUserSchema = userSchema.omit({ id: true, createdAt: true });
 
-// Edit: all fields optional — partial of base
-export const editUserSchema = baseUserSchema.partial();
+// Edit: partial of create schema — all fields optional
+export const editUserSchema = createUserSchema.partial();
 
 export type CreateUserValues = z.infer<typeof createUserSchema>;
 export type EditUserValues   = z.infer<typeof editUserSchema>;`,
@@ -43,38 +44,50 @@ export type EditUserValues   = z.infer<typeof editUserSchema>;`,
     nextjs: {
       description:
         "In Next.js App Router, pair the form with a React Query mutation. The form is a Client Component ('use client'). On success, invalidate the users list so the table refreshes automatically. Reset the form to clear dirty state.",
-      filename: "features/examples/components/UserCreateForm.tsx",
+      filename: "features/examples/components/UserForm.tsx",
       code: `'use client';
 
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { type z } from 'zod';
+import { userSchema } from '@/shared/utils/validators';
 import { useCreateUser } from '@/features/examples/hooks/useCreateUser';
-import { createUserSchema, type CreateUserValues } from '@/lib/schemas/user';
 
-export function UserCreateForm() {
+const createUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+type CreateUserFormValues = z.infer<typeof createUserFormSchema>;
+
+export function UserForm() {
   const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
-    resolver: zodResolver(createUserSchema),
-    defaultValues: { firstName: '', lastName: '', email: '', role: 'viewer', age: 18 },
+    formState: { errors, isSubmitting } } = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserFormSchema),
+    defaultValues: { name: '', email: '', role: 'viewer', status: 'active' },
   });
 
   const createMutation = useCreateUser();
 
-  const onSubmit = async (data: CreateUserValues) => {
+  const onSubmit = async (data: CreateUserFormValues) => {
     await createMutation.mutateAsync(data);
     reset();
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('firstName')} placeholder="First name" />
-      {errors.firstName && <p>{errors.firstName.message}</p>}
-
-      <input {...register('lastName')} placeholder="Last name" />
-      {errors.lastName && <p>{errors.lastName.message}</p>}
+      <input {...register('name')} placeholder="Full name" />
+      {errors.name && <p>{errors.name.message}</p>}
 
       <input {...register('email')} placeholder="Email" />
       {errors.email && <p>{errors.email.message}</p>}
+
+      <select {...register('role')}>
+        <option value="viewer">Viewer</option>
+        <option value="editor">Editor</option>
+        <option value="admin">Admin</option>
+      </select>
+
+      <select {...register('status')}>
+        <option value="active">Active</option>
+        <option value="inactive">Inactive</option>
+      </select>
 
       <button type="submit" disabled={isSubmitting}>Create User</button>
     </form>
@@ -90,32 +103,36 @@ export function UserCreateForm() {
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { type z } from 'zod';
+import { userSchema } from '@/shared/utils/validators';
 import { useUser } from '@/features/examples/hooks/useUser';
 import { useUpdateUser } from '@/features/examples/hooks/useUpdateUser';
-import { editUserSchema, type EditUserValues } from '@/lib/schemas/user';
+
+const editUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+type EditUserFormValues = z.infer<typeof editUserFormSchema>;
 
 export function UserEditForm({ id }: { id: string }) {
   const { data: user } = useUser(id);
   const updateMutation = useUpdateUser(id);
 
   const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<EditUserValues>({
-    resolver: zodResolver(editUserSchema),
+    formState: { errors, isSubmitting } } = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserFormSchema),
   });
 
   // Pre-populate form when user data loads
   useEffect(() => {
     if (user) {
       reset({
-        firstName: user.name.split(' ')[0],
-        lastName:  user.name.split(' ')[1] ?? '',
-        email:     user.email,
-        role:      user.role,
+        name:   user.name,
+        email:  user.email,
+        role:   user.role,
+        status: user.status,
       });
     }
   }, [user, reset]);
 
-  const onSubmit = async (data: EditUserValues) => {
+  const onSubmit = async (data: EditUserFormValues) => {
     await updateMutation.mutateAsync(data);
   };
 
@@ -123,8 +140,22 @@ export function UserEditForm({ id }: { id: string }) {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('firstName')} placeholder="First name" />
-      {errors.firstName && <p>{errors.firstName.message}</p>}
+      <input {...register('name')} placeholder="Full name" />
+      {errors.name && <p>{errors.name.message}</p>}
+
+      <input {...register('email')} placeholder="Email" />
+      {errors.email && <p>{errors.email.message}</p>}
+
+      <select {...register('role')}>
+        <option value="viewer">Viewer</option>
+        <option value="editor">Editor</option>
+        <option value="admin">Admin</option>
+      </select>
+
+      <select {...register('status')}>
+        <option value="active">Active</option>
+        <option value="inactive">Inactive</option>
+      </select>
 
       <button type="submit" disabled={isSubmitting}>Save Changes</button>
     </form>

--- a/src/features/cookbook/data/recipes/form-validation.ts
+++ b/src/features/cookbook/data/recipes/form-validation.ts
@@ -15,72 +15,124 @@ export const formValidation: RecipeDetail = {
     { title: "Omit server-generated fields", description: "Use .omit({ id: true, createdAt: true }) for create forms. The schema reflects what the user provides." },
     { title: "handleSubmit owns errors", description: "Wrap mutation calls in handleSubmit. Validation errors surface automatically without try/catch in the component." },
     { title: "Reset after success", description: "Call reset() after a successful mutation to clear all field values and dirty state." },
+    { title: "Share schemas between create and edit", description: "Define a base schema, then derive create and edit variants with .omit() or .partial(). Single source of truth for all validation rules." },
   ],
   pattern: {
-    filename: "components/UserForm.tsx",
-    code: `import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
+    filename: "lib/schemas/user.ts",
+    code: `import { z } from 'zod';
 
-const createUserSchema = z.object({
-  name:   z.string().min(1, 'Name is required'),
-  email:  z.string().email('Enter a valid email address'),
-  role:   z.enum(['viewer', 'editor', 'admin']),
-  status: z.enum(['active', 'inactive']),
+// Base schema matching DummyJSON user payload
+const baseUserSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName:  z.string().min(1, 'Last name is required'),
+  email:     z.string().email('Enter a valid email address'),
+  role:      z.enum(['viewer', 'editor', 'admin']),
+  age:       z.number().int().min(18, 'Must be at least 18').max(120),
 });
 
-type CreateUserValues = z.infer<typeof createUserSchema>;
+// Create: user provides all fields, no id/createdAt
+export const createUserSchema = baseUserSchema;
 
-export function UserForm() {
-  const { register, handleSubmit, reset,
-    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
-    resolver: zodResolver(createUserSchema),
-    defaultValues: { name: '', email: '', role: 'viewer', status: 'active' },
-  });
+// Edit: all fields optional — partial of base
+export const editUserSchema = baseUserSchema.partial();
 
-  const onSubmit = async (data: CreateUserValues) => {
-    await createUser(data);
-    reset();
-  };
-
-  return <form onSubmit={handleSubmit(onSubmit)}>{/* fields */}</form>;
-}`,
+export type CreateUserValues = z.infer<typeof createUserSchema>;
+export type EditUserValues   = z.infer<typeof editUserSchema>;`,
   },
   implementation: {
     nextjs: {
       description:
-        "In Next.js App Router, pair the form with a Server Action for zero-client-bundle mutations. Validate with the same Zod schema on the server to prevent bypassing client validation.",
-      filename: "app/users/actions.ts",
-      code: `'use server';
+        "In Next.js App Router, pair the form with a React Query mutation. The form is a Client Component ('use client'). On success, invalidate the users list so the table refreshes automatically. Reset the form to clear dirty state.",
+      filename: "features/examples/components/UserCreateForm.tsx",
+      code: `'use client';
 
-import { createUserSchema } from '@/lib/schemas';
-import { db } from '@/lib/db';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCreateUser } from '@/features/examples/hooks/useCreateUser';
+import { createUserSchema, type CreateUserValues } from '@/lib/schemas/user';
 
-export async function createUserAction(values: unknown) {
-  const data = createUserSchema.parse(values); // validates server-side too
-  await db.user.create({ data });
+export function UserCreateForm() {
+  const { register, handleSubmit, reset,
+    formState: { errors, isSubmitting } } = useForm<CreateUserValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: { firstName: '', lastName: '', email: '', role: 'viewer', age: 18 },
+  });
+
+  const createMutation = useCreateUser();
+
+  const onSubmit = async (data: CreateUserValues) => {
+    await createMutation.mutateAsync(data);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('firstName')} placeholder="First name" />
+      {errors.firstName && <p>{errors.firstName.message}</p>}
+
+      <input {...register('lastName')} placeholder="Last name" />
+      {errors.lastName && <p>{errors.lastName.message}</p>}
+
+      <input {...register('email')} placeholder="Email" />
+      {errors.email && <p>{errors.email.message}</p>}
+
+      <button type="submit" disabled={isSubmitting}>Create User</button>
+    </form>
+  );
 }`,
     },
     vite: {
       description:
-        "In Vite, pair the form with a React Query mutation. On success, invalidate the users list so the table refreshes automatically.",
-      filename: "hooks/mutations/useCreateUser.ts",
-      code: `import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createUser } from '@/services/users';
-import { queryKeys } from '@/lib/query-keys';
+        "In Vite, the pattern is identical — React Query mutation with cache invalidation. The only difference is routing: use react-router instead of Next.js file-based routing.",
+      filename: "features/examples/components/UserEditForm.tsx",
+      code: `'use client';
 
-export function useCreateUser() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: createUser,
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.users.lists() });
-    },
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useUser } from '@/features/examples/hooks/useUser';
+import { useUpdateUser } from '@/features/examples/hooks/useUpdateUser';
+import { editUserSchema, type EditUserValues } from '@/lib/schemas/user';
+
+export function UserEditForm({ id }: { id: string }) {
+  const { data: user } = useUser(id);
+  const updateMutation = useUpdateUser(id);
+
+  const { register, handleSubmit, reset,
+    formState: { errors, isSubmitting } } = useForm<EditUserValues>({
+    resolver: zodResolver(editUserSchema),
   });
+
+  // Pre-populate form when user data loads
+  useEffect(() => {
+    if (user) {
+      reset({
+        firstName: user.name.split(' ')[0],
+        lastName:  user.name.split(' ')[1] ?? '',
+        email:     user.email,
+        role:      user.role,
+      });
+    }
+  }, [user, reset]);
+
+  const onSubmit = async (data: EditUserValues) => {
+    await updateMutation.mutateAsync(data);
+  };
+
+  if (!user) return <p>Loading...</p>;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('firstName')} placeholder="First name" />
+      {errors.firstName && <p>{errors.firstName.message}</p>}
+
+      <button type="submit" disabled={isSubmitting}>Save Changes</button>
+    </form>
+  );
 }`,
     },
   },
-  lastUpdated: "Feb 26, 2026",
+  lastUpdated: "May 11, 2026",
   contributor: { name: "Singgih Budi Purnadi", role: "Frontend & Mobile Developer" },
   demoKey: "forms",
 };

--- a/src/features/cookbook/data/recipes/form-validation.ts
+++ b/src/features/cookbook/data/recipes/form-validation.ts
@@ -98,9 +98,7 @@ export function UserForm() {
       description:
         "In Vite, the pattern is identical — React Query mutation with cache invalidation. The only difference is routing: use react-router instead of Next.js file-based routing.",
       filename: "features/examples/components/UserEditForm.tsx",
-      code: `'use client';
-
-import { useEffect } from 'react';
+      code: `import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { type z } from 'zod';

--- a/src/features/cookbook/data/recipes/server-state.ts
+++ b/src/features/cookbook/data/recipes/server-state.ts
@@ -20,12 +20,12 @@ export const serverState: RecipeDetail = {
     filename: "hooks/queries/useUsers.ts",
     code: `import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
-import { getUsers, type GetUsersParams } from '@/services/users';
+import { usersService, type GetUsersParams } from '@/lib/services/users';
 
 export function useUsers(params: GetUsersParams = {}) {
   return useQuery({
     queryKey: queryKeys.users.list(params),
-    queryFn: () => getUsers(params),
+    queryFn: () => usersService.getAll(params),
     staleTime: 1000 * 60 * 5,       // 5 minutes
     placeholderData: (prev) => prev, // no layout shift on page change
   });
@@ -39,13 +39,13 @@ export function useUsers(params: GetUsersParams = {}) {
       code: `import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { getQueryClient } from '@/lib/get-query-client';
 import { queryKeys } from '@/lib/query-keys';
-import { getUsers } from '@/services/users';
+import { usersService } from '@/lib/services/users';
 
 export default async function UsersPage() {
   const qc = getQueryClient();
   await qc.prefetchQuery({
     queryKey: queryKeys.users.list({}),
-    queryFn: () => getUsers({}),
+    queryFn: () => usersService.getAll({}),
   });
   return (
     <HydrationBoundary state={dehydrate(qc)}>
@@ -62,12 +62,12 @@ export default async function UsersPage() {
 import { LoadingState } from '@/components/common/LoadingState';
 
 export function UsersPage() {
-  const { data, isLoading, isError } = useUsers({ page: 1, limit: 10 });
+  const { data, isLoading, isError } = useUsers({ limit: 10, skip: 0 });
 
   if (isLoading) return <LoadingState rows={5} />;
   if (isError) return <p>Failed to load users.</p>;
 
-  return <UserList users={data.data} meta={data.meta} />;
+  return <UserList users={data.users} total={data.total} skip={data.skip} limit={data.limit} />;
 }`,
     },
   },

--- a/src/features/docs/components/docs-nav.ts
+++ b/src/features/docs/components/docs-nav.ts
@@ -61,7 +61,7 @@ export const DOCS_NAV: NavGroup[] = [
       { label: "Radio Group", href: "/docs/radio-group" },
       { label: "Resizable", href: "/docs/resizable" },
       { label: "Select", href: "/docs/select" },
-      { label: "ScrollArea", href: "/docs/scrollarea" },
+      { label: "ScrollArea", href: "/docs/scroll-area" },
       { label: "Sheet", href: "/docs/sheet" },
       { label: "Separator", href: "/docs/separator" },
       { label: "Skeleton", href: "/docs/skeleton" },

--- a/src/features/examples/components/ExamplesNavbar.tsx
+++ b/src/features/examples/components/ExamplesNavbar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { ThemeToggle } from "@/features/landing/components/ThemeToggle";
+import { useAppStore } from "@/shared/stores/useAppStore";
+
+const NAV_LINKS = [
+  { href: "/state", label: "State" },
+  { href: "/react-query", label: "React Query" },
+  { href: "/forms", label: "Forms" },
+  { href: "/table", label: "Table" },
+  { href: "/users", label: "Users" },
+] as const;
+
+export function ExamplesNavbar() {
+  const toggleSidebar = useAppStore((s) => s.toggleSidebar);
+
+  return (
+    <header className="sticky top-0 z-40 w-full border-b border-slate-200 bg-white/80 backdrop-blur-md dark:border-[#1f2937] dark:bg-[#0b0e14]/80">
+      <div className="mx-auto flex h-14 max-w-[1440px] items-center justify-between gap-3 px-4 sm:px-6">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            aria-label="Toggle sidebar"
+            className="flex items-center justify-center rounded-lg p-2 text-slate-500 transition-colors hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+          >
+            <span className="material-symbols-outlined text-xl">menu</span>
+          </button>
+          <Link
+            href="/state"
+            className="text-sm font-bold tracking-tight text-slate-900 dark:text-white"
+          >
+            Examples
+          </Link>
+          <nav className="hidden items-center gap-4 md:flex">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="text-xs font-medium text-slate-500 transition-colors hover:text-primary dark:text-slate-400"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/features/examples/components/ExamplesShell.tsx
+++ b/src/features/examples/components/ExamplesShell.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useAppStore } from "@/shared/stores/useAppStore";
+import { ExamplesNavbar } from "@/features/examples/components/ExamplesNavbar";
+import { ExamplesSidebar } from "@/features/examples/components/ExamplesSidebar";
+import { cn } from "@/shared/utils/cn";
+
+export function ExamplesShell({ children }: { children: React.ReactNode }) {
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen);
+
+  return (
+    <div className="min-h-screen">
+      <ExamplesNavbar />
+      <div className="flex">
+        <ExamplesSidebar />
+        <main
+          className={cn(
+            "flex-1 transition-all duration-200",
+            sidebarOpen ? "ml-56" : "ml-0",
+          )}
+        >
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/features/examples/components/ExamplesSidebar.tsx
+++ b/src/features/examples/components/ExamplesSidebar.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAppStore } from "@/shared/stores/useAppStore";
+import { cn } from "@/shared/utils/cn";
+
+const SIDEBAR_LINKS = [
+  { href: "/state", label: "State", icon: "toggle_on" },
+  { href: "/react-query", label: "React Query", icon: "cloud_sync" },
+  { href: "/forms", label: "Forms", icon: "edit_note" },
+  { href: "/table", label: "Table", icon: "table" },
+  { href: "/users", label: "Users", icon: "group" },
+] as const;
+
+export function ExamplesSidebar() {
+  const pathname = usePathname();
+  const sidebarOpen = useAppStore((s) => s.sidebarOpen);
+
+  return (
+    <aside
+      className={cn(
+        "fixed left-0 top-14 z-30 h-[calc(100vh-3.5rem)] w-56 border-r border-slate-200 bg-white transition-transform duration-200 dark:border-[#1f2937] dark:bg-[#0b0e14]",
+        sidebarOpen ? "translate-x-0" : "-translate-x-full",
+      )}
+    >
+      <nav className="flex flex-col gap-1 p-3">
+        {SIDEBAR_LINKS.map((link) => {
+          const isActive = pathname === link.href;
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-primary/10 text-primary"
+                  : "text-slate-500 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800",
+              )}
+            >
+              <span className="material-symbols-outlined text-lg">
+                {link.icon}
+              </span>
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/features/examples/components/UserEditForm.tsx
+++ b/src/features/examples/components/UserEditForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type z } from "zod";
+import { userSchema } from "@/shared/utils/validators";
+import { useUser } from "@/features/examples/hooks/useUser";
+import { useUpdateUser } from "@/features/examples/hooks/useUpdateUser";
+
+const editUserFormSchema = userSchema.omit({ id: true, createdAt: true });
+
+type EditUserFormValues = z.infer<typeof editUserFormSchema>;
+
+export function UserEditForm({ id }: { id: string }) {
+  const { data: user, isLoading } = useUser(id);
+  const updateUser = useUpdateUser(id);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserFormSchema),
+  });
+
+  useEffect(() => {
+    if (user) {
+      reset({
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        status: user.status,
+      });
+    }
+  }, [user, reset]);
+
+  const onSubmit = async (data: EditUserFormValues) => {
+    try {
+      await updateUser.mutateAsync(data);
+    } catch {
+      // Error is available via updateUser.error
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-sm text-gray-500">Loading user data...</p>;
+  }
+
+  if (!user) {
+    return <p className="text-sm text-red-600">User not found.</p>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div>
+        <label
+          htmlFor="edit-name"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Name
+        </label>
+        <input
+          id="edit-name"
+          type="text"
+          {...register("name")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+          placeholder="John Doe"
+        />
+        {errors.name && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.name.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-email"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Email
+        </label>
+        <input
+          id="edit-email"
+          type="email"
+          {...register("email")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+          placeholder="john@example.com"
+        />
+        {errors.email && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.email.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-role"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Role
+        </label>
+        <select
+          id="edit-role"
+          {...register("role")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <option value="viewer">Viewer</option>
+          <option value="editor">Editor</option>
+          <option value="admin">Admin</option>
+        </select>
+        {errors.role && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.role.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-status"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Status
+        </label>
+        <select
+          id="edit-status"
+          {...register("status")}
+          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+        {errors.status && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+            {errors.status.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? "Saving..." : "Save Changes"}
+        </button>
+        {updateUser.isSuccess && (
+          <p className="text-sm text-green-600 dark:text-green-400">
+            User updated successfully!
+          </p>
+        )}
+        {updateUser.isError && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {updateUser.error.message}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/features/examples/components/UserFilters.tsx
+++ b/src/features/examples/components/UserFilters.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useShallow } from "zustand/shallow";
+import { useFilterStore, useHasActiveFilters } from "@/shared/stores/useFilterStore";
+import { Input } from "@/ui/Input";
+import { NativeSelect } from "@/ui/NativeSelect";
+import type { UserRole } from "@/shared/types/common";
+
+export function UserFilters() {
+  const { search, role, setSearch, setRole, reset } = useFilterStore(
+    useShallow((s) => ({
+      search: s.search,
+      role: s.role,
+      setSearch: s.setSearch,
+      setRole: s.setRole,
+      reset: s.reset,
+    })),
+  );
+  const hasFilters = useHasActiveFilters();
+
+  return (
+    <div className="space-y-3">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search users..."
+        label="Search"
+      />
+      <NativeSelect
+        value={role ?? ""}
+        onChange={(e) =>
+          setRole((e.target.value || null) as UserRole | null)
+        }
+        label="Role"
+      >
+        <option value="">All roles</option>
+        <option value="admin">Admin</option>
+        <option value="editor">Editor</option>
+        <option value="viewer">Viewer</option>
+      </NativeSelect>
+      {hasFilters && (
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+        >
+          Reset Filters
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/examples/components/UserList.tsx
+++ b/src/features/examples/components/UserList.tsx
@@ -2,19 +2,28 @@
 
 import { useState } from "react";
 import { useUsers } from "@/features/examples/hooks/useUsers";
+import { useSearchUsers } from "@/features/examples/hooks/useSearchUsers";
 import { LoadingState } from "@/shared/components/LoadingState";
 import { EmptyState } from "@/shared/components/EmptyState";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
+import { cn } from "@/shared/utils/cn";
+
+const LIMIT = 5;
 
 function UserListInner() {
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
+  const [skip, setSkip] = useState(0);
 
-  const { data, isLoading, isError, error } = useUsers({
-    search,
-    page,
-    limit: 5,
-  });
+  const isSearching = search.length > 0;
+
+  const listQuery = useUsers({ skip, limit: LIMIT });
+  const searchQuery = useSearchUsers(search);
+
+  const { data, isLoading, isError, error } = isSearching ? searchQuery : listQuery;
+
+  const users = data?.users ?? [];
+  const totalPages = data ? Math.ceil(data.total / LIMIT) : 0;
+  const currentPage = data ? Math.floor(data.skip / LIMIT) + 1 : 1;
 
   if (isLoading) {
     return <LoadingState rows={5} message="Loading users..." />;
@@ -24,14 +33,11 @@ function UserListInner() {
     return (
       <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900 dark:bg-red-950">
         <p className="text-sm text-red-600 dark:text-red-400">
-          Failed to load users: {error.message}
+          Failed to load users: {error instanceof Error ? error.message : "Unknown error"}
         </p>
       </div>
     );
   }
-
-  const users = data?.data ?? [];
-  const meta = data?.meta;
 
   return (
     <div className="space-y-4">
@@ -41,7 +47,7 @@ function UserListInner() {
         value={search}
         onChange={(e) => {
           setSearch(e.target.value);
-          setPage(1);
+          setSkip(0);
         }}
         placeholder="Search by name or email..."
         className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-blue-500 focus:outline-hidden focus:ring-1 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900"
@@ -71,11 +77,12 @@ function UserListInner() {
                   {user.role}
                 </span>
                 <span
-                  className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                  className={cn(
+                    "rounded-full px-2.5 py-0.5 text-xs font-medium",
                     user.status === "active"
                       ? "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
-                      : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
-                  }`}
+                      : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+                  )}
                 >
                   {user.status}
                 </span>
@@ -85,23 +92,23 @@ function UserListInner() {
         </ul>
       )}
 
-      {/* Pagination */}
-      {meta && meta.totalPages > 1 && (
+      {/* Pagination — hidden when searching */}
+      {!isSearching && totalPages > 1 && (
         <div className="flex items-center justify-between">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Page {meta.page} of {meta.totalPages} ({meta.total} total)
+            Page {currentPage} of {totalPages} ({data?.total ?? 0} total)
           </p>
           <div className="flex gap-2">
             <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page <= 1}
+              onClick={() => setSkip((s) => Math.max(0, s - LIMIT))}
+              disabled={skip <= 0}
               className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-800"
             >
               Previous
             </button>
             <button
-              onClick={() => setPage((p) => Math.min(meta.totalPages, p + 1))}
-              disabled={page >= meta.totalPages}
+              onClick={() => setSkip((s) => s + LIMIT)}
+              disabled={currentPage >= totalPages}
               className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:hover:bg-gray-800"
             >
               Next

--- a/src/features/examples/components/UserTable.tsx
+++ b/src/features/examples/components/UserTable.tsx
@@ -12,6 +12,7 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import type { User } from "@/shared/types/common";
+import { cn } from "@/shared/utils/cn";
 import { mockUsers } from "@/lib/mock-data";
 
 export function UserTable() {
@@ -47,11 +48,12 @@ export function UserTable() {
           const status = info.getValue<string>();
           return (
             <span
-              className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+              className={cn(
+                "rounded-full px-2.5 py-0.5 text-xs font-medium",
                 status === "active"
                   ? "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300"
-                  : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300"
-              }`}
+                  : "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+              )}
             >
               {status}
             </span>

--- a/src/features/examples/hooks/useCreateUser.ts
+++ b/src/features/examples/hooks/useCreateUser.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { createUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 import type { CreateUserInput } from "@/shared/types/user";
 
 export function useCreateUser() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateUserInput) => createUser(data),
+    mutationFn: (data: CreateUserInput) => usersService.create(data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
     },

--- a/src/features/examples/hooks/useSearchUsers.ts
+++ b/src/features/examples/hooks/useSearchUsers.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebounce } from "@/shared/hooks";
+import { queryKeys } from "@/lib/query-keys";
+import { usersService } from "@/lib/services/users";
+
+export function useSearchUsers(query: string) {
+  const debouncedQuery = useDebounce(query, 300);
+
+  return useQuery({
+    queryKey: queryKeys.users.search(debouncedQuery),
+    queryFn: () => usersService.search({ q: debouncedQuery }),
+    enabled: debouncedQuery.length > 0,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/features/examples/hooks/useUpdateUser.ts
+++ b/src/features/examples/hooks/useUpdateUser.ts
@@ -1,13 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { updateUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 import type { UpdateUserInput } from "@/shared/types/user";
 
 export function useUpdateUser(id: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: UpdateUserInput) => updateUser(id, data),
+    mutationFn: (data: UpdateUserInput) => usersService.update(id, data),
     onSuccess: (updatedUser) => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.users.all });
       queryClient.setQueryData(queryKeys.users.detail(id), updatedUser);

--- a/src/features/examples/hooks/useUser.ts
+++ b/src/features/examples/hooks/useUser.ts
@@ -1,11 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { getUser } from "@/lib/mock-data";
+import { usersService } from "@/lib/services/users";
 
 export function useUser(id: string) {
   return useQuery({
     queryKey: queryKeys.users.detail(id),
-    queryFn: () => getUser(id),
+    queryFn: () => usersService.getById(id),
     enabled: !!id,
+    staleTime: 1000 * 60 * 10,
   });
 }

--- a/src/features/examples/hooks/useUsers.ts
+++ b/src/features/examples/hooks/useUsers.ts
@@ -1,10 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
-import { getUsers, type GetUsersParams } from "@/lib/mock-data";
+import { usersService, type GetUsersParams } from "@/lib/services/users";
 
 export function useUsers(params: GetUsersParams = {}) {
   return useQuery({
     queryKey: queryKeys.users.list(params as Record<string, unknown>),
-    queryFn: () => getUsers(params),
+    queryFn: () => usersService.getAll(params),
+    staleTime: 1000 * 60 * 5,
+    placeholderData: (prev) => prev,
   });
 }

--- a/src/features/landing/components/AICorpusTeaserSection.tsx
+++ b/src/features/landing/components/AICorpusTeaserSection.tsx
@@ -1,0 +1,164 @@
+import Link from "next/link";
+
+import { Button } from "@/ui/Button";
+import { cn } from "@/shared/utils/cn";
+
+const SKILL_CHIPS = [
+  { name: "/reactprinciples-review", category: "review" },
+  { name: "/reactprinciples-component", category: "scaffold" },
+  { name: "/reactprinciples-hook", category: "scaffold" },
+  { name: "/reactprinciples-store", category: "scaffold" },
+  { name: "/reactprinciples-query", category: "scaffold" },
+  { name: "/reactprinciples-form", category: "scaffold" },
+] as const;
+
+const CATEGORY_CLASSES: Record<string, string> = {
+  review: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  scaffold:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+};
+
+const FEATURES = [
+  {
+    icon: "terminal",
+    label: "10 invocable skills — review code, scaffold components, hooks, forms",
+  },
+  {
+    icon: "description",
+    label: "llms.txt — drop the entire cookbook into any AI context window",
+  },
+  {
+    icon: "all_inclusive",
+    label: "Works across Claude Code, Cursor, Copilot, and any Agent Skills tool",
+  },
+  {
+    icon: "package",
+    label: "One install command — npx skills add sindev08/react-principles-skills",
+  },
+];
+
+export function AICorpusTeaserSection() {
+  return (
+    <section
+      id="ai-corpus"
+      className="relative overflow-hidden bg-white px-6 py-24 dark:bg-slate-900"
+    >
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+
+      <div className="mx-auto max-w-7xl">
+        <div className="grid items-center gap-16 md:grid-cols-2">
+          {/* Left column — visual mock */}
+          <div className="relative order-2 md:order-1">
+            <div className="absolute inset-0 -z-10 scale-75 rounded-full bg-primary/5 blur-3xl" />
+            <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl dark:border-white/5 dark:bg-slate-950">
+              {/* Terminal header */}
+              <div className="flex items-center gap-2 border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
+                <div className="flex gap-1.5">
+                  <span className="h-3 w-3 rounded-full bg-red-400" />
+                  <span className="h-3 w-3 rounded-full bg-yellow-400" />
+                  <span className="h-3 w-3 rounded-full bg-green-400" />
+                </div>
+                <span className="ml-2 font-mono text-xs text-slate-500">
+                  install
+                </span>
+              </div>
+
+              {/* Terminal body */}
+              <div className="bg-slate-950 px-5 py-4 font-mono text-sm text-slate-100">
+                <div className="mb-2">
+                  <span className="text-primary">$</span>{" "}
+                  <span className="text-slate-100">
+                    npx skills add sindev08/react-principles-skills
+                  </span>
+                </div>
+                <div className="text-slate-500">
+                  ✓ Installed 10 skills to ~/.claude/skills/
+                </div>
+              </div>
+
+              {/* Skills list */}
+              <div className="border-t border-slate-200 p-5 dark:border-white/5">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Available skills
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {SKILL_CHIPS.map((skill) => (
+                    <span
+                      key={skill.name}
+                      className={cn(
+                        "rounded-full px-3 py-1 font-mono text-xs font-medium",
+                        CATEGORY_CLASSES[skill.category],
+                      )}
+                    >
+                      {skill.name}
+                    </span>
+                  ))}
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                    +4 more
+                  </span>
+                </div>
+              </div>
+
+              {/* llms.txt callout */}
+              <div className="border-t border-slate-200 bg-slate-50 px-5 py-4 dark:border-white/5 dark:bg-slate-900/50">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="material-symbols-outlined text-base text-primary">
+                      description
+                    </span>
+                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                      llms.txt
+                    </span>
+                  </div>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    ~5K / ~17K tokens
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Right column — copy */}
+          <div className="order-1 md:order-2">
+            <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-primary/15 bg-primary/5 px-4 py-2 text-sm font-semibold text-primary dark:border-primary/20 dark:bg-primary/10">
+              <span className="material-symbols-outlined text-base">
+                auto_awesome
+              </span>
+              AI Corpus
+            </div>
+            <h2 className="mb-6 text-3xl font-black tracking-tight text-slate-900 dark:text-white md:text-4xl">
+              Your AI tools,
+              <br />
+              React Principles–aware.
+            </h2>
+            <p className="mb-8 text-lg leading-relaxed text-slate-600 dark:text-slate-400">
+              The cookbook compiled for AI assistants. Drop our principles into
+              any AI context window, or install invocable skills that scaffold
+              and review code following documented patterns.
+            </p>
+            <ul className="mb-10 space-y-4">
+              {FEATURES.map((feature) => (
+                <li
+                  key={feature.label}
+                  className="flex items-start gap-3 text-slate-700 dark:text-slate-300"
+                >
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <span className="material-symbols-outlined text-[18px]">
+                      {feature.icon}
+                    </span>
+                  </span>
+                  <span className="pt-1">{feature.label}</span>
+                </li>
+              ))}
+            </ul>
+            <Link href="/ai">
+              <Button variant="primary" size="md">
+                Explore the AI corpus
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/landing/components/CookbookTeaserSection.tsx
+++ b/src/features/landing/components/CookbookTeaserSection.tsx
@@ -31,7 +31,7 @@ const FEATURED_RECIPES = [
     icon: "cloud_sync",
     gradient: "linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%)",
     category: "Patterns",
-    published: false,
+    published: true,
   },
   {
     slug: "form-validation",
@@ -41,7 +41,7 @@ const FEATURED_RECIPES = [
     icon: "fact_check",
     gradient: "linear-gradient(135deg, #f97316 0%, #c2410c 100%)",
     category: "Patterns",
-    published: false,
+    published: true,
   },
 ] as const;
 

--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -100,7 +100,7 @@ export function Footer() {
         {/* Bottom bar */}
         <div className="flex flex-col items-center justify-between gap-4 pt-8 border-t border-slate-100 dark:border-white/5 md:flex-row">
           <p className="text-sm text-slate-400">
-            © 2026 react-principles · Early access · npm: react-principles@{CLI_VERSION}
+            © 2026 react-principles · v1.0 · npm: react-principles@{CLI_VERSION}
           </p>
         </div>
       </div>

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -179,19 +179,20 @@ export function HeroSection() {
           The Living Cookbook for Modern React
         </h1>
 
-        <p className="mx-auto mb-6 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
+        <p className="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
           A high-end developer reference implementation for scalable React
           architectures. Isolated patterns, real-world examples, and
           production-ready code.
         </p>
 
-        <p className="mx-auto mb-10 inline-flex max-w-2xl flex-wrap items-center justify-center gap-2 text-sm text-slate-500 dark:text-slate-400">
-          <span className="material-symbols-outlined text-base text-primary">
-            auto_awesome
+        <div className="mb-10 flex justify-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-300">
+            <span className="material-symbols-outlined text-base text-primary">
+              auto_awesome
+            </span>
+            Designed for humans and AI assistants
           </span>
-          Designed for humans and AI assistants — drop into Claude, Cursor, or
-          Copilot for principle-aware code.
-        </p>
+        </div>
 
         <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -179,10 +179,18 @@ export function HeroSection() {
           The Living Cookbook for Modern React
         </h1>
 
-        <p className="mx-auto mb-10 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
+        <p className="mx-auto mb-6 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
           A high-end developer reference implementation for scalable React
           architectures. Isolated patterns, real-world examples, and
           production-ready code.
+        </p>
+
+        <p className="mx-auto mb-10 inline-flex max-w-2xl flex-wrap items-center justify-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <span className="material-symbols-outlined text-base text-primary">
+            auto_awesome
+          </span>
+          Designed for humans and AI assistants — drop into Claude, Cursor, or
+          Copilot for principle-aware code.
         </p>
 
         <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -170,7 +170,7 @@ export function HeroSection() {
           <span className="material-symbols-outlined text-sm">
             auto_awesome
           </span>
-          Early access
+          v1.0 is now live
         </Badge>
 
         <h1 className="mb-8 text-5xl font-black leading-[1.1] tracking-tight text-slate-900 md:text-7xl dark:text-white">

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -10,6 +10,7 @@ const NAV_LINKS = [
   { href: "/docs/introduction", label: "Docs" },
   { href: "/nextjs/cookbook", label: "Cookbook" },
   { href: "/create", label: "Create" },
+  { href: "/ai", label: "AI" },
 ] as const;
 
 function GithubIcon() {

--- a/src/features/landing/components/index.ts
+++ b/src/features/landing/components/index.ts
@@ -4,6 +4,7 @@ export { HeroSection } from "./HeroSection";
 export { WhySection } from "./WhySection";
 export { ComponentShowcaseSection } from "./ComponentShowcaseSection";
 export { ConfiguratorTeaserSection } from "./ConfiguratorTeaserSection";
+export { AICorpusTeaserSection } from "./AICorpusTeaserSection";
 export { CookbookTeaserSection } from "./CookbookTeaserSection";
 export { TechStackSection } from "./TechStackSection";
 export { ProjectStructureSection } from "./ProjectStructureSection";

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -12,6 +12,7 @@ export const ENDPOINTS = {
   },
   users: {
     list: "/users",
+    search: "/users/search",
     detail: (id: string) => `/users/${id}`,
     create: "/users",
     update: (id: string) => `/users/${id}`,

--- a/src/lib/get-query-client.ts
+++ b/src/lib/get-query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
+
+export const getQueryClient = cache(
+  () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 60 * 1000,
+        },
+      },
+    }),
+);

--- a/src/lib/llms-txt.ts
+++ b/src/lib/llms-txt.ts
@@ -4,7 +4,9 @@ import type { RecipeDetail, RuleItem } from "@/features/cookbook/data/types";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
 
-const HEADER = `# React Principles — Cookbook
+// ─── Headers / Footers ────────────────────────────────────────────────────────
+
+const COMPACT_HEADER = `# React Principles — Cookbook
 
 > Production-grade React patterns and principles. A curated curriculum for modern React development covering folder structure, TypeScript, components, state, forms, services, and more.
 
@@ -18,31 +20,64 @@ Stack: Next.js 16, React 19, TypeScript 5, Tailwind CSS v4, TanStack Query v5, Z
 ---
 `;
 
+const FULL_HEADER = `# React Principles — Cookbook (Full)
+
+> Production-grade React patterns and principles. A curated curriculum for modern React development covering folder structure, TypeScript, components, state, forms, services, and more.
+
+This is the **full** version of the cookbook — every published recipe with principle, rules, pattern code, and framework-specific implementations (Next.js and Vite). For a lighter version without code, see ${SITE_URL}/llms.txt.
+
+Stack: Next.js 16, React 19, TypeScript 5, Tailwind CSS v4, TanStack Query v5, Zustand v5, React Hook Form + Zod.
+
+Use this file as:
+- RAG context for a custom AI assistant
+- Long-form context to drop into Claude / Cursor / Copilot for principle-aware help
+- Reference for fine-tuning or evaluation
+
+---
+`;
+
 const FOOTER = `---
 
 ## More
 
-- Full cookbook (with code examples): ${SITE_URL}/llms-full.txt
+- Compact cookbook (no code): ${SITE_URL}/llms.txt
+- Full cookbook (with code): ${SITE_URL}/llms-full.txt
 - Interactive web version: ${SITE_URL}/cookbook
 - UI Kit components: ${SITE_URL}/docs
 - AI skills (Claude/Cursor/Copilot): https://github.com/sindev08/react-principles-skills
 `;
 
+// ─── Public API ───────────────────────────────────────────────────────────────
+
 export function generateCompactLlmsTxt(): string {
+  return buildLlmsTxt({ mode: "compact" });
+}
+
+export function generateFullLlmsTxt(): string {
+  return buildLlmsTxt({ mode: "full" });
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+interface BuildOptions {
+  mode: "compact" | "full";
+}
+
+function buildLlmsTxt(opts: BuildOptions): string {
   const publishedRecipes = RECIPES.filter((r) => r.status === "published").sort(
     (a, b) => a.order - b.order,
   );
 
   const grouped = groupByCategory(publishedRecipes);
 
-  const sections: string[] = [HEADER];
+  const sections: string[] = [opts.mode === "full" ? FULL_HEADER : COMPACT_HEADER];
 
   for (const [category, recipes] of grouped) {
     sections.push(`\n## ${category}\n`);
     for (const recipe of recipes) {
       const detail = RECIPE_DETAILS[recipe.slug];
       if (!detail) continue;
-      sections.push(formatRecipe(detail));
+      sections.push(formatRecipe(detail, opts.mode));
     }
   }
 
@@ -62,7 +97,7 @@ function groupByCategory(recipes: Recipe[]): Map<string, Recipe[]> {
   return map;
 }
 
-function formatRecipe(recipe: RecipeDetail): string {
+function formatRecipe(recipe: RecipeDetail, mode: BuildOptions["mode"]): string {
   const lines: string[] = [];
 
   lines.push(`### ${recipe.title}\n`);
@@ -84,10 +119,55 @@ function formatRecipe(recipe: RecipeDetail): string {
     lines.push("");
   }
 
+  if (mode === "full") {
+    appendCodeSections(lines, recipe);
+  }
+
   lines.push(`Read more: ${SITE_URL}/cookbook/${recipe.slug}\n`);
 
   return lines.join("\n");
 }
 
-// Exported for testing or future full-version use
+function appendCodeSections(lines: string[], recipe: RecipeDetail): void {
+  if (recipe.pattern) {
+    lines.push(`**Pattern** — \`${recipe.pattern.filename}\`\n`);
+    lines.push(fenceCode(recipe.pattern.code, languageFor(recipe.pattern.filename)));
+    lines.push("");
+  }
+
+  if (recipe.implementation?.nextjs) {
+    const impl = recipe.implementation.nextjs;
+    lines.push(`**Implementation — Next.js**\n`);
+    lines.push(`${impl.description}\n`);
+    lines.push(`File: \`${impl.filename}\`\n`);
+    lines.push(fenceCode(impl.code, languageFor(impl.filename)));
+    lines.push("");
+  }
+
+  if (recipe.implementation?.vite) {
+    const impl = recipe.implementation.vite;
+    lines.push(`**Implementation — Vite**\n`);
+    lines.push(`${impl.description}\n`);
+    lines.push(`File: \`${impl.filename}\`\n`);
+    lines.push(fenceCode(impl.code, languageFor(impl.filename)));
+    lines.push("");
+  }
+}
+
+function fenceCode(code: string, language: string): string {
+  return `\`\`\`${language}\n${code}\n\`\`\``;
+}
+
+function languageFor(filename: string): string {
+  if (filename.endsWith(".tsx")) return "tsx";
+  if (filename.endsWith(".ts")) return "ts";
+  if (filename.endsWith(".js")) return "js";
+  if (filename.endsWith(".jsx")) return "jsx";
+  if (filename.endsWith(".css")) return "css";
+  if (filename.endsWith(".json")) return "json";
+  if (filename.endsWith(".md")) return "markdown";
+  return "";
+}
+
+// Exported for testing
 export type { RecipeDetail, RuleItem };

--- a/src/lib/llms-txt.ts
+++ b/src/lib/llms-txt.ts
@@ -1,0 +1,93 @@
+import { RECIPES, type Recipe } from "@/features/cookbook/data/cookbook-data";
+import { RECIPE_DETAILS } from "@/features/cookbook/data";
+import type { RecipeDetail, RuleItem } from "@/features/cookbook/data/types";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+const HEADER = `# React Principles — Cookbook
+
+> Production-grade React patterns and principles. A curated curriculum for modern React development covering folder structure, TypeScript, components, state, forms, services, and more.
+
+This is the **compact** version of the cookbook — principle statements and rules only, no code examples. For full content including code examples and framework-specific implementations, see:
+
+- Full version: ${SITE_URL}/llms-full.txt
+- Interactive cookbook: ${SITE_URL}/cookbook
+
+Stack: Next.js 16, React 19, TypeScript 5, Tailwind CSS v4, TanStack Query v5, Zustand v5, React Hook Form + Zod.
+
+---
+`;
+
+const FOOTER = `---
+
+## More
+
+- Full cookbook (with code examples): ${SITE_URL}/llms-full.txt
+- Interactive web version: ${SITE_URL}/cookbook
+- UI Kit components: ${SITE_URL}/docs
+- AI skills (Claude/Cursor/Copilot): https://github.com/sindev08/react-principles-skills
+`;
+
+export function generateCompactLlmsTxt(): string {
+  const publishedRecipes = RECIPES.filter((r) => r.status === "published").sort(
+    (a, b) => a.order - b.order,
+  );
+
+  const grouped = groupByCategory(publishedRecipes);
+
+  const sections: string[] = [HEADER];
+
+  for (const [category, recipes] of grouped) {
+    sections.push(`\n## ${category}\n`);
+    for (const recipe of recipes) {
+      const detail = RECIPE_DETAILS[recipe.slug];
+      if (!detail) continue;
+      sections.push(formatRecipe(detail));
+    }
+  }
+
+  sections.push(FOOTER);
+
+  return sections.join("\n");
+}
+
+function groupByCategory(recipes: Recipe[]): Map<string, Recipe[]> {
+  const map = new Map<string, Recipe[]>();
+  for (const r of recipes) {
+    const cat = r.category ?? "Other";
+    const existing = map.get(cat) ?? [];
+    existing.push(r);
+    map.set(cat, existing);
+  }
+  return map;
+}
+
+function formatRecipe(recipe: RecipeDetail): string {
+  const lines: string[] = [];
+
+  lines.push(`### ${recipe.title}\n`);
+  lines.push(`> ${recipe.description}\n`);
+
+  if (recipe.principle) {
+    lines.push(`**Principle:** ${recipe.principle.text}\n`);
+    if (recipe.principle.tip) {
+      lines.push(`**Tip:** ${recipe.principle.tip}\n`);
+    }
+  }
+
+  if (recipe.rules && recipe.rules.length > 0) {
+    const label = recipe.rulesLabel ?? "Rules";
+    lines.push(`**${label}:**`);
+    for (const rule of recipe.rules) {
+      lines.push(`- **${rule.title}** — ${rule.description}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`Read more: ${SITE_URL}/cookbook/${recipe.slug}\n`);
+
+  return lines.join("\n");
+}
+
+// Exported for testing or future full-version use
+export type { RecipeDetail, RuleItem };

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -6,5 +6,7 @@ export const queryKeys = {
       [...queryKeys.users.lists(), params] as const,
     details: () => [...queryKeys.users.all, "detail"] as const,
     detail: (id: string) => [...queryKeys.users.details(), id] as const,
+    searches: () => [...queryKeys.users.all, "search"] as const,
+    search: (query: string) => [...queryKeys.users.searches(), query] as const,
   },
 };

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -1,4 +1,5 @@
 import type { User } from "@/shared/types/common";
+import type { CreateUserInput, UpdateUserInput } from "@/shared/types/user";
 import { createApiClient } from "@/lib/api-client";
 import { ENDPOINTS } from "@/lib/endpoints";
 
@@ -34,6 +35,14 @@ export interface SearchUsersParams {
   q: string;
   limit?: number;
   skip?: number;
+}
+
+function splitName(fullName: string): { firstName: string; lastName: string } {
+  const parts = fullName.split(" ");
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
 }
 
 function mapUser(raw: DummyJsonUser): User {
@@ -78,5 +87,45 @@ export const usersService = {
         params: { q, ...rest } as Record<string, string | number | boolean | undefined>,
       })
       .then(mapResponse);
+  },
+
+  create(data: CreateUserInput): Promise<User> {
+    const { firstName, lastName } = splitName(data.name);
+    return dummyJsonClient
+      .post<DummyJsonUser>(ENDPOINTS.users.create, {
+        firstName,
+        lastName,
+        email: data.email,
+      })
+      .then(() => ({
+        id: String(Date.now()),
+        name: data.name,
+        email: data.email,
+        role: data.role,
+        status: data.status,
+        createdAt: new Date().toISOString(),
+      }));
+  },
+
+  update(id: string, data: UpdateUserInput): Promise<User> {
+    const body: Record<string, unknown> = {};
+    if (data.name !== undefined) {
+      const { firstName, lastName } = splitName(data.name);
+      body.firstName = firstName;
+      body.lastName = lastName;
+    }
+    if (data.email !== undefined) {
+      body.email = data.email;
+    }
+    return dummyJsonClient
+      .put<DummyJsonUser>(ENDPOINTS.users.update(id), body)
+      .then((raw) => ({
+        id: String(raw.id),
+        name: data.name ?? `${raw.firstName} ${raw.lastName}`,
+        email: data.email ?? raw.email,
+        role: data.role ?? "viewer",
+        status: data.status ?? "active",
+        createdAt: new Date().toISOString(),
+      }));
   },
 };

--- a/src/lib/services/users.ts
+++ b/src/lib/services/users.ts
@@ -1,0 +1,82 @@
+import type { User } from "@/shared/types/common";
+import { createApiClient } from "@/lib/api-client";
+import { ENDPOINTS } from "@/lib/endpoints";
+
+const dummyJsonClient = createApiClient({ baseUrl: "https://dummyjson.com" });
+
+interface DummyJsonUser {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+interface DummyUsersResponse {
+  users: DummyJsonUser[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface UsersResponse {
+  users: User[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface GetUsersParams {
+  limit?: number;
+  skip?: number;
+}
+
+export interface SearchUsersParams {
+  q: string;
+  limit?: number;
+  skip?: number;
+}
+
+function mapUser(raw: DummyJsonUser): User {
+  return {
+    id: String(raw.id),
+    name: `${raw.firstName} ${raw.lastName}`,
+    email: raw.email,
+    role: "viewer",
+    status: "active",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function mapResponse(raw: DummyUsersResponse): UsersResponse {
+  return {
+    users: raw.users.map(mapUser),
+    total: raw.total,
+    skip: raw.skip,
+    limit: raw.limit,
+  };
+}
+
+export const usersService = {
+  getAll(params: GetUsersParams = {}): Promise<UsersResponse> {
+    return dummyJsonClient
+      .get<DummyUsersResponse>(ENDPOINTS.users.list, {
+        params: params as Record<string, string | number | boolean | undefined>,
+      })
+      .then(mapResponse);
+  },
+
+  getById(id: string): Promise<User> {
+    return dummyJsonClient
+      .get<DummyJsonUser>(ENDPOINTS.users.detail(id))
+      .then(mapUser);
+  },
+
+  search(params: SearchUsersParams): Promise<UsersResponse> {
+    const { q, ...rest } = params;
+    return dummyJsonClient
+      .get<DummyUsersResponse>(ENDPOINTS.users.search, {
+        params: { q, ...rest } as Record<string, string | number | boolean | undefined>,
+      })
+      .then(mapResponse);
+  },
+};

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -1,0 +1,144 @@
+import { marked } from "marked";
+
+const REPO_OWNER = "sindev08";
+const REPO_NAME = "react-principles-skills";
+const GITHUB_API_BASE = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}`;
+const REVALIDATE_SECONDS = 3600;
+
+export type SkillCategory = "umbrella" | "review" | "scaffolding" | "internal";
+
+export interface Skill {
+  name: string;
+  description: string;
+  category: SkillCategory;
+  allowedTools: string[];
+  rawMarkdown: string;
+  bodyHtml: string;
+}
+
+export interface SkillsBundle {
+  skills: Skill[];
+  version: string | null;
+  repoUrl: string;
+  installCommand: string;
+}
+
+const CATEGORY_MAP: Record<string, SkillCategory> = {
+  reactprinciples: "umbrella",
+  "reactprinciples-review": "review",
+  "reactprinciples-audit-recipe": "internal",
+  "reactprinciples-component": "scaffolding",
+  "reactprinciples-folder-structure": "scaffolding",
+  "reactprinciples-form": "scaffolding",
+  "reactprinciples-hook": "scaffolding",
+  "reactprinciples-query": "scaffolding",
+  "reactprinciples-recipe": "internal",
+  "reactprinciples-store": "scaffolding",
+};
+
+interface FrontmatterResult {
+  data: { name?: string; description?: string; "allowed-tools"?: string };
+  body: string;
+}
+
+function parseFrontmatter(raw: string): FrontmatterResult | null {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match?.[1] || match[2] === undefined) return null;
+  const [, fm, body] = match;
+  const data: Record<string, string> = {};
+  for (const line of fm.split(/\r?\n/)) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    data[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+  }
+  return { data, body };
+}
+
+interface GitHubContentItem {
+  name: string;
+  type: "file" | "dir";
+}
+
+async function ghFetch<T>(path: string): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(`${GITHUB_API_BASE}${path}`, {
+    headers,
+    next: { revalidate: REVALIDATE_SECONDS },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${path} failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+async function fetchRaw(url: string): Promise<string> {
+  const res = await fetch(url, { next: { revalidate: REVALIDATE_SECONDS } });
+  if (!res.ok) {
+    throw new Error(`Raw fetch ${url} failed: ${res.status}`);
+  }
+  return res.text();
+}
+
+async function fetchSkillFolders(): Promise<string[]> {
+  const items = await ghFetch<GitHubContentItem[]>("/contents/skills");
+  return items.filter((i) => i.type === "dir").map((i) => i.name);
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const release = await ghFetch<{ tag_name: string }>("/releases/latest");
+    return release.tag_name;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchSkill(folder: string): Promise<Skill | null> {
+  const rawUrl = `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/skills/${folder}/SKILL.md`;
+  const raw = await fetchRaw(rawUrl);
+  const parsed = parseFrontmatter(raw);
+  if (!parsed) return null;
+  const allowedTools = parsed.data["allowed-tools"]
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) ?? [];
+  return {
+    name: parsed.data.name ?? folder,
+    description: parsed.data.description ?? "",
+    category: CATEGORY_MAP[folder] ?? "internal",
+    allowedTools,
+    rawMarkdown: raw,
+    bodyHtml: await marked.parse(parsed.body),
+  };
+}
+
+export async function getSkillsBundle(): Promise<SkillsBundle> {
+  const folders = await fetchSkillFolders();
+  const [skills, version] = await Promise.all([
+    Promise.all(folders.map(fetchSkill)),
+    fetchLatestVersion(),
+  ]);
+  return {
+    skills: skills.filter((s): s is Skill => s !== null),
+    version,
+    repoUrl: `https://github.com/${REPO_OWNER}/${REPO_NAME}`,
+    installCommand: `npx skills add ${REPO_OWNER}/${REPO_NAME}`,
+  };
+}
+
+export async function getSkill(name: string): Promise<{ skill: Skill; bundle: SkillsBundle } | null> {
+  const bundle = await getSkillsBundle();
+  const skill = bundle.skills.find((s) => s.name === name);
+  if (!skill) return null;
+  return { skill, bundle };
+}
+
+export function getSkillNames(skills: Skill[]): string[] {
+  return skills.map((s) => s.name);
+}

--- a/src/ui/Accordion.tsx
+++ b/src/ui/Accordion.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   createContext,
   useContext,

--- a/src/ui/AlertDialog.stories.tsx
+++ b/src/ui/AlertDialog.stories.tsx
@@ -36,6 +36,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Destructive: Story = {};
 
 export const Warning: Story = {

--- a/src/ui/AlertDialog.tsx
+++ b/src/ui/AlertDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
@@ -85,12 +85,36 @@ export function AlertDialog({
   isLoading = false,
 }: AlertDialogProps) {
   const { mounted, visible } = useAnimatedMount(open, 200);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-  // Scroll lock only — no Escape dismiss (by design)
+  // Scroll lock + focus trap — no Escape dismiss (by design)
   useEffect(() => {
     if (!open) return;
     document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Tab" && panelRef.current) {
+        const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.body.style.overflow = "";
+      document.removeEventListener("keydown", handleKey);
+    };
   }, [open]);
 
   if (!mounted) return null;
@@ -106,6 +130,7 @@ export function AlertDialog({
       />
 
       <div
+        ref={panelRef}
         role="alertdialog"
         aria-modal="true"
         aria-labelledby="alert-title"

--- a/src/ui/AlertDialog.tsx
+++ b/src/ui/AlertDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";

--- a/src/ui/AlertDialog.tsx
+++ b/src/ui/AlertDialog.tsx
@@ -95,7 +95,7 @@ export function AlertDialog({
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Tab" && panelRef.current) {
         const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
         );
         if (focusable.length === 0) return;
         const first = focusable[0];

--- a/src/ui/AspectRatio.tsx
+++ b/src/ui/AspectRatio.tsx
@@ -1,10 +1,11 @@
+import { type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface AspectRatioProps {
   ratio: number | string;
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }
 

--- a/src/ui/Chart.stories.tsx
+++ b/src/ui/Chart.stories.tsx
@@ -86,6 +86,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const BarChartStory: Story = {
   name: "Bar Chart",
   render: () => (

--- a/src/ui/Checkbox.tsx
+++ b/src/ui/Checkbox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRef, useEffect } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Combobox.tsx
+++ b/src/ui/Combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { cn } from "@/shared/utils/cn";
 
 export interface ComboboxOption {
@@ -38,6 +38,8 @@ export function Combobox({
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [internalValue, setInternalValue] = useState(defaultValue ?? "");
   const containerRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+  const inputId = useId();
   const isControlled = value !== undefined;
   const selectedValue = isControlled ? value : internalValue;
 
@@ -82,10 +84,17 @@ export function Combobox({
 
   return (
     <div className={cn("flex flex-col gap-1.5", className)}>
-      {label && <label className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</label>}
+      {label && <label htmlFor={inputId} className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</label>}
 
       <div ref={containerRef} className="relative">
         <input
+          id={inputId}
+          role="combobox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-activedescendant={open ? `${listboxId}-option-${highlightedIndex}` : undefined}
+          aria-autocomplete="list"
+          autoComplete="off"
           value={query}
           onChange={(event) => {
             setQuery(event.target.value);
@@ -127,7 +136,11 @@ export function Combobox({
         </span>
 
         {open && (
-          <div className="absolute z-40 mt-2 max-h-64 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg dark:border-[#1f2937] dark:bg-[#161b22]">
+          <div
+            id={listboxId}
+            role="listbox"
+            className="absolute z-40 mt-2 max-h-64 w-full overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg dark:border-[#1f2937] dark:bg-[#161b22]"
+          >
             {filtered.length === 0 && (
               <p className="px-3 py-2 text-xs text-slate-500 dark:text-slate-400">{emptyText}</p>
             )}
@@ -137,7 +150,10 @@ export function Combobox({
               return (
                 <button
                   key={option.value}
+                  id={`${listboxId}-option-${index}`}
                   type="button"
+                  role="option"
+                  aria-selected={isSelected || undefined}
                   disabled={option.disabled}
                   onMouseEnter={() => setHighlightedIndex(index)}
                   onClick={() => !option.disabled && selectValue(option.value)}

--- a/src/ui/Combobox.tsx
+++ b/src/ui/Combobox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Command.tsx
+++ b/src/ui/Command.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useEffect, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Command.tsx
+++ b/src/ui/Command.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { createContext, useContext, useEffect, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 interface CommandContextValue {
   query: string;
   setQuery: (query: string) => void;
+  visibleCount: number;
+  incrementVisible: () => void;
+  decrementVisible: () => void;
 }
 
 const CommandContext = createContext<CommandContextValue | null>(null);
@@ -20,22 +23,28 @@ function useCommandContext() {
   return context;
 }
 
-export function Command({ className, initialQuery = "", ...props }: CommandProps) {
+export function Command({ className, initialQuery = "", children, ...props }: CommandProps) {
   const [query, setQuery] = useState(initialQuery);
+  const [visibleCount, setVisibleCount] = useState(0);
 
   useEffect(() => {
     setQuery(initialQuery);
   }, [initialQuery]);
 
+  const incrementVisible = useCallback(() => setVisibleCount((n) => n + 1), []);
+  const decrementVisible = useCallback(() => setVisibleCount((n) => n - 1), []);
+
   return (
-    <CommandContext.Provider value={{ query, setQuery }}>
+    <CommandContext.Provider value={{ query, setQuery, visibleCount, incrementVisible, decrementVisible }}>
       <div
         className={cn(
           "rounded-xl border border-slate-200 bg-white dark:border-[#1f2937] dark:bg-[#161b22]",
           className
         )}
         {...props}
-      />
+      >
+        {children}
+      </div>
     </CommandContext.Provider>
   );
 }
@@ -60,7 +69,7 @@ Command.Input = function CommandInput({ className, ...props }: InputHTMLAttribut
 }
 
 Command.List = function CommandList({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("max-h-64 overflow-y-auto p-1", className)} {...props} />;
+  return <div role="listbox" className={cn("max-h-64 overflow-y-auto p-1", className)} {...props} />;
 }
 
 interface CommandItemProps extends HTMLAttributes<HTMLButtonElement> {
@@ -70,7 +79,7 @@ interface CommandItemProps extends HTMLAttributes<HTMLButtonElement> {
 }
 
 Command.Item = function CommandItem({ value, keywords, className, children, ...props }: CommandItemProps) {
-  const { query } = useCommandContext();
+  const { query, incrementVisible, decrementVisible } = useCommandContext();
 
   const visible = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -79,11 +88,19 @@ Command.Item = function CommandItem({ value, keywords, className, children, ...p
     return terms.includes(normalized);
   }, [query, value, keywords]);
 
+  useEffect(() => {
+    if (visible) {
+      incrementVisible();
+      return decrementVisible;
+    }
+  }, [visible, incrementVisible, decrementVisible]);
+
   if (!visible) return null;
 
   return (
     <button
       type="button"
+      role="option"
       className={cn(
         "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-slate-700 transition-colors hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-[#0d1117]",
         className
@@ -96,9 +113,17 @@ Command.Item = function CommandItem({ value, keywords, className, children, ...p
 }
 
 Command.Empty = function CommandEmpty({ className, children = "No results" }: { className?: string; children?: ReactNode }) {
-  const { query } = useCommandContext();
-  if (!query.trim()) return null;
-  return <p className={cn("px-3 py-5 text-center text-xs text-slate-500 dark:text-slate-400", className)}>{children}</p>;
+  const { query, visibleCount } = useCommandContext();
+  if (!query.trim() || visibleCount > 0) return null;
+
+  return (
+    <p
+      role="presentation"
+      className={cn("px-3 py-5 text-center text-xs text-slate-500 dark:text-slate-400", className)}
+    >
+      {children}
+    </p>
+  );
 }
 
 Command.Group = function CommandGroup({ className, ...props }: HTMLAttributes<HTMLDivElement>) {

--- a/src/ui/Command.tsx
+++ b/src/ui/Command.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type HTMLAttributes, type InputHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
 interface CommandContextValue {

--- a/src/ui/DataTable.tsx
+++ b/src/ui/DataTable.tsx
@@ -146,7 +146,7 @@ export function DataTable<TData>({
   return (
     <div className={cn("space-y-4", className)}>
       {/* Filter input */}
-      <div className="relative">
+      <div className="relative" role="search">
         <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-[18px] text-slate-400">
           search
         </span>
@@ -155,6 +155,7 @@ export function DataTable<TData>({
           value={globalFilter}
           onChange={(e) => handleFilterChange(e.target.value)}
           placeholder={filterPlaceholder}
+          aria-label={filterPlaceholder}
           className={cn(
             "h-10 w-full rounded-lg border border-slate-200 bg-white pl-10 pr-4 text-sm text-slate-900 outline-hidden transition-all",
             "hover:border-slate-300 focus:border-primary focus:ring-2 focus:ring-primary/20",
@@ -168,9 +169,16 @@ export function DataTable<TData>({
         <Table.Header>
           {table.getHeaderGroups().map((headerGroup) => (
             <Table.Row key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
+              {headerGroup.headers.map((header) => {
+                const sortDir = header.column.getIsSorted();
+                return (
                 <Table.Head
                   key={header.id}
+                  aria-sort={
+                    sortDir === "asc" ? "ascending" :
+                    sortDir === "desc" ? "descending" :
+                    header.column.getCanSort() ? "none" : undefined
+                  }
                   className={cn(
                     header.column.getCanSort() && "cursor-pointer select-none",
                   )}
@@ -181,10 +189,11 @@ export function DataTable<TData>({
                       header.column.columnDef.header,
                       header.getContext(),
                     )}
-                    <SortIcon direction={header.column.getIsSorted()} />
+                    <SortIcon direction={sortDir} />
                   </div>
                 </Table.Head>
-              ))}
+                );
+              })}
             </Table.Row>
           ))}
         </Table.Header>
@@ -222,6 +231,7 @@ export function DataTable<TData>({
       </Table>
 
       {/* Pagination */}
+      {!isEmpty && !isLoading && (
       <div className="flex items-center justify-between">
         <p className="text-sm text-slate-500 dark:text-slate-400">
           Page {pagination.pageIndex + 1} of {table.getPageCount()}{" "}
@@ -246,6 +256,7 @@ export function DataTable<TData>({
           </Button>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/ui/DatePicker.tsx
+++ b/src/ui/DatePicker.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type InputHTMLAttributes,
@@ -67,6 +68,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
       onChange,
       mode = "single",
       placeholder = "Pick a date",
+      disabled,
       className,
       id,
       ...props
@@ -76,6 +78,7 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
     const [open, setOpen] = useState(false);
     const [internalValue, setInternalValue] = useState(defaultValue ?? "");
     const containerRef = useRef<HTMLDivElement>(null);
+    const calendarId = useId();
 
     const isControlled = value !== undefined;
     const currentValue = isControlled ? value : internalValue;
@@ -143,6 +146,10 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
         <div ref={containerRef} className="relative">
           <button
             type="button"
+            disabled={disabled}
+            aria-expanded={open}
+            aria-haspopup="dialog"
+            aria-controls={calendarId}
             onClick={() => setOpen(!open)}
             className={cn(
               "h-10 w-full rounded-lg border border-slate-200 bg-white px-3.5 text-left text-sm text-slate-900 outline-hidden transition-all",
@@ -168,11 +175,12 @@ export const DatePicker = forwardRef<HTMLInputElement, DatePickerProps>(
             type="hidden"
             value={currentValue}
             name={props.name}
+            {...props}
           />
 
           {/* Calendar dropdown */}
           {open && (
-            <div className="absolute z-40 mt-2 left-0 w-full">
+            <div id={calendarId} className="absolute z-40 mt-2 left-0 w-full">
               <Calendar
                 mode={mode}
                 selected={calendarSelected}

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -92,6 +92,7 @@ Dialog.Footer = function DialogFooter({ children, className, ...props }: DialogF
 
 export function Dialog({ open, onClose, size = "md", children, className }: DialogProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const { mounted, visible } = useAnimatedMount(open, 200);
 
   useEffect(() => {
@@ -99,6 +100,21 @@ export function Dialog({ open, onClose, size = "md", children, className }: Dial
 
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
+      if (e.key === "Tab" && panelRef.current) {
+        const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
     };
 
     document.addEventListener("keydown", handleKey);
@@ -130,6 +146,7 @@ export function Dialog({ open, onClose, size = "md", children, className }: Dial
 
       {/* Panel */}
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         className={cn(

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -102,7 +102,7 @@ export function Dialog({ open, onClose, size = "md", children, className }: Dial
       if (e.key === "Escape") onClose();
       if (e.key === "Tab" && panelRef.current) {
         const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
         );
         if (focusable.length === 0) return;
         const first = focusable[0];

--- a/src/ui/Drawer.tsx
+++ b/src/ui/Drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type HTMLAttributes, type ReactNode } from "react";
+import { useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
@@ -99,12 +99,28 @@ Drawer.Footer = function DrawerFooter({ children, className, ...props }: DrawerF
 
 export function Drawer({ open, onClose, side = "right", size = "md", children, className }: DrawerProps) {
   const { mounted, visible } = useAnimatedMount(open, 300);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
 
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
+      if (e.key === "Tab" && panelRef.current) {
+        const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
     };
 
     document.addEventListener("keydown", handleKey);
@@ -133,6 +149,7 @@ export function Drawer({ open, onClose, side = "right", size = "md", children, c
 
       {/* Panel */}
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         className={cn(

--- a/src/ui/Drawer.tsx
+++ b/src/ui/Drawer.tsx
@@ -108,7 +108,7 @@ export function Drawer({ open, onClose, side = "right", size = "md", children, c
       if (e.key === "Escape") onClose();
       if (e.key === "Tab" && panelRef.current) {
         const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
         );
         if (focusable.length === 0) return;
         const first = focusable[0];

--- a/src/ui/DropdownMenu.tsx
+++ b/src/ui/DropdownMenu.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/DropdownMenu.tsx
+++ b/src/ui/DropdownMenu.tsx
@@ -131,9 +131,7 @@ DropdownMenu.Label = function DropdownMenuLabel({ className, ...props }: HTMLAtt
 }
 
 DropdownMenu.Separator = function DropdownMenuSeparator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return     <div
-      role="menu"
-      className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
+  return <div role="separator" className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
 }
 
 DropdownMenu.Item = function DropdownMenuItem({ inset = false, onSelect, onClick, className, disabled, ...props }: DropdownMenuItemProps) {

--- a/src/ui/DropdownMenu.tsx
+++ b/src/ui/DropdownMenu.tsx
@@ -85,6 +85,8 @@ DropdownMenu.Trigger = function DropdownMenuTrigger({ children, className, onCli
   return (
     <button
       type="button"
+      aria-expanded={open}
+      aria-haspopup="menu"
       onClick={(event) => {
         onClick?.(event);
         setOpen(!open);
@@ -129,7 +131,9 @@ DropdownMenu.Label = function DropdownMenuLabel({ className, ...props }: HTMLAtt
 }
 
 DropdownMenu.Separator = function DropdownMenuSeparator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
+  return     <div
+      role="menu"
+      className={cn("my-1 h-px bg-slate-200 dark:bg-[#1f2937]", className)} {...props} />;
 }
 
 DropdownMenu.Item = function DropdownMenuItem({ inset = false, onSelect, onClick, className, disabled, ...props }: DropdownMenuItemProps) {
@@ -138,6 +142,7 @@ DropdownMenu.Item = function DropdownMenuItem({ inset = false, onSelect, onClick
   return (
     <button
       type="button"
+      role="menuitem"
       disabled={disabled}
       onClick={(event) => {
         onClick?.(event);

--- a/src/ui/HoverCard.tsx
+++ b/src/ui/HoverCard.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
   useRef,
   useState,
   type HTMLAttributes,
@@ -46,6 +47,7 @@ interface HoverCardContextValue {
   closeDelay: number;
   side: HoverCardSide;
   align: HoverCardAlign;
+  tooltipId: string;
 }
 
 const HoverCardContext = createContext<HoverCardContextValue | null>(null);
@@ -77,6 +79,7 @@ export function HoverCard({
   const containerRef = useRef<HTMLDivElement>(null);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
 
   const setOpen = useCallback((next: boolean) => {
     if (!isControlled) setInternalOpen(next);
@@ -115,7 +118,7 @@ export function HoverCard({
   }, []);
 
   return (
-    <HoverCardContext.Provider value={{ open: isOpen, setOpen, openDelay, closeDelay, side, align }}>
+    <HoverCardContext.Provider value={{ open: isOpen, setOpen, openDelay, closeDelay, side, align, tooltipId }}>
       <div
         ref={containerRef}
         className={cn("relative inline-flex", className)}
@@ -131,8 +134,14 @@ export function HoverCard({
 // ─── Trigger ─────────────────────────────────────────────────────────────────
 
 HoverCard.Trigger = function HoverCardTrigger({ children, className, ...props }: HoverCardTriggerProps) {
+  const { open, tooltipId } = useHoverCardContext();
+
   return (
-    <span className={cn("inline-flex", className)} {...props}>
+    <span
+      className={cn("inline-flex", className)}
+      aria-describedby={open ? tooltipId : undefined}
+      {...props}
+    >
       {children}
     </span>
   );
@@ -161,7 +170,7 @@ const VERTICAL_ALIGN_CLASS: Record<HoverCardAlign, string> = {
 };
 
 HoverCard.Content = function HoverCardContent({ children, className, ...props }: HoverCardContentProps) {
-  const { open, side, align } = useHoverCardContext();
+  const { open, side, align, tooltipId } = useHoverCardContext();
 
   if (!open) return null;
 
@@ -169,6 +178,8 @@ HoverCard.Content = function HoverCardContent({ children, className, ...props }:
 
   return (
     <div
+      id={tooltipId}
+      role="tooltip"
       className={cn(
         "absolute z-50 w-80 rounded-lg border border-slate-200 bg-white p-4 shadow-lg",
         "dark:border-[#1f2937] dark:bg-[#161b22]",

--- a/src/ui/InputOTP.tsx
+++ b/src/ui/InputOTP.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useRef, useEffect, type KeyboardEvent } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/PageProgress.stories.tsx
+++ b/src/ui/PageProgress.stories.tsx
@@ -24,6 +24,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Visible: Story = {};
 
 export const Hidden: Story = {

--- a/src/ui/PageProgress.tsx
+++ b/src/ui/PageProgress.tsx
@@ -22,7 +22,6 @@ export function PageProgress({ progress, visible }: PageProgressProps) {
       aria-valuemin={0}
       aria-valuemax={100}
       aria-valuenow={progress}
-      aria-hidden="true"
       className={cn(
         "pointer-events-none fixed left-0 top-0 z-200 h-0.5 bg-primary",
         // Glow effect matching the primary color

--- a/src/ui/Popover.tsx
+++ b/src/ui/Popover.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
@@ -97,6 +99,8 @@ Popover.Trigger = function PopoverTrigger({ children, className, onClick, ...pro
   return (
     <button
       type="button"
+      aria-expanded={open}
+      aria-haspopup="dialog"
       onClick={(event) => {
         onClick?.(event);
         setOpen(!open);
@@ -131,6 +135,7 @@ Popover.Content = function PopoverContent({ children, className, ...props }: Pop
 
   return (
     <div
+      role="dialog"
       className={cn(
         "absolute z-50 w-72 rounded-xl border border-slate-200 bg-white p-4 shadow-xl dark:border-[#1f2937] dark:bg-[#161b22]",
         SIDE_CLASS[side],

--- a/src/ui/RadioGroup.tsx
+++ b/src/ui/RadioGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useId, useState, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Resizable.stories.tsx
+++ b/src/ui/Resizable.stories.tsx
@@ -12,6 +12,8 @@ const meta = {
 export default meta;
 type Story = StoryObj;
 
+export const Default: Story = {};
+
 export const Horizontal: Story = {
   render: () => (
     <StorySurface className="w-[800px]">

--- a/src/ui/Resizable.tsx
+++ b/src/ui/Resizable.tsx
@@ -148,8 +148,9 @@ Resizable.Handle = function ResizableHandle({
   containerRef,
   activeHandle,
   setActiveHandle,
+  direction: dir,
 }: ResizableHandleProps & ResizableHandleInternalProps) {
-  const direction = "horizontal"; // Hardcode for now
+  const direction = dir ?? "horizontal";
   const isHorizontal = direction === "horizontal";
 
   const handleMouseDown = (e: React.MouseEvent) => {

--- a/src/ui/ScrollArea.stories.tsx
+++ b/src/ui/ScrollArea.stories.tsx
@@ -34,6 +34,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Vertical: Story = {
   args: {
     orientation: "vertical",

--- a/src/ui/SearchDialog.tsx
+++ b/src/ui/SearchDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
 import { cn } from "@/shared/utils/cn";
 
@@ -33,6 +33,8 @@ export function SearchDialog({
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const dialogId = useId();
   const { mounted, visible } = useAnimatedMount(open, 150);
 
   const results = query.trim()
@@ -60,29 +62,44 @@ export function SearchDialog({
     setActiveIndex(0);
   }, [query]);
 
-  // Keyboard navigation
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setActiveIndex((i) => Math.min(i + 1, results.length - 1));
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setActiveIndex((i) => Math.max(i - 1, 0));
-      } else if (e.key === "Enter") {
-        const item = results[activeIndex];
-        if (item) {
-          onNavigate(item.href);
-          onClose();
-        }
-      } else if (e.key === "Escape") {
+  // Keyboard navigation + focus trap
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      const item = results[activeIndex];
+      if (item) {
+        onNavigate(item.href);
         onClose();
       }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, results, activeIndex, onNavigate, onClose]);
+    } else if (e.key === "Escape") {
+      onClose();
+    } else if (e.key === "Tab" && panelRef.current) {
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+        'input, button, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    }
+  }, [results, activeIndex, onNavigate, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
 
   if (!mounted) return null;
 
@@ -101,6 +118,10 @@ export function SearchDialog({
 
       {/* Panel */}
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search"
         className={cn(
           "relative z-10 mx-4 w-full max-w-xl rounded-xl border border-slate-200 dark:border-[#1f2937] bg-white dark:bg-[#161b22] shadow-2xl transition-all duration-150",
           visible ? "scale-100 opacity-100" : "scale-95 opacity-0",
@@ -257,6 +278,8 @@ function ResultGroup({
         return (
           <button
             key={item.href}
+            role="option"
+            aria-selected={isActive || undefined}
             onMouseEnter={() => onHover(globalIdx)}
             onClick={() => onSelect(item.href)}
             className={cn(

--- a/src/ui/SearchDialog.tsx
+++ b/src/ui/SearchDialog.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef, useState } from "react";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
 import { cn } from "@/shared/utils/cn";

--- a/src/ui/SearchDialog.tsx
+++ b/src/ui/SearchDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
 import { cn } from "@/shared/utils/cn";
 
@@ -34,7 +34,6 @@ export function SearchDialog({
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
-  const dialogId = useId();
   const { mounted, visible } = useAnimatedMount(open, 150);
 
   const results = query.trim()
@@ -80,7 +79,7 @@ export function SearchDialog({
       onClose();
     } else if (e.key === "Tab" && panelRef.current) {
       const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-        'input, button, [tabindex]:not([tabindex="-1"])'
+        'input:not(:disabled), button:not(:disabled), [tabindex]:not([tabindex="-1"])'
       );
       if (focusable.length === 0) return;
       const first = focusable[0];

--- a/src/ui/Separator.stories.tsx
+++ b/src/ui/Separator.stories.tsx
@@ -22,6 +22,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Horizontal: Story = {};
 
 export const Vertical: Story = {

--- a/src/ui/Sheet.stories.tsx
+++ b/src/ui/Sheet.stories.tsx
@@ -14,6 +14,8 @@ const meta = {
 export default meta;
 type Story = StoryObj;
 
+export const Default: Story = {};
+
 export const RightSide: Story = {
   render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/ui/Sheet.tsx
+++ b/src/ui/Sheet.tsx
@@ -52,6 +52,8 @@ export interface SheetCloseProps extends HTMLAttributes<HTMLButtonElement> {
 interface SheetContextValue {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  side: SheetSide;
+  size: SheetSize;
 }
 
 const SheetContext = createContext<SheetContextValue | null>(null);
@@ -115,14 +117,6 @@ Sheet.Trigger = function SheetTrigger({ children, className, ...props }: SheetTr
   );
 };
 
-Sheet.Content = function SheetContent({ children, className, ...props }: SheetContentProps) {
-  return (
-    <div className={cn("flex-1 overflow-y-auto px-6 py-4", className)} {...props}>
-      {children}
-    </div>
-  );
-};
-
 Sheet.Header = function SheetHeader({ children, className, ...props }: SheetHeaderProps) {
   return (
     <div className={cn("px-6 pt-6 pb-4 border-b border-slate-100 dark:border-[#1f2937]", className)} {...props}>
@@ -177,11 +171,69 @@ Sheet.Close = function SheetClose({ children, className, ...props }: SheetCloseP
   );
 };
 
-// ─── Main Component ───────────────────────────────────────────────────────────
-
-export function Sheet({ open, onOpenChange, side = "right", size = "md", children, className }: SheetProps) {
+Sheet.Content = function SheetContent({ children, className, ...props }: SheetContentProps) {
+  const { open, onOpenChange, side, size } = useSheetContext();
   const { mounted, visible } = useAnimatedMount(open, 300);
 
+  if (!mounted) return null;
+
+  const { panel, hidden } = SIDE_CLASSES[side];
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div
+        className={cn(
+          "absolute inset-0 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
+          visible ? "opacity-100" : "opacity-0"
+        )}
+        onClick={() => onOpenChange(false)}
+      />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          "absolute flex flex-col bg-white dark:bg-[#161b22]",
+          "border-slate-200 dark:border-[#1f2937]",
+          side === "right" && "border-l",
+          side === "left" && "border-r",
+          side === "top" && "border-b",
+          side === "bottom" && "border-t",
+          "shadow-2xl shadow-black/20",
+          "transition-transform duration-300 ease-in-out",
+          side === "top" || side === "bottom"
+            ? `w-full ${HEIGHT_CLASSES[size]}`
+            : `h-full ${WIDTH_CLASSES[size]}`,
+          panel,
+          visible ? "translate-x-0 translate-y-0" : hidden,
+          className
+        )}
+      >
+        {/* Close button */}
+        <button
+          onClick={() => onOpenChange(false)}
+          className="absolute right-4 top-4 z-10 rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-[#1f2937] hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+          aria-label="Close sheet"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none">
+            <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4" {...props}>
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function Sheet({ open, onOpenChange, side = "right", size = "md", children }: SheetProps) {
   useEffect(() => {
     if (!open) return;
 
@@ -198,61 +250,9 @@ export function Sheet({ open, onOpenChange, side = "right", size = "md", childre
     };
   }, [open, onOpenChange]);
 
-  if (!mounted) return null;
-
-  const { panel, hidden } = SIDE_CLASSES[side];
-
-  const sheet = (
-    <SheetContext.Provider value={{ open, onOpenChange }}>
-      <div className="fixed inset-0 z-50 flex">
-        {/* Backdrop */}
-        <div
-          className={cn(
-            "absolute inset-0 bg-black/50 backdrop-blur-xs transition-opacity duration-300",
-            visible ? "opacity-100" : "opacity-0"
-          )}
-          onClick={() => onOpenChange(false)}
-        />
-
-        {/* Panel */}
-        <div
-          role="dialog"
-          aria-modal="true"
-          className={cn(
-            "absolute flex flex-col bg-white dark:bg-[#161b22]",
-            "border-slate-200 dark:border-[#1f2937]",
-            side === "right" && "border-l",
-            side === "left" && "border-r",
-            side === "top" && "border-b",
-            side === "bottom" && "border-t",
-            "shadow-2xl shadow-black/20",
-            "transition-transform duration-300 ease-in-out",
-            // For top/bottom: size controls height, width is full
-            // For left/right: size controls width, height is full
-            side === "top" || side === "bottom"
-              ? `w-full ${HEIGHT_CLASSES[size]}`
-              : `h-full ${WIDTH_CLASSES[size]}`,
-            panel,
-            visible ? "translate-x-0 translate-y-0" : hidden,
-            className
-          )}
-        >
-          {/* Close button */}
-          <button
-            onClick={() => onOpenChange(false)}
-            className="absolute right-4 top-4 z-10 rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-[#1f2937] hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
-            aria-label="Close sheet"
-          >
-            <svg className="h-4 w-4" viewBox="0 0 16 16" fill="none">
-              <path d="M12 4L4 12M4 4l8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-            </svg>
-          </button>
-
-          {children}
-        </div>
-      </div>
+  return (
+    <SheetContext.Provider value={{ open, onOpenChange, side, size }}>
+      {children}
     </SheetContext.Provider>
   );
-
-  return createPortal(sheet, document.body);
 }

--- a/src/ui/Sheet.tsx
+++ b/src/ui/Sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, type HTMLAttributes, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/utils/cn";
 import { useAnimatedMount } from "@/shared/hooks/useAnimatedMount";
@@ -174,6 +174,30 @@ Sheet.Close = function SheetClose({ children, className, ...props }: SheetCloseP
 Sheet.Content = function SheetContent({ children, className, ...props }: SheetContentProps) {
   const { open, onOpenChange, side, size } = useSheetContext();
   const { mounted, visible } = useAnimatedMount(open, 300);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Tab" && panelRef.current) {
+        const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last?.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
 
   if (!mounted) return null;
 
@@ -192,6 +216,7 @@ Sheet.Content = function SheetContent({ children, className, ...props }: SheetCo
 
       {/* Panel */}
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         className={cn(

--- a/src/ui/Sheet.tsx
+++ b/src/ui/Sheet.tsx
@@ -181,7 +181,7 @@ Sheet.Content = function SheetContent({ children, className, ...props }: SheetCo
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Tab" && panelRef.current) {
         const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
         );
         if (focusable.length === 0) return;
         const first = focusable[0];

--- a/src/ui/Slider.tsx
+++ b/src/ui/Slider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Switch.tsx
+++ b/src/ui/Switch.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useMemo, useState } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Tabs.stories.tsx
+++ b/src/ui/Tabs.stories.tsx
@@ -35,6 +35,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Underline: Story = {
   args: {
     defaultValue: "overview",

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   createContext,
   useContext,

--- a/src/ui/Toggle.tsx
+++ b/src/ui/Toggle.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/ToggleGroup.tsx
+++ b/src/ui/ToggleGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   createContext,
   useCallback,

--- a/src/ui/Tooltip.stories.tsx
+++ b/src/ui/Tooltip.stories.tsx
@@ -26,6 +26,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Top: Story = {};
 
 export const Right: Story = {

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useState, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useState, type HTMLAttributes, type ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
 
-type TooltipSide = "top" | "bottom" | "left" | "right";
+export type TooltipSide = "top" | "bottom" | "left" | "right";
 
 interface TooltipContextValue {
   open: boolean;

--- a/src/ui/Typography.stories.tsx
+++ b/src/ui/Typography.stories.tsx
@@ -12,6 +12,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Default: Story = {};
+
 export const Headings: Story = {
   render: () => (
     <StorySurface className="w-[600px] space-y-4">


### PR DESCRIPTION
## Summary

Sync \`development\` into \`main\` to trigger the v1.0.0 release pipeline. 53 commits ahead, covering the entire v1.0 launch surface.

## What ships in this merge

### Cookbook
- Server State (React Query), Client State (Zustand), Form Validation (Zod), Data Tables (TanStack Table), API Integration recipes published
- AI Corpus: \`/llms.txt\`, \`/llms-full.txt\`, \`/ai\` landing, \`/ai/skills/[name]\` detail pages
- AI Skills repo (\`sindev08/react-principles-skills\`) with 10 skills, distributed via Agent Skills spec
- Hero badge "Early access" → "v1.0 is now live"

### UI Kit
- Full audit pass for 57 components (visual, functional, docs, CLI) — #183
- CLI naming aligned: \`Radio\` → \`RadioGroup\`, \`Dropdown\` → \`DropdownMenu\` (#192), \`scrollarea\` → \`scroll-area\` (#197)
- PascalCase → kebab-case auto-conversion in CLI \`create\` command
- ErrorBoundary, ARIA improvements, "use client" directives across overlays/menus

### Configurator
- Audit pass for all 18 checklist items — #185
- ErrorBoundary around LivePreviewPanel
- Component name sync across sidebar, dependency map, CLI

### Release pipeline
- PR #198 added a \`Release-As: 1.0.0\` footer commit so release-please anchors the CLI at v1.0.0

## What happens after merge

1. \`release.yml\` workflow fires (push to main)
2. release-please reads \`Release-As: 1.0.0\` from #198 and opens a release PR:
   - Bumps \`packages/cli/package.json\` and \`.release-please-manifest.json\` to \`1.0.0\`
   - Auto-generates \`packages/cli/CHANGELOG.md\` covering all commits since \`react-principles@0.1.0\`
3. Reviewing & merging that release PR tags \`react-principles@1.0.0\` and triggers \`publish.yml\` → npm

## Related

- Closes #41 — v1.0 launch (all acceptance criteria met)
- Relates to #194 — submit to skills.sh (post-launch, external)
- Relates to #196 — pre-1.0 CLI breaking changes (CHANGELOG will be auto-generated by release-please)