### PR TITLE
feat(cli): generate ecosystem-ready starters in create

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -7,6 +7,7 @@ import { decodePreset, type CliPreset } from "../utils/preset";
 import { resolvePresetDependencies, installPresetDependencies } from "../utils/deps";
 import { detectPackageManager } from "../utils/pm";
 import { getEntry, getTemplate } from "../registry";
+import { writeAgentsFile, writeMcpConfig } from "../utils/ai-onboarding";
 
 // ── Style system CSS vars ─────────────────────────────────────────────────
 
@@ -338,9 +339,36 @@ function ok(msg: string) {
 
 // ── Main ──────────────────────────────────────────────────────────────────
 
+function buildReadme(appName: string, preset: CliPreset): string {
+  const pmRun = "npm run dev";
+  const components = preset.components.length
+    ? preset.components.join(", ")
+    : "none yet";
+  return `# ${appName}
+
+Generated with [React Principles](https://reactprinciples.dev) — a starter aligned with the cookbook's production patterns.
+
+## Getting started
+
+\`\`\`bash
+${pmRun}
+\`\`\`
+
+## React Principles ecosystem
+
+This project is wired into the React Principles AI ecosystem out of the box:
+
+- **\`AGENTS.md\`** — the cookbook principles, so any AI assistant follows the same patterns. Refresh anytime with \`npx react-principles init\`.
+- **\`.mcp.json\`** — the remote MCP server (\`reactprinciples\`). Connected AI tools can look up recipes and pull component source on demand.
+- **UI Kit** — add more components with \`npx react-principles add <name>\`. Included: ${components}.
+
+Learn more at [reactprinciples.dev/ai](https://reactprinciples.dev/ai).
+`;
+}
+
 export async function create(
   appNameArg: string | undefined,
-  opts: { preset?: string; dryRun?: boolean },
+  opts: { preset?: string; dryRun?: boolean; skipAi?: boolean },
 ): Promise<void> {
   console.log(pc.bold("\n✦ react-principles create\n"));
 
@@ -402,6 +430,7 @@ export async function create(
   console.log(pc.gray(`  Components: ${preset.components.join(", ") || "none"}`));
   console.log(pc.gray(`  Packages  : ${resolved.deps.length} deps, ${resolved.devDeps.length} devDeps`));
   console.log(pc.gray(`  PM        : ${pm}`));
+  console.log(pc.gray(`  AI        : ${opts.skipAi ? "skipped" : "AGENTS.md + .mcp.json"}`));
 
   if (opts.dryRun) {
     console.log(pc.yellow("\n[dry-run] Dependencies that would be installed:"));
@@ -497,7 +526,18 @@ export async function create(
   if (copied.length > 0) ok(`Copied: ${copied.join(", ")}`);
   if (skipped.length > 0) console.log(pc.yellow(`  ⚠ Not found in registry: ${skipped.join(", ")}`));
 
-  // 7. Install
+  // 7. AI onboarding — born in the ecosystem
+  if (!opts.skipAi) {
+    step("Wiring AI integration");
+    await writeAgentsFile(projectDir);
+    ok("AGENTS.md (principles context)");
+    const mcp = writeMcpConfig(projectDir);
+    if (mcp !== null) ok(".mcp.json (reactprinciples server)");
+    write(projectDir, "README.md", buildReadme(appName, preset));
+    ok("README.md");
+  }
+
+  // 8. Install
   step(`Installing dependencies with ${pm}`);
   try {
     const installCmd = pm === "yarn" ? "yarn" : `${pm} install`;
@@ -512,7 +552,7 @@ export async function create(
     console.log(pc.gray(`    cd ${appName} && ${pm} install`));
   }
 
-  // 8. Done
+  // 9. Done
   console.log(`\n${pc.bold(pc.green("✓ Done!"))} ${pc.gray(`Created ${appName}/`)}\n`);
   console.log(pc.gray(`  cd ${appName}`));
   console.log(pc.gray(`  ${pm} run dev\n`));

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -430,7 +430,7 @@ export async function create(
   console.log(pc.gray(`  Components: ${preset.components.join(", ") || "none"}`));
   console.log(pc.gray(`  Packages  : ${resolved.deps.length} deps, ${resolved.devDeps.length} devDeps`));
   console.log(pc.gray(`  PM        : ${pm}`));
-  console.log(pc.gray(`  AI        : ${opts.skipAi ? "skipped" : "AGENTS.md + .mcp.json"}`));
+  console.log(pc.gray(`  AI        : ${opts.skipAi ? "skipped" : opts.dryRun ? "AGENTS.md + .mcp.json (dry-run)" : "AGENTS.md + .mcp.json"}`));
 
   if (opts.dryRun) {
     console.log(pc.yellow("\n[dry-run] Dependencies that would be installed:"));

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,21 @@ import {
 import { getEntry, getTemplate } from "../registry";
 import { installPackages } from "../utils/pm";
 import { setupGlobalsCss } from "../utils/css";
+import {
+  writeAgentsFile,
+  writeMcpConfig,
+  runSkillsInstall,
+  logSkillsHint,
+  MCP_ENDPOINT,
+} from "../utils/ai-onboarding";
+
+export interface InitOptions {
+  template?: string;
+  /** Run AI onboarding without prompting. */
+  ai?: boolean;
+  /** Skip AI onboarding entirely. */
+  skipAi?: boolean;
+}
 
 const FRAMEWORK_LABELS: Record<Config["framework"], string> = {
   next: "Next.js",
@@ -23,10 +38,14 @@ const FRAMEWORK_LABELS: Record<Config["framework"], string> = {
   other: "Other",
 };
 
-export async function init(cwd: string, frameworkFlag?: string): Promise<void> {
+export async function init(cwd: string, options: InitOptions = {}): Promise<void> {
+  const frameworkFlag = options.template;
   const existing = readConfig(cwd);
   if (existing) {
-    console.log(pc.yellow("components.json already exists. Remove it to re-run init."));
+    console.log(
+      pc.yellow("components.json already exists — skipping component setup."),
+    );
+    await setupAiOnboarding(cwd, options);
     return;
   }
 
@@ -141,4 +160,84 @@ export async function init(cwd: string, frameworkFlag?: string): Promise<void> {
     ` Framework: ${FRAMEWORK_LABELS[framework]} | RSC: ${rsc ? "yes" : "no"}\n` +
     `Run ${pc.cyan("npx react-principles add <component>")} to add components.\n`
   );
+
+  await setupAiOnboarding(cwd, options);
+}
+
+/**
+ * Wires the project into the React Principles AI ecosystem: an AGENTS.md
+ * principles block, a merged .mcp.json server entry, and an optional skills
+ * install. Idempotent — safe to re-run. Prompts in interactive mode; honors
+ * `--ai` (run without prompting) and `--skip-ai` (skip entirely).
+ */
+async function setupAiOnboarding(cwd: string, options: InitOptions): Promise<void> {
+  if (options.skipAi) return;
+
+  const interactive = Boolean(process.stdin.isTTY) && !options.ai;
+
+  if (interactive) {
+    const { proceed } = (await prompts(
+      {
+        type: "confirm",
+        name: "proceed",
+        message:
+          "Make your AI tools React Principles-aware? (AGENTS.md + MCP server)",
+        initial: true,
+      },
+      { onCancel: () => ({ proceed: false }) },
+    )) as { proceed?: boolean };
+    if (!proceed) return;
+  } else if (!options.ai) {
+    // Non-interactive without an explicit --ai flag: skip silently.
+    return;
+  }
+
+  console.log(pc.bold("\nSetting up AI integration...\n"));
+
+  const agents = await writeAgentsFile(cwd);
+  console.log(
+    pc.green("✓") +
+      ` ${agents === "created" ? "Created" : "Updated"} AGENTS.md (principles context)`,
+  );
+
+  const mcp = writeMcpConfig(cwd);
+  if (mcp === null) {
+    console.log(
+      pc.yellow("–") +
+        " Skipped .mcp.json (existing file isn't valid JSON — add manually: " +
+        MCP_ENDPOINT +
+        ")",
+    );
+  } else {
+    console.log(
+      pc.green("✓") +
+        ` ${mcp === "created" ? "Created" : "Updated"} .mcp.json (reactprinciples server)`,
+    );
+  }
+
+  await offerSkills(cwd, options);
+}
+
+async function offerSkills(cwd: string, options: InitOptions): Promise<void> {
+  if (!process.stdin.isTTY || options.ai) {
+    logSkillsHint();
+    return;
+  }
+
+  const { install } = (await prompts(
+    {
+      type: "confirm",
+      name: "install",
+      message: "Install the React Principles AI skills now?",
+      initial: false,
+    },
+    { onCancel: () => ({ install: false }) },
+  )) as { install?: boolean };
+
+  if (install) {
+    const ok = runSkillsInstall(cwd);
+    if (!ok) logSkillsHint();
+  } else {
+    logSkillsHint();
+  }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -51,7 +51,8 @@ program
   .description("Scaffold a new React project from a preset")
   .option("--preset <encoded>", "Encoded preset string from reactprinciples.dev/create")
   .option("--dry-run", "Print dependencies without installing or writing files")
-  .action(async (appName: string | undefined, opts: { preset?: string; dryRun?: boolean }) => {
+  .option("--skip-ai", "Skip AI onboarding (AGENTS.md + .mcp.json)")
+  .action(async (appName: string | undefined, opts: { preset?: string; dryRun?: boolean; skipAi?: boolean }) => {
     try {
       await create(appName, opts);
     } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,11 +16,17 @@ program
 
 program
   .command("init")
-  .description("Initialize components.json config and install the cn() utility")
+  .description("Initialize components.json, the cn() utility, and AI onboarding")
   .option("-t, --template <framework>", "Framework: next | vite | remix | other")
-  .action(async (opts: { template?: string }) => {
+  .option("--ai", "Set up AI onboarding (AGENTS.md + MCP) without prompting")
+  .option("--skip-ai", "Skip AI onboarding")
+  .action(async (opts: { template?: string; ai?: boolean; skipAi?: boolean }) => {
     try {
-      await init(process.cwd(), opts.template);
+      await init(process.cwd(), {
+        template: opts.template,
+        ai: opts.ai,
+        skipAi: opts.skipAi,
+      });
     } catch (err) {
       console.error(pc.red("\nError: " + (err instanceof Error ? err.message : String(err))));
       process.exit(1);

--- a/packages/cli/src/utils/ai-onboarding.ts
+++ b/packages/cli/src/utils/ai-onboarding.ts
@@ -1,0 +1,127 @@
+import { execSync } from "child_process";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import pc from "picocolors";
+
+const LLMS_URL = "https://www.reactprinciples.dev/llms.txt";
+const MCP_ENDPOINT = "https://www.reactprinciples.dev/api/mcp";
+const SKILLS_CMD = "npx skills add sindev08/react-principles-skills";
+
+const BEGIN_MARKER = "<!-- BEGIN react-principles -->";
+const END_MARKER = "<!-- END react-principles -->";
+
+/** Short offline fallback if the live corpus can't be fetched. */
+const FALLBACK_PRINCIPLES = `# React Principles
+
+Production-grade React patterns. Full corpus: ${LLMS_URL}
+
+- Feature-sliced folders: \`src/features/<name>/\` owns its components, hooks, stores, data; shared code in \`src/shared/\`, UI primitives in \`src/ui/\`; import via the \`@/\` alias.
+- TypeScript: no \`any\`, no \`!\`, use \`import type\`, prefer optional chaining.
+- Components: props extend native HTMLAttributes; variants as \`Record<>\` constants (not cva); merge classes with \`cn()\`.
+- State taxonomy: local \`useState\`, shared client state in Zustand, server state in React Query — never API data in Zustand.
+- Forms: Zod schema is the single source of truth; \`zodResolver\`; error messages in the schema, not JSX.
+- Services: calls go through \`createApiClient\`; the chain is service → hook → component.`;
+
+async function fetchPrinciples(): Promise<string> {
+  try {
+    const res = await fetch(LLMS_URL);
+    if (!res.ok) return FALLBACK_PRINCIPLES;
+    return (await res.text()).trim();
+  } catch {
+    return FALLBACK_PRINCIPLES;
+  }
+}
+
+function buildBlock(principles: string): string {
+  return [
+    BEGIN_MARKER,
+    "<!-- Managed by react-principles. Re-run `npx react-principles init` to refresh. -->",
+    "",
+    principles,
+    "",
+    END_MARKER,
+  ].join("\n");
+}
+
+/**
+ * Writes or refreshes the delimited React Principles block in AGENTS.md.
+ * Never clobbers surrounding content — replaces only the marked block, or
+ * appends it if the file exists without one.
+ */
+export async function writeAgentsFile(
+  cwd: string,
+): Promise<"created" | "updated"> {
+  const principles = await fetchPrinciples();
+  const block = buildBlock(principles);
+  const path = join(cwd, "AGENTS.md");
+
+  if (!existsSync(path)) {
+    writeFileSync(path, `${block}\n`, "utf8");
+    return "created";
+  }
+
+  const current = readFileSync(path, "utf8");
+  const begin = current.indexOf(BEGIN_MARKER);
+  const end = current.indexOf(END_MARKER);
+
+  if (begin !== -1 && end !== -1 && end > begin) {
+    const next =
+      current.slice(0, begin) + block + current.slice(end + END_MARKER.length);
+    writeFileSync(path, next, "utf8");
+    return "updated";
+  }
+
+  const separator = current.endsWith("\n") ? "\n" : "\n\n";
+  writeFileSync(path, `${current}${separator}${block}\n`, "utf8");
+  return "updated";
+}
+
+interface McpConfig {
+  mcpServers?: Record<string, { url?: string; command?: string }>;
+  [key: string]: unknown;
+}
+
+/**
+ * Merges the reactprinciples remote server into .mcp.json, preserving any
+ * existing servers. Returns null if the file exists but isn't valid JSON,
+ * so we never overwrite a config we can't safely parse.
+ */
+export function writeMcpConfig(cwd: string): "created" | "updated" | null {
+  const path = join(cwd, ".mcp.json");
+  let config: McpConfig = {};
+
+  if (existsSync(path)) {
+    try {
+      config = JSON.parse(readFileSync(path, "utf8")) as McpConfig;
+    } catch {
+      return null;
+    }
+  }
+
+  const existed = existsSync(path);
+  config.mcpServers = {
+    ...config.mcpServers,
+    reactprinciples: { url: MCP_ENDPOINT },
+  };
+
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return existed ? "updated" : "created";
+}
+
+export function runSkillsInstall(cwd: string): boolean {
+  try {
+    execSync(SKILLS_CMD, { cwd, stdio: "inherit" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export { SKILLS_CMD, MCP_ENDPOINT };
+
+export function logSkillsHint(): void {
+  console.log(
+    pc.gray("  Install the React Principles AI skills later with:\n  ") +
+      pc.cyan(SKILLS_CMD),
+  );
+}

--- a/src/features/configurator/components/CreateProjectModal.tsx
+++ b/src/features/configurator/components/CreateProjectModal.tsx
@@ -127,6 +127,22 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
               copied={copied === "url"}
               onCopy={() => void copyToClipboard(shareUrl, "url")}
             />
+            <div className="flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
+              <span className="material-symbols-outlined text-[20px] text-primary">
+                auto_awesome
+              </span>
+              <p className="text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                Your starter is AI-ready: it ships with{" "}
+                <code className="rounded-sm bg-white px-1 py-0.5 font-mono text-slate-700 dark:bg-[#0d1117] dark:text-slate-300">
+                  AGENTS.md
+                </code>{" "}
+                principles and a preconfigured{" "}
+                <code className="rounded-sm bg-white px-1 py-0.5 font-mono text-slate-700 dark:bg-[#0d1117] dark:text-slate-300">
+                  .mcp.json
+                </code>{" "}
+                so your AI tools follow React Principles from the first commit.
+              </p>
+            </div>
             <div className="grid gap-2 sm:grid-cols-2">
               <Button
                 variant="outline"


### PR DESCRIPTION
## Summary

- `npx react-principles create` now produces starters **born in the ecosystem**, in addition to the existing scaffold:
  - **AGENTS.md** — principles block seeded from the live cookbook (`llms.txt`), so the project's AI follows React Principles from the first commit
  - **.mcp.json** — preconfigured `reactprinciples` remote MCP server
  - **README.md** — a "React Principles ecosystem" section documenting the hooks and how to add more components
  - Reuses the `init` onboarding helpers (`writeAgentsFile` / `writeMcpConfig`); default on, `--skip-ai` opts out
- The Configurator modal (`/create`) now notes the generated starter is AI-ready

Note: the Configurator is a browser wizard that emits an `npx react-principles create --preset` command — the actual scaffolding is the CLI `create`, which is where these hooks belong.

## Verification

- `create myapp` in a temp dir → AGENTS.md (live cookbook content), .mcp.json (reactprinciples server), README with the ecosystem section listing the included components; components copied from the preset
- `create --skip-ai` → no AI files, summary reports "AI: skipped"
- typecheck ✓, 103 tests ✓, lint 0 errors, CLI + site builds ✓

## Dependencies

- **Stacked on #218** (reuses `packages/cli/src/utils/ai-onboarding.ts`); its commit shows here until #218 merges. Merge #218 first.
- `feat:` on `packages/cli/` → release-please **minor** bump on merge to main (shared with #218).

## Related

- Closes #215