### PR TITLE
fix(ai): use canonical www host for mcp endpoint

### DIFF
--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -7,7 +7,9 @@ const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
 const SKILLS_REPO_URL = "https://github.com/sindev08/react-principles-skills";
 const SKILLS_INSTALL_CMD = "npx skills add sindev08/react-principles-skills";
-const MCP_ENDPOINT = `${SITE_URL}/api/mcp`;
+// MCP clients POST directly and may not follow the apex→www 307 redirect,
+// so advertise the canonical www host explicitly for the endpoint.
+const MCP_ENDPOINT = "https://www.reactprinciples.dev/api/mcp";
 const MCP_INSTALL_CMD = `claude mcp add --transport http reactprinciples ${MCP_ENDPOINT}`;
 const MCP_JSON_CONFIG = `{
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Advertise `https://www.reactprinciples.dev/api/mcp` explicitly in the `/ai` page install command and JSON config, instead of deriving from the apex host
- MCP clients POST to the endpoint directly and may not follow the apex→www 307 redirect; browser-followed links (llms.txt) are unaffected and stay on the existing host

## Related

- Relates to #208