### PR TITLE
fix(ci): remove --provenance from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   publish:
@@ -29,6 +28,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Publish to npm
-        run: pnpm --filter ./packages/cli publish --no-git-checks --provenance
+        run: pnpm --filter ./packages/cli publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.0.0 publish job failed with a misleading \`404 Not Found\` from npm because \`--provenance\` requires Trusted Publishing (OIDC) on npm, but the workflow uses \`NODE_AUTH_TOKEN\`. Drop \`--provenance\` (and the now-unused \`id-token: write\` permission) so token auth can publish.

## What this unblocks

After this lands on \`main\`, manually re-trigger \`Publish CLI\` via \`workflow_dispatch\` on Actions tab. v1.0.0 should publish successfully to npm.

## Follow-up (post-launch)

Re-enable provenance attestation properly:
1. npmjs.com → \`react-principles\` → Settings → Trusted Publishers → add this repo + \`publish.yml\`
2. Remove \`NODE_AUTH_TOKEN\` and restore \`id-token: write\` + \`--provenance\`

## Related

- Hotfix to unblock #41 v1.0 ship