### PR TITLE
feat(changelog): add durable what's-new page and markdown feed

### DIFF
--- a/src/app/changelog.txt/route.ts
+++ b/src/app/changelog.txt/route.ts
@@ -1,0 +1,11 @@
+import { generateChangelogMarkdown } from "@/features/changelog";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return new Response(generateChangelogMarkdown(), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Navbar, Footer } from "@/features/landing/components";
+import {
+  CHANGELOG_ENTRIES,
+  type ChangeType,
+} from "@/features/changelog/data";
+import { formatDate } from "@/shared/utils/formatters";
+import { cn } from "@/shared/utils/cn";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+export const metadata: Metadata = {
+  title: "Changelog — React Principles",
+  description:
+    "What's new in React Principles. A durable, public record of every release — new AI capabilities, components, and changes across the ecosystem.",
+  openGraph: {
+    title: "Changelog — React Principles",
+    description:
+      "A durable, public record of every React Principles release — new AI capabilities, components, and changes.",
+    type: "website",
+    url: `${SITE_URL}/changelog`,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Changelog — React Principles",
+    description:
+      "A durable, public record of every React Principles release.",
+  },
+  alternates: {
+    canonical: `${SITE_URL}/changelog`,
+  },
+};
+
+const CHANGE_LABEL: Record<ChangeType, string> = {
+  added: "Added",
+  changed: "Changed",
+  fixed: "Fixed",
+};
+
+const CHANGE_BADGE_CLASSES: Record<ChangeType, string> = {
+  added:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  changed:
+    "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+  fixed:
+    "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+};
+
+export default function ChangelogPage() {
+  return (
+    <>
+      <Navbar />
+      <main className="mx-auto max-w-3xl px-6 pt-32 pb-20 lg:pt-40">
+        {/* Hero */}
+        <section className="mb-16 text-center">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-1.5 text-xs font-semibold tracking-wider uppercase text-primary">
+            <span className="material-symbols-outlined text-sm">history</span>
+            Changelog
+          </div>
+          <h1 className="mb-6 text-4xl font-extrabold tracking-tight text-slate-900 dark:text-white lg:text-5xl">
+            What&apos;s new in{" "}
+            <span className="text-primary">React Principles</span>
+          </h1>
+          <p className="mx-auto max-w-xl text-lg leading-8 text-slate-600 dark:text-slate-400">
+            A durable record of what shipped in each release across the
+            cookbook, UI Kit, and CLI.
+          </p>
+        </section>
+
+        {/* Entries */}
+        <ol className="space-y-16">
+          {CHANGELOG_ENTRIES.map((entry) => (
+            <li
+              key={`${entry.date}-${entry.title}`}
+              className="border-t border-slate-200 pt-8 dark:border-white/5"
+            >
+              <div className="mb-4 flex flex-wrap items-center gap-3">
+                <time
+                  dateTime={entry.date}
+                  className="text-sm font-medium text-slate-500 dark:text-slate-400"
+                >
+                  {formatDate(`${entry.date}T00:00:00`)}
+                </time>
+                {entry.version && (
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                    v{entry.version}
+                  </span>
+                )}
+              </div>
+
+              <h2 className="mb-3 text-2xl font-bold tracking-tight text-slate-900 dark:text-white">
+                {entry.title}
+              </h2>
+              <p className="mb-6 leading-7 text-slate-600 dark:text-slate-400">
+                {entry.summary}
+              </p>
+
+              <ul className="space-y-4">
+                {entry.items.map((item, index) => (
+                  <li
+                    key={index}
+                    className="flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4"
+                  >
+                    <span
+                      className={cn(
+                        "inline-flex w-fit shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide sm:mt-0.5",
+                        CHANGE_BADGE_CLASSES[item.type],
+                      )}
+                    >
+                      {CHANGE_LABEL[item.type]}
+                    </span>
+                    <p className="leading-7 text-slate-700 dark:text-slate-300">
+                      {item.text}{" "}
+                      {item.href && (
+                        <a
+                          href={item.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-medium text-primary underline-offset-2 hover:underline"
+                        >
+                          Details
+                        </a>
+                      )}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+
+        {/* AI-readable pointer */}
+        <p className="mt-16 border-t border-slate-200 pt-8 text-center text-sm text-slate-500 dark:border-white/5 dark:text-slate-400">
+          Reading with an AI tool? The same history is available as markdown at{" "}
+          <Link
+            href="/changelog.txt"
+            className="font-medium text-primary underline-offset-2 hover:underline"
+          >
+            /changelog.txt
+          </Link>
+          .
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -35,6 +35,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.85,
     },
     {
+      url: `${BASE_URL}/changelog`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.75,
+    },
+    {
       url: `${BASE_URL}/llms.txt`,
       lastModified: now,
       changeFrequency: "weekly",

--- a/src/features/changelog/changelog-md.ts
+++ b/src/features/changelog/changelog-md.ts
@@ -1,0 +1,42 @@
+import { CHANGELOG_ENTRIES, type ChangeType } from "./data";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://reactprinciples.dev";
+
+const CHANGE_LABEL: Record<ChangeType, string> = {
+  added: "Added",
+  changed: "Changed",
+  fixed: "Fixed",
+};
+
+const HEADER = `# React Principles — Changelog
+
+> What shipped in each release, newest first. A durable, public record of new AI capabilities, components, and changes across the cookbook, UI Kit, and CLI.
+
+Web version: ${SITE_URL}/changelog
+
+---
+`;
+
+/**
+ * Renders the changelog entries as a single markdown document, mirroring the
+ * llms.txt approach so AI tools and crawlers can read the release history.
+ */
+export function generateChangelogMarkdown(): string {
+  const entries = CHANGELOG_ENTRIES.map((entry) => {
+    const heading = entry.version
+      ? `## ${entry.date} — ${entry.title} (v${entry.version})`
+      : `## ${entry.date} — ${entry.title}`;
+
+    const items = entry.items
+      .map((item) => {
+        const link = item.href ? ` ([details](${item.href}))` : "";
+        return `- **${CHANGE_LABEL[item.type]}** — ${item.text}${link}`;
+      })
+      .join("\n");
+
+    return `${heading}\n\n${entry.summary}\n\n${items}`;
+  }).join("\n\n---\n\n");
+
+  return `${HEADER}\n${entries}\n`;
+}

--- a/src/features/changelog/data/entries.ts
+++ b/src/features/changelog/data/entries.ts
@@ -1,0 +1,41 @@
+import type { ChangelogEntry } from "./types";
+
+const REPO_URL = "https://github.com/sindev08/react-principles";
+const SKILLS_REPO_URL = "https://github.com/sindev08/react-principles-skills";
+
+/**
+ * Public release history, newest first.
+ *
+ * Keep entries truthful — only list what is live in production. Internal-only
+ * work (analytics, tooling) stays out of the public record.
+ */
+export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
+  {
+    date: "2026-07-13",
+    title: "React Principles is now an AI-first ecosystem.",
+    summary:
+      "One command wires your project into the whole ecosystem — your AI follows the principles, looks up recipes, and pulls components on its own. Principles and building blocks now share a single connection.",
+    items: [
+      {
+        type: "added",
+        text: "Remote MCP server now serves the UI Kit too: list_components, search_components, and get_component (full source, matching the CLI). One connection gives your AI both the principles and the components.",
+        href: `${REPO_URL}/pull/213`,
+      },
+      {
+        type: "added",
+        text: "npx react-principles init wires an existing project into the ecosystem — it generates AGENTS.md, .mcp.json, and skills so your AI is React Principles-aware from the next prompt.",
+        href: `${REPO_URL}/pull/214`,
+      },
+      {
+        type: "added",
+        text: "npx react-principles create scaffolds starters that ship AI-ready from the first commit.",
+        href: `${REPO_URL}/pull/215`,
+      },
+      {
+        type: "changed",
+        text: "Skills now fetch recipe content live, so updates reach installed skills automatically (existing users need a one-time re-install).",
+        href: `${SKILLS_REPO_URL}/pull/6`,
+      },
+    ],
+  },
+];

--- a/src/features/changelog/data/index.ts
+++ b/src/features/changelog/data/index.ts
@@ -1,0 +1,2 @@
+export type { ChangelogEntry, ChangelogChange, ChangeType } from "./types";
+export { CHANGELOG_ENTRIES } from "./entries";

--- a/src/features/changelog/data/types.ts
+++ b/src/features/changelog/data/types.ts
@@ -1,0 +1,24 @@
+/** Category of a single change within a changelog entry. */
+export type ChangeType = "added" | "changed" | "fixed";
+
+export interface ChangelogChange {
+  /** Category tag used for grouping and the colored badge. */
+  type: ChangeType;
+  /** Human-readable description of the change. */
+  text: string;
+  /** Optional link to the PR, recipe, or surface the change affects. */
+  href?: string;
+}
+
+export interface ChangelogEntry {
+  /** Optional semver-style version label (e.g. "1.1.0"). */
+  version?: string;
+  /** Release date in ISO format (YYYY-MM-DD). */
+  date: string;
+  /** Short, headline-style title for the release. */
+  title: string;
+  /** One or two sentences framing what shipped and why it matters. */
+  summary: string;
+  /** The individual changes, tagged by category. */
+  items: ChangelogChange[];
+}

--- a/src/features/changelog/index.ts
+++ b/src/features/changelog/index.ts
@@ -1,0 +1,3 @@
+export type { ChangelogEntry, ChangelogChange, ChangeType } from "./data";
+export { CHANGELOG_ENTRIES } from "./data";
+export { generateChangelogMarkdown } from "./changelog-md";

--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -5,6 +5,7 @@ import { CLI_VERSION } from "@/shared/constants/versions";
 const RESOURCES = [
   { label: "Components", href: "/components/introduction" },
   { label: "Cookbook", href: "/nextjs/cookbook" },
+  { label: "Changelog", href: "/changelog" },
   { label: "GitHub", href: "https://github.com/sindev08/react-principles" },
 ];
 


### PR DESCRIPTION
## Summary

- Add a `/changelog` route as the permanent home for "what's new," complementing the temporary "New" badges (#222). Entries render reverse-chronologically with Added/Changed/Fixed category tags.
- Keep content out of JSX: entries live in a typed data module (`src/features/changelog/data`), mirroring the cookbook/registry pattern.
- Expose `/changelog.txt` — the same history as markdown — so AI tools and crawlers can read release history (same approach as `llms.txt`). Linked from the footer and registered in the sitemap.
- First entry documents the AI-first ecosystem release: MCP UI Kit tools (#213), `init` (#214) and `create` (#215) commands, and live-fetch skills. Analytics (#216) intentionally omitted as internal.

## Related

- Closes #223
- Pairs with #222 (temporary "New" badges)
- Documents #213, #214, #215, and react-principles-skills#6