### PR TITLE
feat(landing): surface the ecosystem update + navbar polish

### DIFF
--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -158,6 +158,14 @@ export default function AICorpusPage() {
         {/* Quick start — the one-command path */}
         <section className="mb-20">
           <div className="rounded-2xl border border-primary/20 bg-gradient-to-br from-primary/5 to-transparent p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-2">
+              <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide text-primary">
+                New
+              </span>
+              <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                One-command setup
+              </span>
+            </div>
             <div className="grid gap-8 md:grid-cols-2">
               <div>
                 <p className="mb-2 text-xs font-semibold tracking-wider uppercase text-primary">
@@ -286,14 +294,17 @@ export default function AICorpusPage() {
               description="Full recipe as markdown — principle, rules, pattern, implementations."
             />
             <McpToolCard
+              isNew
               name="list_components"
               description="All UI Kit components with target dir, description, and dependencies."
             />
             <McpToolCard
+              isNew
               name="search_components"
               description="Ranked keyword search across component names and descriptions."
             />
             <McpToolCard
+              isNew
               name="get_component"
               description="Full component source (matches the CLI), install command, and deps."
             />
@@ -608,12 +619,27 @@ function LlmsCard({
   );
 }
 
-function McpToolCard({ name, description }: { name: string; description: string }) {
+function McpToolCard({
+  name,
+  description,
+  isNew = false,
+}: {
+  name: string;
+  description: string;
+  isNew?: boolean;
+}) {
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
-      <code className="mb-2 block font-mono text-sm font-semibold text-slate-900 dark:text-white">
-        {name}
-      </code>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <code className="block font-mono text-sm font-semibold text-slate-900 dark:text-white">
+          {name}
+        </code>
+        {isNew && (
+          <span className="shrink-0 rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-bold uppercase leading-none tracking-wide text-primary">
+            New
+          </span>
+        )}
+      </div>
       <p className="text-sm leading-6 text-slate-600 dark:text-slate-400">
         {description}
       </p>

--- a/src/features/docs/components/DocsHeader.tsx
+++ b/src/features/docs/components/DocsHeader.tsx
@@ -9,7 +9,7 @@ import { useSearchStore } from "@/shared/stores/useSearchStore";
 import { useSavedStore } from "@/features/cookbook/stores/useSavedStore";
 import { RECIPES } from "@/features/cookbook/data/cookbook-data";
 import { DOCS_NAV } from "./docs-nav";
-import Image from "next/image";
+import { BrandLogo } from "@/shared/components";
 
 function GithubIcon() {
   return (
@@ -77,27 +77,7 @@ export function DocsHeader() {
       <header className="sticky top-0 z-40 w-full border-b border-slate-200 dark:border-[#1f2937] bg-white/80 dark:bg-[#0b0e14]/80 backdrop-blur-md">
         <div className="relative mx-auto flex h-14 max-w-[1440px] items-center justify-between gap-3 px-4 sm:px-6 lg:px-10">
           <div className="flex min-w-0 items-center gap-8">
-            <Link href="/" className="flex min-w-0 items-center gap-2">
-              <Image
-                src="/logo-icon.svg"
-                alt="React Principles logo"
-                width={32}
-                height={32}
-                className="block dark:hidden"
-              />
-              <Image
-                src="/logo-icon-dark.svg"
-                alt="React Principles logo"
-                width={32}
-                height={32}
-                className="hidden dark:block"
-              />
-              <h2 className="truncate text-base tracking-tight leading-tight">
-                <span className="font-medium text-slate-600 dark:text-slate-300">React</span>
-                {" "}
-                <span className="font-black text-primary">Principles</span>
-              </h2>
-            </Link>
+            <BrandLogo />
             <nav className="items-center hidden gap-6 md:flex">
               <Link href="/" className={navLinkClass(!isDocsActive && !isCookbookActive && !isCreateActive)}>
                 Home

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -166,33 +166,29 @@ export function HeroSection() {
         </div>
       )}
       <div className="relative z-10 mx-auto max-w-4xl text-center">
-        <Badge className="mb-6">
-          <span className="material-symbols-outlined text-sm">
-            auto_awesome
-          </span>
-          v1.0 is now live
-        </Badge>
+        <Link href="/ai" className="group inline-block">
+          <Badge className="mb-6 transition-colors group-hover:border-primary/40">
+            <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-bold uppercase leading-none tracking-wide text-primary">
+              New
+            </span>
+            Your AI is now React Principles–aware
+            <span className="material-symbols-outlined text-sm transition-transform group-hover:translate-x-0.5">
+              arrow_forward
+            </span>
+          </Badge>
+        </Link>
 
         <h1 className="mb-8 text-5xl font-black leading-[1.1] tracking-tight text-slate-900 md:text-7xl dark:text-white">
           <span className="text-primary">React Principles</span>
           <br />
-          The Living Cookbook for Modern React
+          Production patterns, wired into your AI.
         </h1>
 
-        <p className="mx-auto mb-8 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
-          A high-end developer reference implementation for scalable React
-          architectures. Isolated patterns, real-world examples, and
-          production-ready code.
+        <p className="mx-auto mb-10 max-w-2xl text-xl leading-relaxed text-slate-600 dark:text-slate-200">
+          The cookbook, UI Kit, and starters — now connected to your AI tools.
+          Learn the patterns yourself, or let your assistant look them up and
+          pull components on demand.
         </p>
-
-        <div className="mb-10 flex justify-center">
-          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-300">
-            <span className="material-symbols-outlined text-base text-primary">
-              auto_awesome
-            </span>
-            Designed for humans and AI assistants
-          </span>
-        </div>
 
         <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link
@@ -209,9 +205,14 @@ export function HeroSection() {
           </Link>
         </div>
 
-        <div className="mt-6 inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white/80 px-5 py-2.5 font-mono text-sm text-slate-500 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-400">
-          <span className="text-primary">$</span>
-          npx react-principles init
+        <div className="mt-6 flex flex-col items-center gap-1.5">
+          <div className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white/80 px-5 py-2.5 font-mono text-sm text-slate-500 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-400">
+            <span className="text-primary">$</span>
+            npx react-principles init
+          </div>
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            Sets up AGENTS.md + MCP + skills — one command.
+          </span>
         </div>
       </div>
 

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -22,6 +22,10 @@ const Grainient = dynamic(
   { ssr: false },
 );
 
+// Temporarily disabled — flip to true to restore the animated hero background.
+// Falls back to the section's `mesh-gradient` CSS while off.
+const SHOW_HERO_ANIMATION = false;
+
 type Tab = "hook" | "component";
 
 const TABS: Array<{ id: Tab; label: string; icon: string }> = [
@@ -140,31 +144,32 @@ export function HeroSection() {
 
   return (
     <section className="mesh-gradient relative overflow-hidden px-6 pb-20 pt-40">
-      {isDark ? (
-        <FloatingLines
-          linesGradient={["#4628F1", "#7c3aed", "#06b6d4"]}
-          enabledWaves={["middle", "bottom"]}
-          lineCount={[5, 10]}
-          lineDistance={[5, 3]}
-          animationSpeed={0.4}
-        />
-      ) : (
-        <div className="absolute inset-0">
-          <Grainient
-            color1="#c4b5fd"
-            color2="#4628F1"
-            color3="#e0e7ff"
-            timeSpeed={0.5}
-            grainAmount={0.05}
-            contrast={1.2}
-            saturation={0.8}
-            warpAmplitude={50.0}
-            warpFrequency={5.0}
-            warpSpeed={2.0}
-            rotationAmount={500.0}
+      {SHOW_HERO_ANIMATION &&
+        (isDark ? (
+          <FloatingLines
+            linesGradient={["#4628F1", "#7c3aed", "#06b6d4"]}
+            enabledWaves={["middle", "bottom"]}
+            lineCount={[5, 10]}
+            lineDistance={[5, 3]}
+            animationSpeed={0.4}
           />
-        </div>
-      )}
+        ) : (
+          <div className="absolute inset-0">
+            <Grainient
+              color1="#c4b5fd"
+              color2="#4628F1"
+              color3="#e0e7ff"
+              timeSpeed={0.5}
+              grainAmount={0.05}
+              contrast={1.2}
+              saturation={0.8}
+              warpAmplitude={50.0}
+              warpFrequency={5.0}
+              warpSpeed={2.0}
+              rotationAmount={500.0}
+            />
+          </div>
+        ))}
       <div className="relative z-10 mx-auto max-w-4xl text-center">
         <Link href="/ai" className="group inline-block">
           <Badge className="mb-6 transition-colors group-hover:border-primary/40">

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -7,11 +7,19 @@ import Image from "next/image";
 import { cn } from "@/shared/utils/cn";
 
 const NAV_LINKS = [
-  { href: "/nextjs/cookbook", label: "Cookbook" },
-  { href: "/components/introduction", label: "Components" },
-  { href: "/create", label: "Create" },
-  { href: "/ai", label: "AI" },
+  { href: "/nextjs/cookbook", label: "Cookbook", badge: false },
+  { href: "/components/introduction", label: "Components", badge: false },
+  { href: "/create", label: "Create", badge: false },
+  { href: "/ai", label: "AI", badge: true },
 ] as const;
+
+function NewPill() {
+  return (
+    <span className="rounded-full bg-primary/15 px-1.5 py-0.5 text-[10px] font-bold uppercase leading-none tracking-wide text-primary">
+      New
+    </span>
+  );
+}
 
 function GithubIcon() {
   return (
@@ -54,9 +62,10 @@ export function Navbar() {
             <Link
               key={link.href}
               href={link.href}
-              className="text-sm font-medium text-slate-600 dark:text-slate-400 transition-colors hover:text-primary"
+              className="flex items-center gap-1.5 text-sm font-medium text-slate-600 dark:text-slate-400 transition-colors hover:text-primary"
             >
               {link.label}
+              {link.badge && <NewPill />}
             </Link>
           ))}
         </nav>
@@ -96,9 +105,10 @@ export function Navbar() {
               key={link.href}
               href={link.href}
               onClick={() => setIsOpen(false)}
-              className="py-3 text-sm font-medium text-slate-600 dark:text-slate-400 transition-colors border-b hover:text-primary border-slate-100 dark:border-white/5 last:border-0"
+              className="flex items-center gap-1.5 py-3 text-sm font-medium text-slate-600 dark:text-slate-400 transition-colors border-b hover:text-primary border-slate-100 dark:border-white/5 last:border-0"
             >
               {link.label}
+              {link.badge && <NewPill />}
             </Link>
           ))}
         </nav>

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -33,7 +33,7 @@ export function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background-light/80 dark:bg-background-dark/80 border-primary/10 dark:border-white/5 backdrop-blur-md">
+    <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background-light/95 dark:bg-background-dark/95 border-primary/10 dark:border-white/5 backdrop-blur-md">
       <div className="flex h-16 items-center justify-between px-6 mx-auto max-w-7xl md:grid md:grid-cols-3">
         <Link
           href="/"

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { ThemeToggle } from "./ThemeToggle";
-import Image from "next/image";
+import { BrandLogo } from "@/shared/components";
 import { cn } from "@/shared/utils/cn";
 
 const NAV_LINKS = [
@@ -35,31 +35,7 @@ export function Navbar() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background-light/95 dark:bg-background-dark/95 border-primary/10 dark:border-white/5 backdrop-blur-md">
       <div className="flex h-16 items-center justify-between px-6 mx-auto max-w-7xl md:grid md:grid-cols-3">
-        <Link
-          href="/"
-          aria-label="React Principles home"
-          className="flex min-w-0 items-center gap-2 transition-opacity hover:opacity-80"
-        >
-          <Image
-            src="/logo-icon.svg"
-            alt="React Principles logo"
-            width={32}
-            height={32}
-            className="block dark:hidden"
-          />
-          <Image
-            src="/logo-icon-dark.svg"
-            alt="React Principles logo"
-            width={32}
-            height={32}
-            className="hidden dark:block"
-          />
-          <span className="whitespace-nowrap text-lg tracking-tight">
-            <span className="font-medium text-slate-600 dark:text-slate-300">React</span>
-            {" "}
-            <span className="font-black text-primary">Principles</span>
-          </span>
-        </Link>
+        <BrandLogo />
 
         <nav className="items-center justify-center hidden gap-8 md:flex">
           {NAV_LINKS.map((link) => (

--- a/src/features/landing/components/Navbar.tsx
+++ b/src/features/landing/components/Navbar.tsx
@@ -35,7 +35,11 @@ export function Navbar() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background-light/80 dark:bg-background-dark/80 border-primary/10 dark:border-white/5 backdrop-blur-md">
       <div className="flex h-16 items-center justify-between px-6 mx-auto max-w-7xl md:grid md:grid-cols-3">
-        <div className="flex min-w-0 items-center gap-2">
+        <Link
+          href="/"
+          aria-label="React Principles home"
+          className="flex min-w-0 items-center gap-2 transition-opacity hover:opacity-80"
+        >
           <Image
             src="/logo-icon.svg"
             alt="React Principles logo"
@@ -55,7 +59,7 @@ export function Navbar() {
             {" "}
             <span className="font-black text-primary">Principles</span>
           </span>
-        </div>
+        </Link>
 
         <nav className="items-center justify-center hidden gap-8 md:flex">
           {NAV_LINKS.map((link) => (

--- a/src/shared/components/BrandLogo.tsx
+++ b/src/shared/components/BrandLogo.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import Image from "next/image";
+import { cn } from "@/shared/utils/cn";
+
+interface BrandLogoProps {
+  /** Extra classes for the link wrapper (e.g. layout tweaks per header). */
+  className?: string;
+}
+
+/**
+ * The React Principles brand mark — logo + wordmark, linked to home.
+ * Single source of truth so every header renders it identically.
+ */
+export function BrandLogo({ className }: BrandLogoProps) {
+  return (
+    <Link
+      href="/"
+      aria-label="React Principles home"
+      className={cn(
+        "flex min-w-0 items-center gap-2 transition-opacity hover:opacity-80",
+        className,
+      )}
+    >
+      <Image
+        src="/logo-icon.svg"
+        alt="React Principles logo"
+        width={32}
+        height={32}
+        className="block dark:hidden"
+      />
+      <Image
+        src="/logo-icon-dark.svg"
+        alt="React Principles logo"
+        width={32}
+        height={32}
+        className="hidden dark:block"
+      />
+      <span className="truncate text-lg tracking-tight">
+        <span className="font-medium text-slate-600 dark:text-slate-300">
+          React
+        </span>{" "}
+        <span className="font-black text-primary">Principles</span>
+      </span>
+    </Link>
+  );
+}

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,3 +1,4 @@
+export { BrandLogo } from "./BrandLogo";
 export { EmptyState } from "./EmptyState";
 export { ErrorBoundary } from "./ErrorBoundary";
 export { LoadingState } from "./LoadingState";


### PR DESCRIPTION
## Summary

Makes the landing/AI content reflect the shipped ecosystem work and fixes the navbar inconsistencies found while reviewing it. All landing-only (no CLI/API changes).

- **Signal the update** — "New" badges on the AI nav item and on the genuinely new /ai surfaces (one-command quick-start + list/search/get component MCP tools), so returning visitors notice something shipped
- **Evolve the hero** — headline moves from "The Living Cookbook" to "Production patterns, wired into your AI" (keeps cookbook as the substance), explains the `init` command chip, and links a "New" badge to /ai
- **Navbar fixes** — logo now links home (was a plain div — no way back from /ai or /create); bumped navbar opacity to 95% so the semi-transparent bar/badge render consistently across pages instead of picking up the hero behind it
- **Brand consistency** — extract a shared `BrandLogo` component used by both the landing navbar and the docs header, which had drifted (text-lg vs text-base); the wordmark is now identical everywhere and can't drift again
- **Temporary** — hero WebGL background animation gated behind a `SHOW_HERO_ANIMATION` flag (off) to cut GPU cost; the "New" badges are temporary novelty signals to be removed once the release ages

## Verification

typecheck ✓, lint 0 errors, production build ✓; badges + logo link + shared BrandLogo verified rendering on `/`, `/ai`, and `/components`.

## Related

- Signals the ecosystem release (#213, #214, #215)
- Pairs with the durable changelog page (#223)