### PR TITLE
fix(ci): sync publish workflow fix to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   publish:
@@ -29,6 +28,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Publish to npm
-        run: pnpm --filter ./packages/cli publish --no-git-checks --provenance
+        run: pnpm --filter ./packages/cli publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Fast-follow sync to bring PR #201 (\`fix(ci): remove --provenance from publish workflow\`) to \`main\` so the next \`workflow_dispatch\` of \`Publish CLI\` checks out the fixed workflow and publishes v1.0.0 to npm successfully.

## After merge

1. Open Actions tab → \`Publish CLI\` workflow
2. Click "Run workflow" on \`main\`
3. The dispatch should publish \`react-principles@1.0.0\` to npm

## Related

- Hotfix sync for #41 v1.0 ship
- Follow-up #201