### PR TITLE
refactor(analytics): read analytics key from a single env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,8 @@
 NEXT_PUBLIC_SITE_URL=https://reactprinciples.dev
+
+# sindev-analytics project key.
+# Browser (track.js) needs NEXT_PUBLIC_ — it ships to the client and is public
+# by nature. The server key is read only on the server; both may hold the same
+# project key. Unset in local dev: no script is injected and trackEvent no-ops.
+NEXT_PUBLIC_ANALYTICS_API_KEY=
+ANALYTICS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 NEXT_PUBLIC_SITE_URL=https://reactprinciples.dev
+
+# sindev-analytics project key. One var for both browser and server — the key
+# is public by nature (track.js ships it to the client). Unset in local dev:
+# no script is injected and server-side trackEvent no-ops.
+NEXT_PUBLIC_ANALYTICS_API_KEY=

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -161,9 +161,13 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-screen bg-(--background) text-(--foreground) antialiased">
-                {process.env.NODE_ENV === "production" && (
-          <Script src="https://analytics.sindev.my.id/track.js" data-api-key="4744f6b200cecd79c9241430f5049e3e5c1f65478888e82542469a170d6c6e7c" />
-        )}
+        {process.env.NODE_ENV === "production" &&
+          process.env.NEXT_PUBLIC_ANALYTICS_API_KEY && (
+            <Script
+              src="https://analytics.sindev.my.id/track.js"
+              data-api-key={process.env.NEXT_PUBLIC_ANALYTICS_API_KEY}
+            />
+          )}
         <NuqsAdapter>
           <Providers>{children}</Providers>
         </NuqsAdapter>

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -17,13 +17,13 @@ describe("trackEvent", () => {
   });
 
   it("no-ops when no API key is set", async () => {
-    vi.stubEnv("ANALYTICS_API_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_ANALYTICS_API_KEY", "");
     await trackEvent("mcp.tool_call", { tool: "get_recipe" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("posts a bearer-authorized event when the key is set", async () => {
-    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    vi.stubEnv("NEXT_PUBLIC_ANALYTICS_API_KEY", "secret-key");
     await trackEvent("mcp.tool_call", { tool: "get_recipe" });
 
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -40,7 +40,7 @@ describe("trackEvent", () => {
   });
 
   it("omits props when none are given", async () => {
-    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    vi.stubEnv("NEXT_PUBLIC_ANALYTICS_API_KEY", "secret-key");
     await trackEvent("list_recipes");
 
     const init = fetchMock.mock.calls[0]?.[1];
@@ -49,7 +49,7 @@ describe("trackEvent", () => {
   });
 
   it("never throws when the network call fails", async () => {
-    vi.stubEnv("ANALYTICS_API_KEY", "secret-key");
+    vi.stubEnv("NEXT_PUBLIC_ANALYTICS_API_KEY", "secret-key");
     fetchMock.mockRejectedValueOnce(new Error("network down"));
     await expect(trackEvent("llms.fetch", { path: "/llms.txt" })).resolves.toBeUndefined();
   });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -13,21 +13,32 @@
 const INGEST_URL =
   process.env.ANALYTICS_INGEST_URL ?? "https://analytics.sindev.my.id/api/event";
 
+/**
+ * Same var for browser and server. The key is public anyway (track.js ships
+ * it to the client), and sindev-analytics allows one key per project, so a
+ * separate server key would add ceremony without adding anything. Revisit
+ * only if the service gains multi-key support and we want a private server key.
+ * Read at call time so tests can stub it without a module-reload dance.
+ */
+function apiKey(): string | undefined {
+  return process.env.NEXT_PUBLIC_ANALYTICS_API_KEY;
+}
+
 export type EventProps = Record<string, string | number | boolean>;
 
 export async function trackEvent(
   name: string,
   props?: EventProps,
 ): Promise<void> {
-  const apiKey = process.env.ANALYTICS_API_KEY;
-  if (!apiKey) return;
+  const key = apiKey();
+  if (!key) return;
 
   try {
     await fetch(INGEST_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify(props ? { name, props } : { name }),
     });


### PR DESCRIPTION
## Summary

- Read the sindev-analytics key from one `NEXT_PUBLIC_ANALYTICS_API_KEY` for both browser (track.js) and server (`trackEvent`), instead of hardcoding it in `layout.tsx` and splitting server into a second var that held the same value.
- `layout.tsx` now injects no script at all when the key is missing (previously it would emit a tag with an empty `data-api-key` that failed silently).
- `analytics.ts` reads the key at call time so tests can stub it without a module-reload dance; tests updated accordingly (114 passing).

## Context

Both halves of the project key were configured in different places but held the same value. Since the key is public by nature (it ships to the browser) and sindev-analytics allows one key per project, one var is enough.

**Deploy note:** `NEXT_PUBLIC_ANALYTICS_API_KEY` is already set in Vercel Production, so this deploys clean. Set it before this lands if it ever gets rotated.

## Related

None.