### PR TITLE
feat(analytics): instrument mcp tool calls and llms.txt fetches

### DIFF
--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,12 +1,19 @@
+import { after } from "next/server";
 import { createMcpHandler } from "mcp-handler";
 // The MCP SDK validates tool inputs with zod v3 — use the v3 compat entry
 import { z } from "zod/v3";
 import { getRecipeDetail } from "@/features/cookbook/data";
 import { formatRecipeMarkdown } from "@/lib/recipe-md";
 import { listPublishedRecipes, searchRecipes } from "@/lib/recipe-search";
+import { trackEvent, type EventProps } from "@/lib/analytics";
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+/** Record a tool call after the response, without blocking it. */
+function trackToolCall(tool: string, props?: EventProps) {
+  after(() => trackEvent("mcp.tool_call", { tool, ...props }));
+}
 
 function text(value: string) {
   return { content: [{ type: "text" as const, text: value }] };
@@ -33,10 +40,12 @@ const handler = createMcpHandler(
           "List all published React Principles cookbook recipes with slug, title, category, and description. Use get_recipe with a slug for full content.",
         inputSchema: {},
       },
-      async () =>
-        text(
+      async () => {
+        trackToolCall("list_recipes");
+        return text(
           `# React Principles — Recipes\n\n${formatSummaries(listPublishedRecipes())}\n\nWeb version: ${SITE_URL}/cookbook`,
-        ),
+        );
+      },
     );
 
     server.registerTool(
@@ -53,6 +62,7 @@ const handler = createMcpHandler(
       },
       async ({ slug }) => {
         const detail = getRecipeDetail(slug);
+        trackToolCall("get_recipe", { slug, found: detail !== null });
         if (!detail) {
           return text(
             `Recipe "${slug}" not found. Available recipes:\n\n${formatSummaries(listPublishedRecipes())}`,
@@ -81,6 +91,7 @@ const handler = createMcpHandler(
       },
       async ({ query, limit }) => {
         const results = searchRecipes(query, limit ?? 5);
+        trackToolCall("search_recipes", { results: results.length });
         if (results.length === 0) {
           return text(
             `No recipes matched "${query}". Try broader keywords or list_recipes.`,

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { trackEvent } from "./analytics";
+
+describe("trackEvent", () => {
+  const fetchMock = vi.fn((_input: string, _init?: RequestInit) =>
+    Promise.resolve(new Response(null, { status: 202 })),
+  );
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("no-ops when no API key is set", async () => {
+    vi.stubEnv("ANALYTICS_API_KEY", "");
+    await trackEvent("mcp.tool_call", { tool: "get_recipe" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts a bearer-authorized event when the key is set", async () => {
+    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    await trackEvent("mcp.tool_call", { tool: "get_recipe" });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const init = fetchMock.mock.calls[0]?.[1];
+    if (!init) throw new Error("fetch was not called with init");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer secret-key",
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "mcp.tool_call",
+      props: { tool: "get_recipe" },
+    });
+  });
+
+  it("omits props when none are given", async () => {
+    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    await trackEvent("list_recipes");
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    if (!init) throw new Error("fetch was not called with init");
+    expect(JSON.parse(init.body as string)).toEqual({ name: "list_recipes" });
+  });
+
+  it("never throws when the network call fails", async () => {
+    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    await expect(trackEvent("llms.fetch", { path: "/llms.txt" })).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,37 @@
+/**
+ * Server-side event tracking for the self-hosted analytics service.
+ *
+ * Captures machine/agent traffic the browser script (track.js) can't see —
+ * MCP tool calls, llms.txt fetches, CLI usage. Fire-and-forget: analytics
+ * must never block or break the request path. No-op when the API key is
+ * absent (local dev / preview), so nothing needs mocking there.
+ *
+ * Callers should not block on this. In route handlers use `after(() =>
+ * trackEvent(...))`; in middleware use `event.waitUntil(trackEvent(...))`.
+ */
+
+const INGEST_URL =
+  process.env.ANALYTICS_INGEST_URL ?? "https://analytics.sindev.my.id/api/event";
+
+export type EventProps = Record<string, string | number | boolean>;
+
+export async function trackEvent(
+  name: string,
+  props?: EventProps,
+): Promise<void> {
+  const apiKey = process.env.ANALYTICS_API_KEY;
+  if (!apiKey) return;
+
+  try {
+    await fetch(INGEST_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(props ? { name, props } : { name }),
+    });
+  } catch {
+    // Swallow — a failed analytics call must not surface to the caller.
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest, type NextFetchEvent } from "next/server";
+import { trackEvent } from "@/lib/analytics";
+
+/**
+ * Counts fetches of the AI corpus endpoints. These routes are `force-static`
+ * (served from the CDN, so their handlers never run per request), so the edge
+ * middleware is the only place to observe the traffic without de-optimizing
+ * them. Scoped tightly via `config.matcher` — it does not run on normal pages.
+ */
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+  event.waitUntil(
+    trackEvent("llms.fetch", { path: request.nextUrl.pathname }),
+  );
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/llms.txt", "/llms-full.txt", "/cookbook/:slug/llms.txt"],
+};


### PR DESCRIPTION
## Summary

- Add `src/lib/analytics.ts` — a fire-and-forget `trackEvent(name, props?)` that POSTs to the self-hosted analytics ingest endpoint (`analytics.sindev.my.id/api/event`). No-ops without `ANALYTICS_API_KEY`, never throws, never blocks the request path
- MCP tool handlers emit `mcp.tool_call` (props: tool, plus slug/found/results) via `after()`
- New scoped `middleware.ts` emits `llms.fetch` for the `force-static` llms.txt routes — the CDN serves those without running their handlers, so the edge is the only place to observe that traffic; matcher is limited to the three llms.txt paths so it never runs on normal pages

Captures the machine/agent traffic the browser `track.js` script can't see. Verified end-to-end against a local fake ingest: llms.txt fetches and all MCP tool calls produced correctly-shaped, bearer-authorized events.

## Deploy note

Needs `ANALYTICS_API_KEY` set as a server env var in Vercel (production). Without it the code cleanly no-ops, so this is safe to merge before the key is set.

## Related

- Part of the ecosystem plan (point 5 of 5); implements the instrumentation slice of #216