### PR TITLE
feat(ai): add mcp flow diagram and probe client headers

### DIFF
--- a/src/app/ai/McpFlowDiagram.tsx
+++ b/src/app/ai/McpFlowDiagram.tsx
@@ -1,0 +1,58 @@
+interface FlowNode {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+const NODES: FlowNode[] = [
+  {
+    icon: "smart_toy",
+    title: "Your AI",
+    description: "Claude, Cursor, Copilot, GPT — any MCP client",
+  },
+  {
+    icon: "hub",
+    title: "MCP Server",
+    description: "reactprinciples.dev/api/mcp — 6 tools, live",
+  },
+  {
+    icon: "menu_book",
+    title: "Cookbook + UI Kit",
+    description: "Recipes and components, always current",
+  },
+];
+
+/**
+ * Explains the MCP request path in plain terms: three nodes connected by
+ * arrows, reusing the icon-badge card idiom used elsewhere on this page.
+ */
+export function McpFlowDiagram() {
+  return (
+    <div className="mb-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+      {NODES.map((node, i) => (
+        <div key={node.title} className="flex flex-1 items-center gap-3">
+          <div className="flex flex-1 items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900/50">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+              <span className="material-symbols-outlined text-[18px] text-primary">
+                {node.icon}
+              </span>
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                {node.title}
+              </p>
+              <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                {node.description}
+              </p>
+            </div>
+          </div>
+          {i < NODES.length - 1 && (
+            <span className="material-symbols-outlined shrink-0 rotate-90 text-slate-400 sm:rotate-0 dark:text-slate-600">
+              arrow_forward
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/ai/page.tsx
+++ b/src/app/ai/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Navbar, Footer } from "@/features/landing/components";
 import { CopyButton } from "@/shared/components";
 import { cn } from "@/shared/utils/cn";
+import { McpFlowDiagram } from "./McpFlowDiagram";
 import { McpInstallTabs } from "./McpInstallTabs";
 
 const SITE_URL =
@@ -289,6 +290,7 @@ export default function AICorpusPage() {
             description="A remote Model Context Protocol server serving both the cookbook and the UI Kit. Connect once and your AI can look up recipes and pull component source on demand — no copy-paste, always in sync with the published site."
           />
 
+          <McpFlowDiagram />
           <McpInstallTabs />
 
           <div className="grid gap-4 sm:grid-cols-3">

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -229,4 +229,37 @@ const handler = createMcpHandler(
   },
 );
 
-export { handler as GET, handler as POST };
+/**
+ * TEMPORARY — logs the identifying request headers MCP clients actually send,
+ * to decide what per-client / unique-visitor metrics are feasible.
+ * `mcp-handler` only populates clientInfo on the SSE path, so on Streamable
+ * HTTP these headers are the only source. Remove once the shape is known.
+ *
+ * ponytail: console-only, gated on MCP_DEBUG_HEADERS. Swap for a real
+ * trackEvent call once we know which headers are worth recording.
+ */
+function logHeaders(request: Request) {
+  if (process.env.MCP_DEBUG_HEADERS !== "1") return;
+  console.warn(
+    "[mcp headers]",
+    JSON.stringify({
+      ua: request.headers.get("user-agent"),
+      xff: request.headers.get("x-forwarded-for"),
+      realIp: request.headers.get("x-real-ip"),
+      origin: request.headers.get("origin"),
+      referer: request.headers.get("referer"),
+      mcpVersion: request.headers.get("mcp-protocol-version"),
+      mcpSession: request.headers.get("mcp-session-id"),
+    }),
+  );
+}
+
+export async function GET(request: Request) {
+  logHeaders(request);
+  return handler(request);
+}
+
+export async function POST(request: Request) {
+  logHeaders(request);
+  return handler(request);
+}


### PR DESCRIPTION
## Summary

- Add a three-node flow diagram (Your AI → MCP Server → Cookbook + UI Kit) above the install tabs on `/ai`, so the MCP request path reads visually before the config snippets. Reuses the icon-badge card idiom already on the page; arrows rotate vertical on mobile.
- Log MCP client request headers behind `MCP_DEBUG_HEADERS=1`. `mcp-handler` only populates `clientInfo` on the SSE path, so on Streamable HTTP (what every documented client uses) `userAgent`/`ip` never arrive via `onEvent` — the handler now reads them off the request directly.

## Context

Groundwork for answering "how many people actually use the MCP server". Today only `mcp.tool_call` is tracked, which measures call volume, not users.

Verified locally against a real client: Claude Code sends `claude-code/2.1.212 (sdk-cli)`, the raw MCP SDK sends `node`. So a per-client breakdown is feasible but will need an honest `other` bucket.

## Follow-ups (not in this PR)

- Enable `MCP_DEBUG_HEADERS` in prod briefly to capture the real client mix (Cursor, ChatGPT, VS Code), then remove the probe.
- Add a normalizer + `trackEvent("mcp.client", …)` once the UA shapes are known.
- sindev-analytics has no breakdown-by-prop query anywhere, so props like `client` would be stored but not aggregated — needs a `props->>` query + table in the Events tab before per-client numbers are visible.

## Related

None.